### PR TITLE
Clean favorites list-entry templates

### DIFF
--- a/themes/finna2/templates/RecordDriver/DefaultRecord/list-entry.phtml
+++ b/themes/finna2/templates/RecordDriver/DefaultRecord/list-entry.phtml
@@ -166,28 +166,6 @@
         <?php if ($countNotes > 0 && !$list): ?>
           <strong><?=$this->transEsc('description_count', ['%%count%%' => $countNotes])?></strong>
         <?php endif; ?>
-
-        <div class="result-links hidden">
-          <i class="fa fa-pen"></i> <a href="<?=$this->url('myresearch-edit')?>?id=<?=urlencode($id)?>&amp;source=<?=urlencode($source)?><?php if (null !== $list_id):?>&amp;list_id=<?=urlencode($list_id)?><?php endif; ?>" class="edit tool"><?=$this->transEsc('Edit')?></a><br/>
-            <?php /* Use a different delete URL if we're removing from a specific list or the overall favorites: */
-            $deleteUrl = null === $list_id
-                ? $this->url('myresearch-favorites')
-                : $this->url('userList', ['id' => $list_id]);
-            $deleteUrlGet = $deleteUrl . '?delete=' . urlencode($id) . '&amp;source=' . urlencode($source);
-
-            $dLabel = 'delete-label-' . preg_replace('[\W]', '-', $id);
-            ?>
-          <div class="dropdown">
-            <i class="fa fa-remove"></i> <a class="dropdown-toggle" id="<?=$dLabel ?>" role="button" data-toggle="dropdown" data-target="#" href="<?=$deleteUrlGet ?>">
-                  <?=$this->transEsc('Delete') ?>
-            </a>
-            <ul class="dropdown-menu" role="menu" aria-labelledby="<?=$dLabel ?>">
-              <li><a onClick="$.post('<?=$deleteUrl?>', {'delete':'<?=$this->escapeJs($id) ?>','source':'<?=$this->escapeJs($source) ?>','confirm':true},function(){location.reload(true)})" title="<?=$this->transEsc('confirm_delete_brief')?>"><?=$this->transEsc('confirm_dialog_yes')?></a></li>
-              <li><a><?=$this->transEsc('confirm_dialog_no')?></a></li>
-            </ul>
-          </div>
-            <?=$this->driver->supportsCoinsOpenUrl()?'<span class="Z3988" title="' . $this->escapeHtmlAttr($this->driver->getCoinsOpenUrl()) . '"></span>':''?>
-        </div>
       </div>
       <?php if ($thumbnail && $thumbnailAlignment == 'right'): ?>
         <?=$thumbnail ?>

--- a/themes/finna2/templates/RecordDriver/EDS/list-entry.phtml
+++ b/themes/finna2/templates/RecordDriver/EDS/list-entry.phtml
@@ -150,26 +150,6 @@
         <?php if ($countNotes > 0 && !$list): ?>
           <strong><?=$this->transEsc('Description')?>:</strong> <?=$countNotes?>
         <?php endif; ?>
-        <div class="result-links hidden">
-          <i class="fa fa-pen"></i> <a href="<?=$this->url('myresearch-edit')?>?id=<?=urlencode($id)?>&amp;source=<?=urlencode($source)?><?php if (null !== $list_id):?>&amp;list_id=<?=urlencode($list_id)?><?php endif; ?>" class="edit tool"><?=$this->transEsc('Edit')?></a><br/>
-            <?php /* Use a different delete URL if we're removing from a specific list or the overall favorites: */
-            $deleteUrl = null === $list_id
-                ? $this->url('myresearch-favorites')
-                : $this->url('userList', ['id' => $list_id]);
-            $deleteUrlGet = $deleteUrl . '?delete=' . urlencode($id) . '&amp;source=' . urlencode($source);
-
-            $dLabel = 'delete-label-' . preg_replace('[\W]', '-', $id);
-            ?>
-          <div class="dropdown">
-            <i class="fa fa-remove"></i> <a class="dropdown-toggle" id="<?=$dLabel ?>" role="button" data-toggle="dropdown" data-target="#" href="<?=$deleteUrlGet ?>">
-                  <?=$this->transEsc('Delete') ?>
-            </a>
-            <ul class="dropdown-menu" role="menu" aria-labelledby="<?=$dLabel ?>">
-              <li><a onClick="$.post('<?=$deleteUrl?>', {'delete':'<?=$this->escapeJs($id) ?>','source':'<?=$this->escapeJs($source) ?>','confirm':true},function(){location.reload(true)})" title="<?=$this->transEsc('confirm_delete_brief')?>"><?=$this->transEsc('confirm_dialog_yes')?></a></li>
-              <li><a><?=$this->transEsc('confirm_dialog_no')?></a></li>
-            </ul>
-          </div>
-        </div>
       </div>
     </div>
   </div>

--- a/themes/finna2/templates/RecordDriver/Primo/list-entry.phtml
+++ b/themes/finna2/templates/RecordDriver/Primo/list-entry.phtml
@@ -150,26 +150,6 @@
         <?php if ($countNotes > 0 && !$list): ?>
           <strong><?=$this->transEsc('Description')?>:</strong> <?=$countNotes?>
         <?php endif; ?>
-        <div class="result-links hidden">
-          <i class="fa fa-pen"></i> <a href="<?=$this->url('myresearch-edit')?>?id=<?=urlencode($id)?>&amp;source=<?=urlencode($source)?><?php if (null !== $list_id):?>&amp;list_id=<?=urlencode($list_id)?><?php endif; ?>" class="edit tool"><?=$this->transEsc('Edit')?></a><br/>
-            <?php /* Use a different delete URL if we're removing from a specific list or the overall favorites: */
-            $deleteUrl = null === $list_id
-                ? $this->url('myresearch-favorites')
-                : $this->url('userList', ['id' => $list_id]);
-            $deleteUrlGet = $deleteUrl . '?delete=' . urlencode($id) . '&amp;source=' . urlencode($source);
-
-            $dLabel = 'delete-label-' . preg_replace('[\W]', '-', $id);
-            ?>
-          <div class="dropdown">
-            <i class="fa fa-remove"></i> <a class="dropdown-toggle" id="<?=$dLabel ?>" role="button" data-toggle="dropdown" data-target="#" href="<?=$deleteUrlGet ?>">
-                  <?=$this->transEsc('Delete') ?>
-            </a>
-            <ul class="dropdown-menu" role="menu" aria-labelledby="<?=$dLabel ?>">
-              <li><a onClick="$.post('<?=$deleteUrl?>', {'delete':'<?=$this->escapeJs($id) ?>','source':'<?=$this->escapeJs($source) ?>','confirm':true},function(){location.reload(true)})" title="<?=$this->transEsc('confirm_delete_brief')?>"><?=$this->transEsc('confirm_dialog_yes')?></a></li>
-              <li><a><?=$this->transEsc('confirm_dialog_no')?></a></li>
-            </ul>
-          </div>
-        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Removes parts of list-entry.phtml as they are obsolete, caused an error and the other button wasn't working anymore.