### PR TITLE
Fix bug in sorting navigation menu items.

### DIFF
--- a/module/Finna/src/Finna/View/Helper/Root/Navibar.php
+++ b/module/Finna/src/Finna/View/Helper/Root/Navibar.php
@@ -359,8 +359,9 @@ class Navibar extends \Zend\View\Helper\AbstractHelper
 
         foreach ($sortDataOrder as $index => $menuKey) {
             $sortDataProcessed[$menuKey] = $sortData[$menuKey];
+            unset($sortData[$menuKey]);
         }
-        $sortData = $sortDataProcessed;
+        $sortData = array_merge($sortDataProcessed, $sortData);
 
         return ['menuData' => $menuData, 'sortData' => $sortData];
     }


### PR DESCRIPTION
Menu items were sorted only when the parent menu was also
positioned (i.e. only when __MENU__ = <pos> was found in navibar.ini).