### PR TITLE
Fix reference notice

### DIFF
--- a/module/Finna/src/Finna/Controller/CoverController.php
+++ b/module/Finna/src/Finna/Controller/CoverController.php
@@ -87,7 +87,8 @@ class CoverController extends \VuFind\Controller\CoverController
                         $filename = $issn;
                     } else {
                         // Strip the data source prefix
-                        $filename = end(explode('.', $driver->getUniqueID(), 2));
+                        $parts = explode('.', $driver->getUniqueID(), 2);
+                        $filename = end($parts);
                     }
                 } elseif (!empty($params['title'])) {
                     $filename = $params['title'];


### PR DESCRIPTION
Fixes to following notice, caused by the fact that you can't call `end()` with an expression:

    Notice: Only variables should be passed by reference in /private/var/www/NDL-VuFind2/module/Finna/src/Finna/Controller/CoverController.php on line 90

