### PR TITLE
Remove duplicate login header

### DIFF
--- a/themes/finna2/templates/myresearch/login.phtml
+++ b/themes/finna2/templates/myresearch/login.phtml
@@ -1,8 +1,6 @@
 <!-- START of: finna - Auth/myresearch/login.phtml -->
 <?
   // Set up page title:
-  $this->layout()->finnaMainHeader = '<div><h1><i class="fa fa-sign-in"></i> ' . $this->transEsc('Login') . '</h1></div>';
-
   $this->headTitle($this->translate('Login'));
 
   // Set up breadcrumbs:


### PR DESCRIPTION
Tällä hetkellä tulostaa kaksi otsikkoa. Poistin toisen. 

![screen shot 2018-03-09 at 9 44 39](https://user-images.githubusercontent.com/1954586/37196449-770582a6-237f-11e8-8321-5092488cc575.png)
