### PR TITLE
AWS: Use the highest number of reservations

### DIFF
--- a/module/Finna/src/Finna/ILS/Driver/AxiellWebServices.php
+++ b/module/Finna/src/Finna/ILS/Driver/AxiellWebServices.php
@@ -1080,7 +1080,10 @@ class AxiellWebServices extends \VuFind\ILS\Driver\AbstractBase
             if ($this->singleReservationQueue
                 && isset($item['availabilityInfo']['reservations'])
             ) {
-                $reservationsTotal = $item['availabilityInfo']['reservations'];
+                $reservationsTotal
+                    = max(
+                        $reservationsTotal, $item['availabilityInfo']['reservations']
+                    );
             }
             $locations[$item['location']] = true;
             if (!$journal && $item['is_holdable']) {


### PR DESCRIPTION
AWS: Use the highest number of reservations for a single reservationqueue in oder to avoid inconsistencies.