### PR TITLE
Initialize RSS reader http client

### DIFF
--- a/module/Finna/src/Finna/Controller/AjaxController.php
+++ b/module/Finna/src/Finna/Controller/AjaxController.php
@@ -675,6 +675,9 @@ class AjaxController extends \VuFind\Controller\AjaxController
         $maxAge = isset($cacheConfig->Content->feedcachetime)
             ? $cacheConfig->Content->feedcachetime : false;
 
+        $httpService = $this->getServiceLocator()->get('\VuFind\Http');
+        Reader::setHttpClient($httpService->createClient());
+
         if ($maxAge) {
             $cacheEnabled = true;
             if (is_readable($localFile)


### PR DESCRIPTION
Initializes the RSS reader http client using Vufind settings. By default, the rss reader uses a HTTP client with default settings, which causes SSL peer verification to fail due to lack of configured cafile/capath.