### PR TITLE
Add missing use statement

### DIFF
--- a/module/Finna/src/Finna/ILS/Connection.php
+++ b/module/Finna/src/Finna/ILS/Connection.php
@@ -30,6 +30,8 @@
  */
 namespace Finna\ILS;
 
+use VuFind\Exception\ILS as ILSException;
+
 /**
  * Catalog Connection Class
  *


### PR DESCRIPTION
Fixes missing class 'ILSException' errors in connection.php on error.