### PR TITLE
[ALLI-4273] [ALLI-4274] MetaLib fixes.

### DIFF
--- a/themes/finna/js/finna-metalib.js
+++ b/themes/finna/js/finna-metalib.js
@@ -172,9 +172,11 @@ finna.metalib = (function() {
     };
 
     var initTabNavigation = function(hash) {
-        $(".nav-tabs li a").click(function() {
+        $(".nav-tabs li:not(.active) a").click(function() {
             var href = $(this).attr('href');
-            href += ('&search[]=MetaLib:' + hash);
+            href += href.indexOf('?') == -1
+               ? '?' : '&';
+            href += ('search[]=MetaLib:' + hash);
             $(this).attr('href', href);
         });
     };

--- a/themes/finna/templates/metalib/sidebar.phtml
+++ b/themes/finna/templates/metalib/sidebar.phtml
@@ -2,7 +2,9 @@
 <?
 $queryHandler = 'AllFields';
 if (isset($results) && $results->getParams()->getSearchType() == 'basic') {
-  $queryHandler = $results->getParams()->getQuery()->getHandler();
+  if ($handler = $results->getParams()->getQuery()->getHandler()) {
+     $queryHandler = $handler;
+  }
 }
 $customQueryHandler = $queryHandler != 'AllFields';
 ?>


### PR DESCRIPTION
- Disable MetaLib-tab click event when the tab is already active.
- Do not display notification of non-default (AllFields) search
  handler when URL parameter type is undefined.
- Add check for '?' sign when appending search hash to URLs pointing
  to other search tabs.