### PR TITLE
[Alli-5765] Feed uppercase name fix

### DIFF
--- a/module/Finna/src/Finna/Controller/FeedContentController.php
+++ b/module/Finna/src/Finna/Controller/FeedContentController.php
@@ -51,7 +51,7 @@ class FeedContentController extends ContentController
     {
         $event = $this->getEvent();
         $routeMatch = $event->getRouteMatch();
-        $page = strtolower($routeMatch->getParam('page'));
+        $page = $routeMatch->getParam('page');
         $element = $routeMatch->getParam('element');
         $feedUrl = $this->params()->fromQuery('feedUrl', false);
         $rssConfig = $this->serviceLocator->get('VuFind\Config')->get(


### PR DESCRIPTION
Fixes the problem where feeds were not working properly on modals or new pages when the feed started with a capital letter