### PR TITLE
[ALLI-4337] Fixes to database & journal browsing.

### DIFF
--- a/module/Finna/src/Finna/Controller/SearchController.php
+++ b/module/Finna/src/Finna/Controller/SearchController.php
@@ -231,7 +231,6 @@ class SearchController extends \VuFind\Controller\SearchController
         try {
             $config = $config[$type];
             $query = $this->getRequest()->getQuery();
-            $query->set('view', 'condensed');
             if (!$query->get('limit')) {
                 $query->set('limit', $config['resultLimit'] ?: 100);
             }
@@ -264,6 +263,7 @@ class SearchController extends \VuFind\Controller\SearchController
             $this->getSearchMemory()->forgetSearch();
             $this->rememberSearch($view->results);
 
+            $view->results->getParams()->setView('condensed');
             $view->results->getParams()->getQuery()->setHandler($queryType);
 
             return $view;


### PR DESCRIPTION
- Use condensed result view even when it has not been enabled
  for "normal" search results.
- Do not save the result type used in browsing to the search object.