### PR TITLE
Fix cache constructor execution order

### DIFF
--- a/module/Finna/src/Finna/Cache/Manager.php
+++ b/module/Finna/src/Finna/Cache/Manager.php
@@ -49,10 +49,11 @@ class Manager extends \VuFind\Cache\Manager
      */
     public function __construct(Config $config, Config $searchConfig)
     {
+        parent::__construct($config, $searchConfig);
+
         $cacheBase = $this->getCacheDir();
         foreach (['feed', 'description'] as $cache) {
             $this->createFileCache($cache, $cacheBase . $cache . 's');
         }
-        return parent::__construct($config, $searchConfig);
     }
 }


### PR DESCRIPTION
The cache directories were created with incorrect permission due to the the permissions being configured in the parent constructor, which was called after the caches were created.