### PR TITLE
[Alli-5604] Search tooltip accessibility fix

### DIFF
--- a/themes/finna2/less/finna/searchbox.less
+++ b/themes/finna2/less/finna/searchbox.less
@@ -2,6 +2,11 @@
   .searchbox-home {
     .search-tooltip {
       width: 30%;
+      .tooltip-button {
+        background-color: transparent;
+        border: none;
+        height: 50px;
+      }
     }
     .btn.btn-link {
       background: @finna-searchbox-link-background;

--- a/themes/finna2/less/finna/searchbox.less
+++ b/themes/finna2/less/finna/searchbox.less
@@ -2,10 +2,15 @@
   .searchbox-home {
     .search-tooltip {
       width: 30%;
-      .tooltip-button {
+      button {
         background-color: transparent;
         border: none;
-        height: 50px;
+        &.tooltip-button {
+          height: 50px;
+        }
+        &.tooltip-image {
+          height: 30px;
+        }
       }
     }
     .btn.btn-link {

--- a/themes/finna2/less/finna/tooltip.less
+++ b/themes/finna2/less/finna/tooltip.less
@@ -16,7 +16,7 @@
   font-size: 1.1em;
   font-weight: normal;
   box-shadow: 0px 0px 20px -10px @body-bg inset;
-  & h4 {
+  h4 {
     font-size: 16px;
     margin-top: 0;
     margin: -12px -16px;
@@ -103,29 +103,27 @@
   }
 }
 .tooltip-image { 
-  & .tooltip {
+  .tooltip {
     overflow: hidden;    
   }
-  & .tooltip-arrow {
+  .tooltip-arrow {
     display: none;    
   }
-  & .tooltip-image-info {
-    i {
-      margin-left: 2px;  
-      position: relative;                 
-      text-align: center;
-      cursor: pointer;
-      font-style: normal;
-      padding: 3px;
-      color: @action-link-color;
-    }
+  i {
+    margin-left: 0;  
+    position: relative;                 
+    text-align: center;
+    cursor: pointer;
+    font-style: normal;
+    padding: 3px;
+    color: @action-link-color;
   }
   @media (max-width: @screen-sm) {
     display: none;
    }
 }
 .finna-main-tabs ul.nav-tabs>li.active>a {
-  & .tooltip-tabs_local, .tooltip-tabs_pci {
+  .tooltip-tabs_local, .tooltip-tabs_pci {
     color: @gray;
   }
 }
@@ -135,18 +133,18 @@
 .tooltip-myaccount {
   margin-left: 10px;
   color: @gray;
-  & >i {
+  >i {
     vertical-align: 0px !important;
   }
 }
 .slider {
-  & .tooltip.top .tooltip-inner {
+  .tooltip.top .tooltip-inner {
     min-width: initial;
     padding: 4px 8px;
     box-shadow: none;
     background: @gray-lighter;
   }
-  & .tooltip.top .tooltip-arrow {
+  .tooltip.top .tooltip-arrow {
     border-top-color: @gray-lighter;
   }
 }

--- a/themes/finna2/less/finna/tooltip.less
+++ b/themes/finna2/less/finna/tooltip.less
@@ -92,7 +92,7 @@
   .tooltip-search-pci, .tooltip-search-local {
     i {
       font-size: 36px;
-      margin-left: 0px;            
+      margin-left: 0px;
       position: relative;          
       text-align: center;
       cursor: pointer;

--- a/themes/finna2/less/finna/tooltip.less
+++ b/themes/finna2/less/finna/tooltip.less
@@ -91,8 +91,8 @@
 .searchbox-home {
   .tooltip-search-pci, .tooltip-search-local {
     i {
-      font-size: 36px;                
-      margin-left: 4px;   
+      font-size: 36px;
+      margin-left: 0px;            
       position: relative;          
       text-align: center;
       cursor: pointer;

--- a/themes/finna2/templates/search/searchbox.phtml
+++ b/themes/finna2/templates/search/searchbox.phtml
@@ -202,13 +202,22 @@
       <?php if (!$browse && !$mainPage && $advSearch): ?>
         <a href="<?=$this->url($advSearch)?>" class="btn btn-link btn-advanced hidden-xs"><i class="fa fa-search-adv"></i><?=$this->transEsc("Advanced Search")?></a>
       <?php endif; ?>
-      <?php if ($module === 'search' && !$this->translationEmpty('tooltip_local_search_html')): ?><span class="tooltip-search-local pull-right hidden-xs" data-toggle="tooltip" data-placement="auto" data-html="true" data-original-title="<?=$this->transEsc('tooltip_local_search_html')?>"><i class="fa fa-question-circle-big"></i></span><?php endif; ?>
-      <?php if ($module === 'primo' && !$this->translationEmpty('tooltip_pci_search_html')): ?><span class="tooltip-search-pci pull-right hidden-xs" data-toggle="tooltip" data-placement="auto" data-html="true" data-original-title="<?=$this->transEsc('tooltip_pci_search_html')?>"><i class="fa fa-question-circle-big"></i></span><?php endif; ?>
-      <?php if ($module === 'eds' && !$this->translationEmpty('tooltip_eds_search_html')): ?><span class="tooltip-search-eds pull-right hidden-xs" data-toggle="tooltip" data-placement="auto" data-html="true" data-original-title="<?=$this->transEsc('tooltip_eds_search_html')?>"><i class="fa fa-question-circle-big"></i></span><?php endif; ?>
-      <?php if ($module === 'summon' && !$this->translationEmpty('tooltip_summon_search_html')): ?><span class="tooltip-search-summon pull-right hidden-xs" data-toggle="tooltip" data-placement="auto" data-html="true" data-original-title="<?=$this->transEsc('tooltip_summon_search_html')?>"><i class="fa fa-question-circle-big"></i></span><?php endif; ?>
-      <?php if ($this->layout()->templateDir === 'search' && $this->layout()->templateName === 'home' && !$this->translationEmpty('tooltip_image_html')): ?>
-         <div class="tooltip-image">
-           <span class="tooltip-image-info" data-toggle="tooltip" data-placement="auto" data-html="true" data-original-title="<?=$this->transEsc('tooltip_image_html')?>"><i class="fa fa-info-circle"></i></span>
+      <?php
+        $searchTypes = ['search' => 'local', 'primo' => 'pci', 'eds' => 'eds', 'summon' => 'summon'];
+        if (isset($searchTypes[$module]) && !$this->translationEmpty('tooltip_'.$searchTypes[$module].'_search_html')) {
+          $tooltipClass = 'tooltip-search-'.$searchTypes[$module];
+          $tooltipText = $this->transEsc('tooltip_'.$searchTypes[$module].'_search_html');
+        }
+
+        if(isset($tooltipClass) && isset($tooltipText)) :
+      ?>
+        <button aria-label="<?= $this->transEsc('Search Tips') ?>" class="tooltip-button <?=$tooltipClass?> pull-right hidden-xs" data-toggle="tooltip" data-placement="auto" data-html="true" data-original-title="<?=$tooltipText?>">
+          <i class="fa fa-question-circle-big"></i>
+        </button>
+      <?php endif; ?>
+      <?php if ($module === 'search' && $action === 'home' && !$this->translationEmpty('tooltip_image_html')): ?>
+        <div aria-hidden="true" class="tooltip-image">
+          <span class="tooltip-image-info" data-toggle="tooltip" data-placement="auto" data-html="true" data-original-title="<?=$this->transEsc('tooltip_image_html')?>"><i class="fa fa-info-circle"></i></span>
         </div>
       <?php endif; ?>
     </div>

--- a/themes/finna2/templates/search/searchbox.phtml
+++ b/themes/finna2/templates/search/searchbox.phtml
@@ -209,7 +209,7 @@
           $tooltipText = $this->transEsc('tooltip_' . $searchTypes[$module] . '_search_html');
         }
 
-        if(isset($tooltipClass) && isset($tooltipText)) :
+        if (isset($tooltipClass) && isset($tooltipText)):
       ?>
         <button aria-label="<?= $this->transEsc('Search Tips') ?>" class="tooltip-button <?=$tooltipClass?> pull-right hidden-xs" data-toggle="tooltip" data-placement="auto" data-html="true" data-original-title="<?=$tooltipText?>">
           <i class="fa fa-question-circle-big"></i>

--- a/themes/finna2/templates/search/searchbox.phtml
+++ b/themes/finna2/templates/search/searchbox.phtml
@@ -216,9 +216,9 @@
         </button>
       <?php endif; ?>
       <?php if ($module === 'search' && $action === 'home' && !$this->translationEmpty('tooltip_image_html')): ?>
-        <div aria-hidden="true" class="tooltip-image">
-          <span class="tooltip-image-info" data-toggle="tooltip" data-placement="auto" data-html="true" data-original-title="<?=$this->transEsc('tooltip_image_html')?>"><i class="fa fa-info-circle"></i></span>
-        </div>
+        <button aria-hidden="true" class="tooltip-image" data-toggle="tooltip" data-placement="auto" data-html="true" data-original-title="<?=$this->transEsc('tooltip_image_html')?>">
+          <i class="fa fa-info-circle"></i>
+        </button>
       <?php endif; ?>
     </div>
     <div class="clearfix"></div>

--- a/themes/finna2/templates/search/searchbox.phtml
+++ b/themes/finna2/templates/search/searchbox.phtml
@@ -204,9 +204,9 @@
       <?php endif; ?>
       <?php
         $searchTypes = ['search' => 'local', 'primo' => 'pci', 'eds' => 'eds', 'summon' => 'summon'];
-        if (isset($searchTypes[$module]) && !$this->translationEmpty('tooltip_'.$searchTypes[$module].'_search_html')) {
-          $tooltipClass = 'tooltip-search-'.$searchTypes[$module];
-          $tooltipText = $this->transEsc('tooltip_'.$searchTypes[$module].'_search_html');
+        if (isset($searchTypes[$module]) && !$this->translationEmpty('tooltip_' . $searchTypes[$module] . '_search_html')) {
+          $tooltipClass = 'tooltip-search-' . $searchTypes[$module];
+          $tooltipText = $this->transEsc('tooltip_' . $searchTypes[$module] . '_search_html');
         }
 
         if(isset($tooltipClass) && isset($tooltipText)) :


### PR DESCRIPTION
Changes the search tooltip to be a button type element so the aria-describedby is being read properly by the screen readers. Hides the background image tooltip from screenreader and changes it to a button also. Cleaned a funky lookin part of code in searchbox.phtml.