### PR TITLE
Make it possible to use a relative path in Parent_Config.

### DIFF
--- a/config/vufind/config.ini
+++ b/config/vufind/config.ini
@@ -731,6 +731,8 @@ skip_numeric = true
 [Parent_Config]
 ; Full path to parent configuration file:
 ;path = /usr/local/vufind/application/config/config.ini
+; Path to parent configuration file (relative to the location of this file):
+;relative_path = ../masterconfig/config.ini
 
 ; A comma-separated list of config sections from the parent which should be
 ; completely overwritten by the equivalent sections in this configuration;

--- a/module/VuFind/src/VuFind/Config/PluginFactory.php
+++ b/module/VuFind/src/VuFind/Config/PluginFactory.php
@@ -87,8 +87,15 @@ class PluginFactory implements AbstractFactoryInterface
                 = new Config($this->iniReader->fromFile($fullpath), true);
 
             $i = count($configs) - 1;
-            $fullpath = isset($configs[$i]->Parent_Config->path)
-                ? $configs[$i]->Parent_Config->path : false;
+            if (isset($configs[$i]->Parent_Config->path)) {
+                $fullpath = $configs[$i]->Parent_Config->path;
+            } elseif (isset($configs[$i]->Parent_Config->relative_path)) {
+                $fullpath = pathinfo($fullpath, PATHINFO_DIRNAME)
+                    . DIRECTORY_SEPARATOR
+                    . $configs[$i]->Parent_Config->relative_path;
+            } else {
+                $fullpath = false;
+            }
         } while ($fullpath);
 
         // The last element in the array will be the top of the inheritance tree.


### PR DESCRIPTION
This change allows specifying a relative (to current config file location) path for the parent config. Since there's no proper way to determine if a file name is absolute, I added a new setting for it, but a regexp check or such could be used as well.
