### PR TITLE
[ALLI-4969] AWS: getMyHolds shows requestGroup

### DIFF
--- a/module/Finna/src/Finna/ILS/Driver/AxiellWebServices.php
+++ b/module/Finna/src/Finna/ILS/Driver/AxiellWebServices.php
@@ -1610,6 +1610,11 @@ class AxiellWebServices extends \VuFind\ILS\Driver\AbstractBase
                 'publication_year' =>
                    isset($reservation->catalogueRecord->publicationYear)
                        ? $reservation->catalogueRecord->publicationYear : '',
+                'requestGroup' =>
+                   isset($reservation->reservationType)
+                   && $this->requestGroupsEnabled
+                   ? "axiell_$reservation->reservationType"
+                   : '',
                 'title' => $title
             ];
             $holdsList[] = $hold;


### PR DESCRIPTION
[ALLI-4969] AWS: getMyHolds shows requestGroup (reginal and municipality holds) if it is enabled.