### PR TITLE
Make sure that Finna's record image generator receives an array of parameters even when VuFind's record driver returns image URL as a string.

### DIFF
--- a/module/Finna/src/Finna/RecordDriver/Primo.php
+++ b/module/Finna/src/Finna/RecordDriver/Primo.php
@@ -158,6 +158,25 @@ class Primo extends \VuFind\RecordDriver\Primo
     }
 
     /**
+     * Returns an array of parameter to send to Finna's cover generator.
+     * Fallbacks to VuFind's getThumbnail if no record image with the
+     * given index was found.
+     *
+     * @param string $size  Size of thumbnail
+     * @param int    $index Image index
+     *
+     * @return array|bool
+     */
+    public function getRecordImage($size = 'small', $index = 0)
+    {
+        $params = parent::getThumbnail($size);
+        if ($params && !is_array($params)) {
+            $params = ['url' => $params];
+        }
+        return $params;
+    }
+
+    /**
      * Get OpenURL parameters for an article.
      *
      * @return array

--- a/module/Finna/src/Finna/RecordDriver/SolrFinna.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrFinna.php
@@ -234,7 +234,7 @@ trait SolrFinna
      * @param string $size  Size of thumbnail
      * @param int    $index Image index
      *
-     * @return string|array|bool
+     * @return array|bool
      */
     public function getRecordImage($size = 'small', $index = 0)
     {
@@ -251,7 +251,11 @@ trait SolrFinna
                 return array('id' => $this->getUniqueId(), 'url' => $url);
             }
         }
-        return parent::getThumbnail($size);
+        $params = parent::getThumbnail($size);
+        if ($params && !is_array($params)) {
+            $params = ['url' => $params];
+        }
+        return $params;
     }
 
     /**


### PR DESCRIPTION
Make sure that Finna's record image generator receives an array of parameters even when VuFind's record driver returns image URL as a string.