### PR TITLE
Add default value for finna_type

### DIFF
--- a/module/Finna/sql/mysql.sql
+++ b/module/Finna/sql/mysql.sql
@@ -14,7 +14,7 @@
 --
 ALTER TABLE comments ADD COLUMN `finna_visible` tinyint(1) DEFAULT '1';
 ALTER TABLE comments ADD COLUMN `finna_rating` float DEFAULT NULL;
-ALTER TABLE comments ADD COLUMN `finna_type` tinyint(1) NOT NULL;
+ALTER TABLE comments ADD COLUMN `finna_type` tinyint(1) DEFAULT '0' NOT NULL;
 ALTER TABLE comments ADD COLUMN `finna_updated` datetime DEFAULT NULL;
 ALTER TABLE comments ADD INDEX `finna_visible` (`finna_visible`);
 ALTER TABLE comments ADD INDEX `finna_rating` (`finna_rating`);
@@ -56,7 +56,7 @@ CREATE TABLE `finna_user` (
   `due_date_notification` int(11) NOT NULL DEFAULT '0',
   `due_date_reminder` int(11) NOT NULL DEFAULT '0',
   `last_login` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
-  `auth_method` varchar(50) DEFAULT NULL,  
+  `auth_method` varchar(50) DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `user_id` (`user_id`),
   CONSTRAINT `finna_user_ibfk_1` FOREIGN KEY (`user_id`) REFERENCES `user` (`id`) ON DELETE CASCADE


### PR DESCRIPTION
The comments are saved by VuFind before the type is determined. Thus, the column needs a default value to prevent errors in strict sql mode.