### PR TITLE
[ALLI-2985] Added getSummary to SolrLido.php

### DIFF
--- a/module/Finna/src/Finna/RecordDriver/SolrLido.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrLido.php
@@ -988,9 +988,9 @@ class SolrLido extends \VuFind\RecordDriver\SolrDefault
                 $label = $attributes->attributes()->label !== null
                     ? $attributes->attributes()->label : '';
             }
-            if ($label == 'aihe' && $notTitle) {
+            if ($label == 'aihe' && isset($subject) && $notTitle) {
                 $results[] = (string)$subject;
-            } else if ($label == null && $notTitle) {
+            } else if ($label == null && isset($subject) && $notTitle) {
                 $results[] = (string)$subject;
             }
         }

--- a/module/Finna/src/Finna/RecordDriver/SolrLido.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrLido.php
@@ -983,14 +983,14 @@ class SolrLido extends \VuFind\RecordDriver\SolrDefault
             'lido/descriptiveMetadata/objectRelationWrap/subjectWrap/subjectSet'
         ) as $node) {
             $subject = $node->displaySubject;
-            $notTitle = (string)$subject != $title ? true : false;
+            $checkTitle = (string)$subject != $title ? true : false;
             foreach ($subject as $attributes) {
                 $label = $attributes->attributes()->label !== null
                     ? $attributes->attributes()->label : '';
             }
-            if ($label == 'aihe' && isset($subject) && $notTitle) {
+            if ($label == 'aihe' && isset($subject) && $checkTitle) {
                 $results[] = (string)$subject;
-            } else if ($label == null && isset($subject) && $notTitle) {
+            } else if ($label == null && isset($subject) && $checkTitle) {
                 $results[] = (string)$subject;
             }
         }

--- a/module/Finna/src/Finna/RecordDriver/SolrLido.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrLido.php
@@ -969,4 +969,31 @@ class SolrLido extends \VuFind\RecordDriver\SolrDefault
             }
         }
     }
+
+    /**
+     * Get the displaysubject info to summary
+     *
+     * @return array $result with info
+     */
+    public function getSummary()
+    {
+        $results = [];
+        $title = $this->getTitle();
+        foreach ($this->getSimpleXML()->xpath(
+            'lido/descriptiveMetadata/objectRelationWrap/subjectWrap/subjectSet'
+        ) as $node) {
+            $subject = $node->displaySubject;
+            $notTitle = (string)$subject != $title ? true : false;
+            foreach ($subject as $attributes) {
+                $label = $attributes->attributes()->label !== null
+                    ? $attributes->attributes()->label : '';
+            }
+            if ($label == 'aihe' && $notTitle) {
+                $results[] = (string)$subject;
+            } else if ($label == null && $notTitle) {
+                $results[] = (string)$subject;
+            }
+        }
+        return $results;
+    }
 }

--- a/module/Finna/src/Finna/RecordDriver/SolrLido.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrLido.php
@@ -987,7 +987,7 @@ class SolrLido extends \VuFind\RecordDriver\SolrDefault
             $checkTitle = str_replace([',', ';'], ' ', (string)$subject) != $title;
             foreach ($subject as $attributes) {
                 $label = $attributes->attributes()->label;
-                if ($label == 'aihe' || $label == null  && $checkTitle) {
+                if (($label == 'aihe' || $label == null)  && $checkTitle) {
                     $results[] = (string)$subject;
                 }
             }

--- a/module/Finna/src/Finna/RecordDriver/SolrLido.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrLido.php
@@ -984,7 +984,7 @@ class SolrLido extends \VuFind\RecordDriver\SolrDefault
             'lido/descriptiveMetadata/objectRelationWrap/subjectWrap/subjectSet'
         ) as $node) {
             $subject = $node->displaySubject;
-            $checkTitle = (string)$subject !== $title ? true : false;
+            $checkTitle = (string)$subject != $title ? true : false;
             foreach ($subject as $attributes) {
                 $label = $attributes->attributes()->label !== null
                     ? $attributes->attributes()->label : null;
@@ -992,6 +992,12 @@ class SolrLido extends \VuFind\RecordDriver\SolrDefault
                     $results[] = (string)$subject;
                 }
             }
