### PR TITLE
Hide Available online -text from search results when only OpenURL links are  available

### DIFF
--- a/themes/finna/templates/RecordDriver/SolrDefault/result-online-urls.phtml
+++ b/themes/finna/templates/RecordDriver/SolrDefault/result-online-urls.phtml
@@ -20,7 +20,7 @@
   ?>
   <? if (!empty($urls) || $openUrlActive || !empty($onlineURLs) || !empty($mergedData['urls']) || strncmp($this->driver->getUniqueID(), 'metalib_', 8) == 0): ?>
     <div class="available-online-links">
-      <strong class="available-online-header <?=(!empty($onlineURLs) || !empty($mergedData['urls']) || !empty($urls) || $openUrlActive) ? '' : 'hidden'; ?>"><?=$this->transEsc('Available Online') ?>:</strong>
+      <strong class="available-online-header <?=(!empty($onlineURLs) || !empty($mergedData['urls']) || !empty($urls)) ? '' : 'hidden'; ?>"><?=$this->transEsc('Available Online') ?>:</strong>
       <div class="truncate-field">
       <? $renderedURLs = []; ?>
       <? if (!empty($urls)): ?>


### PR DESCRIPTION
(this partly reverts c8a1d1f3e6b95f8f3a164be1593ee8ed44ab191d)