### PR TITLE
[ALLI-3287] Improvements to condensed result view.

### DIFF
--- a/themes/finna/js/finna-item-status.js
+++ b/themes/finna/js/finna-item-status.js
@@ -90,54 +90,63 @@ finna.itemStatus = (function() {
       }
     });
     item.data('xhr', xhr);
-  }
+  };
 
-  var initDedupRecordSelection = function () {
-    $('.dedup-select').change(function() {
-      var id = $(this).val();
-      var source = $(this).find('option:selected').data('source');
-      $.cookie('preferredRecordSource', source);
-
-      var recordContainer = $(this).closest('.record-container');
-      var oldRecordId = recordContainer.find('.hiddenId')[0].value;
-
-      // Update IDs of elements
-      recordContainer.find('.hiddenId').val(id);
-
-      // Update IDs of elements
-      recordContainer.find('[id="' + oldRecordId + '"]').each(function() {
-        $(this).attr('id', id);
-      });
-
-      // Update links as well
-      recordContainer.find('a').each(function() {
-        if (typeof $(this).attr('href') !== 'undefined') {
-          $(this).attr('href', $(this).attr('href').replace(oldRecordId, id));
+    var initDedupRecordSelection = function (holder) {
+        if (typeof holder === 'undefined') {
+            holder = $(document);
         }
-      })
 
-      recordContainer.find('.locationDetails').addClass('hidden');
-      recordContainer.find('.callnumber').removeClass('hidden');
-      recordContainer.find('.location').removeClass('hidden');
-      checkItemStatus(id);
-    });
-  }
+        holder.find('.dedup-select').change(function() {
+            var id = $(this).val();
+            var source = $(this).find('option:selected').data('source');
+            $.cookie('preferredRecordSource', source);
 
-  var initItemStatuses = function() {
-    $('.ajaxItem').each(function(ind, e) {
-      $(this).unbind('inview').one('inview', function() {
-        var id = $(this).find('.hiddenId')[0].value;
-        checkItemStatus(id);
-      });
-    });
-  }
+            var recordContainer = $(this).closest('.record-container');
+            var oldRecordId = recordContainer.find('.hiddenId')[0].value;
+
+            // Update IDs of elements
+            recordContainer.find('.hiddenId').val(id);
+
+            // Update IDs of elements
+            recordContainer.find('[id="' + oldRecordId + '"]').each(function() {
+                $(this).attr('id', id);
+            });
+
+            // Update links as well
+            recordContainer.find('a').each(function() {
+                if (typeof $(this).attr('href') !== 'undefined') {
+                    $(this).attr('href', $(this).attr('href').replace(oldRecordId, id));
+                }
+            });
+
+            recordContainer.find('.locationDetails').addClass('hidden');
+            recordContainer.find('.callnumber').removeClass('hidden');
+            recordContainer.find('.location').removeClass('hidden');
+            checkItemStatus(id);
+        });
+    };
+
+    var initItemStatuses = function(holder) {
+        if (typeof holder === 'undefined') {
+            holder = $(document);
+        }
+        holder.find('.ajaxItem').each(function(ind, e) {
+            $(this).one('inview', function() {
+                var id = $(this).find('.hiddenId')[0].value;
+                checkItemStatus(id);
+            });
+        });
+    };
 
   var my = {
     initItemStatuses: initItemStatuses,
     initDedupRecordSelection: initDedupRecordSelection,
     init: function() {
-      initItemStatuses();
-      initDedupRecordSelection();
+        if (!$(".results").hasClass("result-view-condensed")) {
+            initItemStatuses();
+            initDedupRecordSelection();
+        }
     }
   };
 

--- a/themes/finna/js/finna-layout.js
+++ b/themes/finna/js/finna-layout.js
@@ -375,9 +375,16 @@ finna.layout = (function() {
     var initCondensedList = function () {
         $('.condensed-collapse-toggle').click(function(event) {
             if ((event.target.nodeName) != 'A' && (event.target.nodeName) != 'MARK') {
-              $(this).nextAll('.condensed-collapse-data').first().slideToggle(120, 'linear');
-              $('.fa-arrow-right', this).toggleClass('fa-arrow-down');
-              $(this).parent().parent().toggleClass('open');
+                $(this).nextAll('.condensed-collapse-data').first().slideToggle(120, 'linear');
+                $('.fa-arrow-right', this).toggleClass('fa-arrow-down');
+                var holder = $(this).parent().parent();
+                holder.toggleClass('open');
+                if (holder.hasClass('open') && !holder.hasClass('opened')) {
+                    holder.addClass('opened');
+                    finna.itemStatus.initItemStatuses(holder);
+                    finna.itemStatus.initDedupRecordSelection(holder);
+                }
+                $(this).parent().parent().toggleClass('open');
             }
         });
     };
@@ -388,7 +395,14 @@ finna.layout = (function() {
         }
         holder.find('.save-record').click(function() {
             var parts = this.href.split('/');
-            return finna.layout.lightbox.get(parts[parts.length-3],'Save',{id:$(this).attr('id')});
+            var id = $(this).attr('id');
+            if (!id) {
+                id = $(this).data('id');
+            }
+            if (!id) {
+                return;
+            }
+            return finna.layout.lightbox.get(parts[parts.length-3],'Save',{id:id});
         });
     };
 

--- a/themes/finna/js/finna-search-tabs-recommendations.js
+++ b/themes/finna/js/finna-search-tabs-recommendations.js
@@ -14,8 +14,8 @@ finna.searchTabsRecommendations = (function() {
                 finna.layout.initTruncate(holder);
                 finna.openUrl.initLinks();
                 finna.layout.initSaveRecordLinks(holder);
-                finna.itemStatus.initItemStatuses();
-                finna.itemStatus.initDedupRecordSelection();
+                finna.itemStatus.initItemStatuses(holder);
+                finna.itemStatus.initDedupRecordSelection(holder);
                 finna.layout.checkSaveStatuses(holder);
           }
         });

--- a/themes/finna/js/finna.js
+++ b/themes/finna/js/finna.js
@@ -11,6 +11,7 @@ var finna = (function() {
                 'feed',
                 'feedback',
                 'imagePopup',
+                'itemStatus',
                 'layout',
                 'myList',
                 'openUrl',

--- a/themes/finna/templates/RecordDriver/SolrDefault/result-condensed.phtml
+++ b/themes/finna/templates/RecordDriver/SolrDefault/result-condensed.phtml
@@ -5,7 +5,7 @@
     $this->record($this->driver)->getFormatClass(end($formats)) === '1journaleserial' ? $ejournal = 'true' :  $ejournal = 'false';
 
 ?>
-<div class="record-container<?=$this->driver->supportsAjaxStatus()?' ajaxItem ':''?> list-view">
+<div class="record-container<?=$this->driver->supportsAjaxStatus()?' ajaxItem ':''?> list-view" id="<?=$this->escapeHtmlAttr($this->driver->getUniqueId()) ?>">
   <div class="col-xs-12 condensed-collapse-toggle">
       <div class="col-sm-6 col-md-8">
         <i class="fa fa-arrow-right"></i>
@@ -224,7 +224,7 @@
 
       <? if ($this->userlist()->getMode() !== 'disabled'): ?>
         <? /* Add to favorites */ ?>
-        <a href="<?=$this->recordLink()->getActionUrl($this->driver, 'Save')?>" class="save-record modal-link" id="<?=$this->driver->getUniqueId() ?>" title="<?=$this->transEsc('Add to favorites')?>"><i class="fa fa-heart"></i> <span class="hidden-sm hidden-md hidden-lg"><?=$this->transEsc('Add to favorites')?></span> <span class="sr-only hidden-xs"><?=$this->transEsc('Add to favorites')?></span></a>
+        <a href="<?=$this->recordLink()->getActionUrl($this->driver, 'Save')?>" class="save-record modal-link" data-id="<?=$this->driver->getUniqueId() ?>" title="<?=$this->transEsc('Add to favorites')?>"><i class="fa fa-heart"></i> <span class="hidden-sm hidden-md hidden-lg"><?=$this->transEsc('Add to favorites')?></span> <span class="sr-only hidden-xs"><?=$this->transEsc('Add to favorites')?></span></a>
       <? endif; ?>
       <? /* Hierarchy tree link */ ?>
       <? $trees = $this->driver->tryMethod('getHierarchyTrees'); if (!empty($trees)): ?>

--- a/themes/finna/templates/RecordDriver/SolrEad/result-condensed.phtml
+++ b/themes/finna/templates/RecordDriver/SolrEad/result-condensed.phtml
@@ -1,5 +1,5 @@
 <!-- start of Ead result-condensed.phtml -->
-<div class="record-container<?=$this->driver->supportsAjaxStatus()?' ajaxItem ':''?> list-view">
+<div class="record-container<?=$this->driver->supportsAjaxStatus()?' ajaxItem ':''?> list-view" id="<?=$this->escapeHtmlAttr($this->driver->getUniqueId()) ?>">
   <div class="col-xs-12 condensed-collapse-toggle">
     <div class="col-sm-6 col-md-8">
       <i class="fa fa-arrow-right"></i>
@@ -142,7 +142,7 @@
 
       <? if ($this->userlist()->getMode() !== 'disabled'): ?>
         <? /* Add to favorites */ ?>
-        <a href="<?=$this->recordLink()->getActionUrl($this->driver, 'Save')?>" class="save-record modal-link" id="<?=$this->driver->getUniqueId() ?>" title="<?=$this->transEsc('Add to favorites')?>"><i class="fa fa-heart"></i> <span class="hidden-sm hidden-md hidden-lg"><?=$this->transEsc('Add to favorites')?></span> <span class="sr-only hidden-xs"><?=$this->transEsc('Add to favorites')?></span></a>
+        <a href="<?=$this->recordLink()->getActionUrl($this->driver, 'Save')?>" class="save-record modal-link" data-id="<?=$this->driver->getUniqueId() ?>" title="<?=$this->transEsc('Add to favorites')?>"><i class="fa fa-heart"></i> <span class="hidden-sm hidden-md hidden-lg"><?=$this->transEsc('Add to favorites')?></span> <span class="sr-only hidden-xs"><?=$this->transEsc('Add to favorites')?></span></a>
       <? endif; ?>
 
       <? $openUrl = $this->driver->getOpenURL(); ?>

--- a/themes/finna/templates/RecordDriver/SolrLido/result-condensed.phtml
+++ b/themes/finna/templates/RecordDriver/SolrLido/result-condensed.phtml
@@ -1,5 +1,5 @@
 <!-- start of Ead result-condensed.phtml -->
-<div class="record-container<?=$this->driver->supportsAjaxStatus()?' ajaxItem ':''?> list-view">
+<div class="record-container<?=$this->driver->supportsAjaxStatus()?' ajaxItem ':''?> list-view" id="<?=$this->escapeHtmlAttr($this->driver->getUniqueId()) ?>">
   <div class="col-xs-12 condensed-collapse-toggle">
     <div class="col-sm-8 col-md-10">
       <i class="fa fa-arrow-right"></i>
@@ -80,7 +80,7 @@
 
       <? if ($this->userlist()->getMode() !== 'disabled'): ?>
         <? /* Add to favorites */ ?>
-       <a href="<?=$this->recordLink()->getActionUrl($this->driver, 'Save')?>" class="save-record modal-link" id="<?=$this->driver->getUniqueId() ?>" title="<?=$this->transEsc('Add to favorites')?>"><i class="fa fa-heart"></i> <span class="hidden-sm hidden-md hidden-lg"><?=$this->transEsc('Add to favorites')?></span> <span class="sr-only hidden-xs"><?=$this->transEsc('Add to favorites')?></span></a>
+       <a href="<?=$this->recordLink()->getActionUrl($this->driver, 'Save')?>" class="save-record modal-link" data-id="<?=$this->driver->getUniqueId() ?>" title="<?=$this->transEsc('Add to favorites')?>"><i class="fa fa-heart"></i> <span class="hidden-sm hidden-md hidden-lg"><?=$this->transEsc('Add to favorites')?></span> <span class="sr-only hidden-xs"><?=$this->transEsc('Add to favorites')?></span></a>
       <? endif; ?>
 
       <? $openUrl = $this->driver->getOpenURL(); ?>

--- a/themes/finna/templates/RecordDriver/SolrQdc/result-condensed.phtml
+++ b/themes/finna/templates/RecordDriver/SolrQdc/result-condensed.phtml
@@ -1,6 +1,6 @@
 <!-- start of QDC result-condensed.phtml -->
 
-<div class="record-container<?=$this->driver->supportsAjaxStatus()?' ajaxItem ':''?> list-view">
+<div class="record-container<?=$this->driver->supportsAjaxStatus()?' ajaxItem ':''?> list-view" id="<?=$this->escapeHtmlAttr($this->driver->getUniqueId()) ?>">
   <div class="col-xs-12 condensed-collapse-toggle">
       <div class="col-sm-6 col-md-8">
         <i class="fa fa-arrow-right"></i>
@@ -184,7 +184,7 @@
 
       <? if ($this->userlist()->getMode() !== 'disabled'): ?>
         <? /* Add to favorites */ ?>
-        <a href="<?=$this->recordLink()->getActionUrl($this->driver, 'Save')?>" class="save-record modal-link" id="<?=$this->driver->getUniqueId() ?>" title="<?=$this->transEsc('Add to favorites')?>"><i class="fa fa-heart"></i> <span class="hidden-sm hidden-md hidden-lg"><?=$this->transEsc('Add to favorites')?></span> <span class="sr-only hidden-xs"><?=$this->transEsc('Add to favorites')?></span></a>
+        <a href="<?=$this->recordLink()->getActionUrl($this->driver, 'Save')?>" class="save-record modal-link" data-id="<?=$this->driver->getUniqueId() ?>" title="<?=$this->transEsc('Add to favorites')?>"><i class="fa fa-heart"></i> <span class="hidden-sm hidden-md hidden-lg"><?=$this->transEsc('Add to favorites')?></span> <span class="sr-only hidden-xs"><?=$this->transEsc('Add to favorites')?></span></a>
       <? endif; ?>
       <? /* Hierarchy tree link */ ?>
       <? $trees = $this->driver->tryMethod('getHierarchyTrees'); if (!empty($trees)): ?>

--- a/themes/finna/templates/combined/results.phtml
+++ b/themes/finna/templates/combined/results.phtml
@@ -41,9 +41,9 @@
   $this->showBulkOptions = $this->supportsCart && $this->showBulkOptions;
 
   // Load Javascript dependencies into header:
-  $this->headScript()->appendFile("check_item_statuses.js");
   $this->headScript()->appendFile("check_save_statuses.js");
   $this->headScript()->appendFile("finna-combined-results.js");
+  $this->headScript()->appendFile("finna-item-status.js");
   // Style
   $this->headLink()->appendStylesheet('combined-search.css');
 ?>

--- a/themes/finna/templates/search/results.phtml
+++ b/themes/finna/templates/search/results.phtml
@@ -63,6 +63,7 @@
 
   // Load Javascript dependencies into header:
   $this->headScript()->appendFile("finna-search-tabs-recommendations.js");
+  $this->headScript()->appendFile("finna-item-status.js");
 ?>
     <? if (($recordTotal = $this->results->getResultTotal()) > 0): // only display these at very top if we have results ?>
       <? foreach ($this->results->getRecommendations('top') as $current): ?>
@@ -84,7 +85,7 @@
         </div>
       <? endif; ?>
     </div>
-<div class="row">
+<div class="row results result-view-<?=$this->escapeHtmlAttr($this->params->getView())?>">
   <div class="<?=$this->layoutClass('mainbody')?>">
 
     <? /* End Listing Options */ ?>

--- a/themes/finna/theme.config.php
+++ b/themes/finna/theme.config.php
@@ -49,7 +49,6 @@ return array(
         'finna-adv-search.js',
         'finna-daterange-vis.js',
         'finna-feed.js',
-        'finna-item-status.js',
         'finna-layout.js',
         'finna-openurl.js',
         'finna-persona.js',


### PR DESCRIPTION
- Load item statuses also when searchtabs recommendations are not enabled.
- Load item status in condensed view only when result item is expanded.
- Move record id attribute from "Save record" button to result item
  container div in condensed result view so that the window scroll
  position is restored when returning to search results from record page.