### PR TITLE
[ALLI-5050] Advanced search term bug fix

### DIFF
--- a/themes/finna/js/finna-add-adv-search.js
+++ b/themes/finna/js/finna-add-adv-search.js
@@ -1,0 +1,48 @@
+function addSearch(group, _fieldValues) {
+    var fieldValues = _fieldValues || {};
+    // Build the new search
+    var inputID = group + '_' + groupLength[group];
+    var $newSearch = $($('#new_search_template').html());
+
+    $newSearch.attr('id', 'search' + inputID);
+    $newSearch.find('input.form-control')
+        .attr('id', 'search_lookfor' + inputID)
+        .attr('name', 'lookfor' + group + '[]')
+        .val('');
+    $newSearch.find('select.adv-term-type option:first-child').attr('selected', 1);
+    $newSearch.find('select.adv-term-type')
+        .attr('id', 'search_type' + inputID)
+        .attr('name', 'type' + group + '[]');
+    $newSearch.find('.adv-term-remove')
+        .attr('onClick', 'return deleteSearch(' + group + ',' + groupLength[group] + ')');
+    // Preset Values
+    if (typeof fieldValues.term !== "undefined") {
+        $newSearch.find('input.form-control').val(fieldValues.term);
+    }
+    if (typeof fieldValues.field !== "undefined") {
+        $newSearch.find('select.adv-term-type option[value="' + fieldValues.field + '"]').attr('selected', 1);
+    }
+    if (typeof fieldValues.op !== "undefined") {
+        $newSearch.find('select.adv-term-op option[value="' + fieldValues.op + '"]').attr('selected', 1);
+    }
+    // Insert it
+    $("#group" + group + "Holder").before($newSearch);
+    // Individual search ops (for searches like EDS)
+    if (groupLength[group] === 0) {
+        $newSearch.find('.first-op')
+            .attr('name', 'op' + group + '[]')
+            .removeClass('hidden');
+        $newSearch.find('select.adv-term-op').remove();
+    } else {
+        $newSearch.find('select.adv-term-op')
+            .attr('id', 'search_op' + group + '_' + groupLength[group])
+            .attr('name', 'op' + group + '[]')
+            .removeClass('hidden');
+        $newSearch.find('.first-op').remove();
+        $newSearch.find('label').remove();
+        // Show x if we have more than one search inputs
+        $('#group' + group + ' .adv-term-remove').removeClass('hidden');
+    }
+    groupLength[group]++;
+    return false;
+}

--- a/themes/finna/templates/search/advanced/layout.phtml
+++ b/themes/finna/templates/search/advanced/layout.phtml
@@ -40,6 +40,7 @@
   $this->headScript()->appendFile(
     isset($this->advancedSearchJsOverride) ? $this->advancedSearchJsOverride : 'advanced_search.js'
   );
+  $this->headScript()->appendFile('finna-add-adv-search.js');
   $this->headScript()->appendFile('finna-daterange-vis.js');
 
   // Step 2: Build the page


### PR DESCRIPTION
fixed advanced search bug in IE by replacing .attr('value') by .val() because of search term input fields' values is not shown correctly if there is scands in first search term