### PR TITLE
Fallback for large images in paginator

### DIFF
--- a/themes/finna2/templates/RecordDriver/DefaultRecord/record-image-paginator.phtml
+++ b/themes/finna2/templates/RecordDriver/DefaultRecord/record-image-paginator.phtml
@@ -16,7 +16,7 @@
       $obj = [
         'small' => $img['urls']['small'],
         'medium' => $img['urls']['medium'],
-        'largest' => $enableImageZoom && $originalImage !== false ? $originalImage : $img['urls']['large'],
+        'largest' => $enableImageZoom && $originalImage !== false ? $originalImage : $img['urls']['large'] ?? $img['urls']['medium'],
         'index' => $ind++,
         'alt' => $desc,
         'description' => $img['description'],


### PR DESCRIPTION
Large image is optional so lets use coalescing selection to use medium if large is not set