### PR TITLE
Fix search handler logic.

### DIFF
--- a/module/Finna/src/Finna/View/Helper/Root/Factory.php
+++ b/module/Finna/src/Finna/View/Helper/Root/Factory.php
@@ -294,10 +294,12 @@ class Factory extends \VuFind\View\Helper\Root\Factory
     public static function getSearchBox(ServiceManager $sm)
     {
         $config = $sm->getServiceLocator()->get('VuFind\Config');
-        return new SearchBox(
+        $searchbox = new SearchBox(
             $sm->getServiceLocator()->get('VuFind\SearchOptionsPluginManager'),
             $config->get('searchbox')->toArray()
         );
+        $searchbox->setTabConfig($config->get('config'));
+        return $searchbox;
     }
 
     /**

--- a/module/Finna/src/Finna/View/Helper/Root/SearchBox.php
+++ b/module/Finna/src/Finna/View/Helper/Root/SearchBox.php
@@ -39,6 +39,49 @@ namespace Finna\View\Helper\Root;
 class SearchBox extends \VuFind\View\Helper\Root\SearchBox
 {
     /**
+     * Configuration for search tabs
+     *
+     * @var array
+     */
+    protected $tabConfig;
+
+    /**
+     * Set configuration for search tabs
+     *
+     * @param array $config Configuration
+     *
+     * @return void
+     */
+    public function setTabConfig($config)
+    {
+        if (isset($config['SearchTabs'])) {
+            $this->tabConfig = $config['SearchTabs'];
+        }
+    }
+
+    /**
+     * Are combined handlers enabled?
+     *
+     * @return bool
+     */
+    public function combinedHandlersActive()
+    {
+        if (isset($this->tabConfig)
+            && count($this->tabConfig) > 1
+        ) {
+            if (!isset($this->config['General']['combinedHandlers'])
+                || !$this->config['General']['combinedHandlers']
+            ) {
+                throw new \Exception(
+                    'Combined handlers must be enabled when search tabs are used'
+                );
+            }
+            return true;
+        }
+        return false;
+    }
+
+    /**
      * Support method for getHandlers() -- load combined settings.
      *
      * @param string $activeSearchClass Active search class ID
@@ -49,11 +92,10 @@ class SearchBox extends \VuFind\View\Helper\Root\SearchBox
     protected function getCombinedHandlers($activeSearchClass, $activeHandler)
     {
         if (isset($this->config['CombinedHandlers'])) {
-            $backend = "VuFind:$activeSearchClass";
             $handlers = [];
             foreach ($this->config['CombinedHandlers'] as $type => $label) {
                 $handlers[] = [
-                   'value' => "$backend|$type",
+                   'value' => $type,
                    'label' => $label,
                    'indent' => false,
                    'selected' => ($activeHandler == $type)

--- a/themes/finna/templates/search/searchbox.phtml
+++ b/themes/finna/templates/search/searchbox.phtml
@@ -12,12 +12,7 @@
         isset($this->searchIndex) ? $this->searchIndex : null
     );
     $handlerCount = count($handlers);
-    $basicSearch = null;
-    if ($browse) {
-      $basicSearch = "browse-{$browse}";
-    } else {
-      $basicSearch = $this->searchbox()->combinedHandlersActive() ? 'combined-searchbox' : $options->getSearchAction();
-    }
+    $basicSearch = $browse ? "browse-{$browse}" : $options->getSearchAction();
     $searchHome = $options->getSearchHomeAction();
     $advSearch = $options->getAdvancedSearchAction();
     $lastSort = $browse ? null : $options->getLastSort();
@@ -117,10 +112,6 @@
       </div>
     <? endif; ?>
     <?
-      /* Show hidden field for active search class when in combined handler mode. */
-      if ($this->searchbox()->combinedHandlersActive()) {
-        echo '<input type="hidden" name="activeSearchClassId" value="' . $this->escapeHtmlAttr($this->searchClassId) . '" />';
-      }
       /* Load hidden limit preference from Session */
       if (!empty($lastLimit)) {
         echo '<input type="hidden" name="limit" value="' . $this->escapeHtmlAttr($lastLimit) . '" />';


### PR DESCRIPTION
- Use combined handlers only when search tabs are enabled.
- Bypass Combined/Searchbox in search form actions.