### PR TITLE
[ALLI-6012] Set max width limit to popup trigger

### DIFF
--- a/themes/finna2/less/finna/record.less
+++ b/themes/finna2/less/finna/record.less
@@ -172,6 +172,7 @@ a.authority {
         position: relative;
         display: inline-block;
         height: 100%;
+        max-width: 100%;
         img {
           max-height: 600px;
         }


### PR DESCRIPTION
Fixes a problem where image would overlap other html elements in IE 11