### PR TITLE
Fix for missing address below map in OrganisationInfo in museums

### DIFF
--- a/themes/finna2/js/finna-organisation-info-page.js
+++ b/themes/finna2/js/finna-organisation-info-page.js
@@ -271,10 +271,12 @@ finna.organisationInfoPage = (function finnaOrganisationInfoPage() {
     finna.feed.init(contactHolder);
 
     holder.find('.office-quick-information .service-title').text(data.name);
-    if ('address' in data && !data.details.museum) {
+    if ('address' in data) {
       holder.find('.office-links.address').html(data.address);
-      var address = holder.find('.address-contact');
-      address.show().find('> p').html(data.address);
+      if (!data.details.museum) {
+        var address = holder.find('.address-contact');
+        address.show().find('> p').html(data.address);
+      }
     }
     if ('email' in data) {
       var email = data.email;


### PR DESCRIPTION
Was supposed to only hide from "contact details" -box and not below map