### PR TITLE
HtmlElement empty boolean attribute fix

### DIFF
--- a/module/Finna/src/Finna/View/Helper/Root/HtmlElement.php
+++ b/module/Finna/src/Finna/View/Helper/Root/HtmlElement.php
@@ -119,11 +119,6 @@ class HtmlElement extends \Zend\View\Helper\AbstractHelper
         $escaped = [];
 
         foreach ($array as $key => $value) {
-            if (in_array($key, $this->booleanAttributes)
-                && strlen($value) === 0
-            ) {
-                continue;
-            }
             $escaped[$key]
                 = $value ? $this->escaper->escapeHtmlAttr($value) : $value;
         }
@@ -176,6 +171,12 @@ class HtmlElement extends \Zend\View\Helper\AbstractHelper
         $stringified = [];
 
         foreach ($element as $key => $value) {
+            if (in_array($key, $this->booleanAttributes)
+                && strlen($value) === 0
+            ) {
+                continue;
+            }
+
             $stringified[] = "$key=\"$value\"";
         }
 

--- a/module/Finna/src/Finna/View/Helper/Root/HtmlElement.php
+++ b/module/Finna/src/Finna/View/Helper/Root/HtmlElement.php
@@ -119,6 +119,11 @@ class HtmlElement extends \Zend\View\Helper\AbstractHelper
         $escaped = [];
 
         foreach ($array as $key => $value) {
+            if (in_array($key, $this->booleanAttributes)
+                && strlen($value) === 0
+            ) {
+                continue;
+            }
             $escaped[$key]
                 = $value ? $this->escaper->escapeHtmlAttr($value) : $value;
         }

--- a/module/Finna/src/Finna/View/Helper/Root/HtmlElement.php
+++ b/module/Finna/src/Finna/View/Helper/Root/HtmlElement.php
@@ -196,15 +196,6 @@ class HtmlElement extends \Zend\View\Helper\AbstractHelper
         array $newAttributes
     ) {
         foreach ($newAttributes as $key => $value) {
-            if (in_array($key, $this->booleanAttributes)
-                && strlen($value) === 0
-            ) {
-                if (isset($baseAttributes[$key])) {
-                    unset($baseAttributes[$key]);
-                }
-                continue;
-            }
-
             if ($key !== 'class') {
                 $baseAttributes[$key] = $value;
             } else {


### PR DESCRIPTION
Put the check for empty boolean values to stringifyElement as the old way let empty values through if there were no template set for the html element.