+        }
+        if (isset($this->fields['description'])
+            && !empty($this->fields['description'])
+        ) {
+            $results[] = (string)($this->fields['description']) != $title
+                ? (string)$this->fields['description'] : '';
         }
         return $results;
     }

--- a/module/Finna/src/Finna/RecordDriver/SolrLido.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrLido.php
@@ -979,7 +979,7 @@ class SolrLido extends \VuFind\RecordDriver\SolrDefault
     {
         $results = [];
         $label = null;
-        $title = $this->getTitle();
+        $title = str_replace(';', ',', $this->getTitle());
         foreach ($this->getSimpleXML()->xpath(
             'lido/descriptiveMetadata/objectRelationWrap/subjectWrap/subjectSet'
         ) as $node) {
@@ -988,11 +988,9 @@ class SolrLido extends \VuFind\RecordDriver\SolrDefault
             foreach ($subject as $attributes) {
                 $label = $attributes->attributes()->label !== null
                     ? $attributes->attributes()->label : null;
-            }
-            if ($label == 'aihe' && $checkTitle) {
-                $results[] = (string)$subject;
-            } else if ($label == null && $checkTitle) {
-                $results[] = (string)$subject;
+                if ($label == 'aihe' || $label == null  && $checkTitle) {
+                    $results[] = (string)$subject;
+                }
             }
         }
         return $results;

--- a/module/Finna/src/Finna/RecordDriver/SolrLido.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrLido.php
@@ -978,6 +978,7 @@ class SolrLido extends \VuFind\RecordDriver\SolrDefault
     public function getSummary()
     {
         $results = [];
+        $label = null;
         $title = $this->getTitle();
         foreach ($this->getSimpleXML()->xpath(
             'lido/descriptiveMetadata/objectRelationWrap/subjectWrap/subjectSet'
@@ -986,7 +987,7 @@ class SolrLido extends \VuFind\RecordDriver\SolrDefault
             $checkTitle = (string)$subject !== $title ? true : false;
             foreach ($subject as $attributes) {
                 $label = $attributes->attributes()->label !== null
-                    ? $attributes->attributes()->label : '';
+                    ? $attributes->attributes()->label : null;
             }
             if ($label == 'aihe' && $checkTitle) {
                 $results[] = (string)$subject;

--- a/module/Finna/src/Finna/RecordDriver/SolrLido.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrLido.php
@@ -971,9 +971,9 @@ class SolrLido extends \VuFind\RecordDriver\SolrDefault
     }
 
     /**
-     * Get the displaysubject info to summary
+     * Get the displaysubject and description info to summary
      *
-     * @return array $result with info
+     * @return array $results with summary from displaySubject or description field
      */
     public function getSummary()
     {

--- a/module/Finna/src/Finna/RecordDriver/SolrLido.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrLido.php
@@ -983,14 +983,14 @@ class SolrLido extends \VuFind\RecordDriver\SolrDefault
             'lido/descriptiveMetadata/objectRelationWrap/subjectWrap/subjectSet'
         ) as $node) {
             $subject = $node->displaySubject;
-            $checkTitle = (string)$subject != $title ? true : false;
+            $checkTitle = (string)$subject !== $title ? true : false;
             foreach ($subject as $attributes) {
                 $label = $attributes->attributes()->label !== null
                     ? $attributes->attributes()->label : '';
             }
-            if ($label == 'aihe' && isset($subject) && $checkTitle) {
+            if ($label == 'aihe' && $checkTitle) {
                 $results[] = (string)$subject;
-            } else if ($label == null && isset($subject) && $checkTitle) {
+            } else if ($label == null && $checkTitle) {
                 $results[] = (string)$subject;
             }
         }

--- a/module/Finna/src/Finna/RecordDriver/SolrLido.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrLido.php
@@ -979,23 +979,20 @@ class SolrLido extends \VuFind\RecordDriver\SolrDefault
     {
         $results = [];
         $label = null;
-        $title = str_replace(';', ',', $this->getTitle());
+        $title = str_replace([',', ';'], ' ', $this->getTitle());
         foreach ($this->getSimpleXML()->xpath(
             'lido/descriptiveMetadata/objectRelationWrap/subjectWrap/subjectSet'
         ) as $node) {
             $subject = $node->displaySubject;
-            $checkTitle = (string)$subject != $title ? true : false;
+            $checkTitle = str_replace([',', ';'], ' ', (string)$subject) != $title;
             foreach ($subject as $attributes) {
-                $label = $attributes->attributes()->label !== null
-                    ? $attributes->attributes()->label : null;
+                $label = $attributes->attributes()->label;
                 if ($label == 'aihe' || $label == null  && $checkTitle) {
                     $results[] = (string)$subject;
                 }
             }
         }
-        if (isset($this->fields['description'])
-            && !empty($this->fields['description']) && empty($results[0])
-        ) {
+        if (!$results && !empty($this->fields['description'])) {
             $results[] = (string)($this->fields['description']) != $title
                 ? (string)$this->fields['description'] : '';
         }

--- a/module/Finna/src/Finna/RecordDriver/SolrLido.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrLido.php
@@ -994,7 +994,7 @@ class SolrLido extends \VuFind\RecordDriver\SolrDefault
             }
         }
         if (isset($this->fields['description'])
-            && !empty($this->fields['description'])
+            && !empty($this->fields['description']) && empty($results[0])
         ) {
             $results[] = (string)($this->fields['description']) != $title
                 ? (string)$this->fields['description'] : '';

--- a/themes/finna/templates/RecordDriver/SolrLido/core.phtml
+++ b/themes/finna/templates/RecordDriver/SolrLido/core.phtml
@@ -76,10 +76,12 @@
           </div>
         <? endif; ?>
       </div>
-      <? $summary = $this->driver->getSummary(); $summary = isset($summary[0]) ? $summary[0] : false; ?>
+      <? $summary = $this->driver->getSummary();?>
       <? if ($summary): ?>
         <div class="truncate-field wide recordSummary">
-          <p class="summary"><?=preg_replace('/&lt;br\/?&gt;/', '<br>', $this->escapeHtml($summary)); /* Allow <br> tag */ ?></p>
+          <? foreach ($summary as $row): ?>
+            <p class="summary"><?=preg_replace('/&lt;br\/?&gt;/', '<br>', $this->escapeHtml($row)); /* Allow <br> tag */ ?></p>
+          <? endforeach; ?>
         </div>
       <? endif; ?>
 

--- a/themes/finna/templates/RecordDriver/SolrLido/core.phtml
+++ b/themes/finna/templates/RecordDriver/SolrLido/core.phtml
@@ -76,12 +76,10 @@
           </div>
         <? endif; ?>
       </div>
-      <? $summary = $this->driver->getSummary();?>
+      <? $summary = $this->driver->getSummary(); $summary = isset($summary[0]) ? $summary[0] : false; ?>
       <? if ($summary): ?>
         <div class="truncate-field wide recordSummary">
-          <? foreach ($summary as $row): ?>
-            <p class="summary"><?=preg_replace('/&lt;br\/?&gt;/', '<br>', $this->escapeHtml($row)); /* Allow <br> tag */ ?></p>
-          <? endforeach; ?>
+          <p class="summary"><?=preg_replace('/&lt;br\/?&gt;/', '<br>', $this->escapeHtml($summary)); /* Allow <br> tag */ ?></p>
         </div>
       <? endif; ?>
 


### PR DESCRIPTION
Added check for displaySubject, if found and it is different than the title of the record and it has label 'aihe' or no label at all, then it is shown below that said title. If not found or not usable then we will check description field and use that instead, if it is different than the title, if not then nothing is shown in summary field.