### PR TITLE
Prioritize registration of base url

### DIFF
--- a/module/Finna/Module.php
+++ b/module/Finna/Module.php
@@ -26,8 +26,8 @@
  * @link     https://github.com/dmj/vf2-proxy
  */
 namespace Finna;
-use Zend\EventManager\StaticEventManager;
-use Zend\ModuleManager\ModuleManager,
+use Zend\EventManager\StaticEventManager,
+    Zend\ModuleManager\ModuleManager,
     Zend\Mvc\MvcEvent;
 
 /**
@@ -58,13 +58,13 @@ class Module
      */
     public function getAutoloaderConfig()
     {
-        return [
-            'Zend\Loader\StandardAutoloader' => [
-                'namespaces' => [
+        return array(
+            'Zend\Loader\StandardAutoloader' => array(
+                'namespaces' => array(
                     __NAMESPACE__ => __DIR__ . '/src/' . __NAMESPACE__,
-                ],
-            ],
-        ];
+                ),
+            ),
+        );
     }
 
     /**

--- a/module/Finna/Module.php
+++ b/module/Finna/Module.php
@@ -77,7 +77,7 @@ class Module
     public function init(ModuleManager $m)
     {
         $em = StaticEventManager::getInstance();
-        $em->attach('*', 'bootstrap', [$this, 'registerBaseUrl'], 100000);
+        $em->attach('Zend\Mvc\Application', 'bootstrap', [$this, 'registerBaseUrl'], 100000);
     }
 
     /**

--- a/module/Finna/Module.php
+++ b/module/Finna/Module.php
@@ -81,6 +81,18 @@ class Module
     }
 
     /**
+     * Bootstrap the module
+     *
+     * @param MvcEvent $e Event
+     *
+     * @return void
+     */
+    public function onBootstrap(MvcEvent $e)
+    {
+
+    }
+
+    /**
      * Initializes the base url for the application from environment variable
      * @param MvcEvent $e
      */
@@ -95,17 +107,5 @@ class Module
             $router->setBaseUrl($baseUrl);
             $request->setBaseUrl($baseUrl);
         }
-    }
-
-    /**
-     * Bootstrap the module
-     *
-     * @param MvcEvent $e Event
-     *
-     * @return void
-     */
-    public function onBootstrap(MvcEvent $e)
-    {
-
     }
 }


### PR DESCRIPTION
When `limit_by_path` is set to `true` in `config.ini`, the bootstrap needs the the base url for session management before Finna module's onBoostrap is called. Thus we need to attach a callback with higher priority to bootstrap to ensure that the base url is set before it is requested.