### PR TITLE
Adding support for basic gulp tasks "gulp less" and "gulp watch"

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,14 @@
+var gulp = require('gulp');
+var less = require('gulp-less');
+var cleanCSS = require('gulp-clean-css');
+ 
+gulp.task('less', function () {
+  return gulp.src('./themes/finna2/less/finna.less')
+    .pipe(less())
+    .pipe(cleanCSS({keepSpecialComments: 0, advanced: true }))
+    .pipe(gulp.dest('./themes/finna2/css/'));
+});
+
+gulp.task('watch', function() {
+    gulp.watch('./themes/finna2/less/finna/**/*.less', [less]);
+});


### PR DESCRIPTION
Adding support for basic gulp tasks "gulp less" and "gulp watch", to make compiling css easier. Added required libraries to package.json and also updated some of the grunt packages in package.json to be compatible with grunt 1.0 that's already there.