### PR TITLE
[ALLI-4132] Always preserve 'type' URL parameter.

### DIFF
--- a/module/Finna/src/Finna/View/Helper/Root/SearchTabs.php
+++ b/module/Finna/src/Finna/View/Helper/Root/SearchTabs.php
@@ -219,12 +219,8 @@ class SearchTabs extends \VuFind\View\Helper\Root\SearchTabs
             $targetUrlQuery->removeSearchId($targetTabId);
         }
 
-        // Find matching handler for new query (and use default if no match):
         $targetOptions = $targetResults->getOptions();
-        $targetHandler = $targetOptions->getHandlerForLabel(
-            $activeOptions->getLabelForBasicHandler($handler)
-        );
-        $targetParams->setBasicSearch($query, $targetHandler);
+        $targetParams->setBasicSearch($query, $handler);
 
         // Clone the active query so that we can remove active filters
         $currentResults = clone($this->getView()->results);


### PR DESCRIPTION
Preserve 'type' URL parameter even when the selected handler
is not enabled. This is needed for autocomplete handlers to work
correctly when AllFields is the only enabled combined handler
(i.e. handler options are only shown in the autocomplete menu).