### PR TITLE
[ALLI-6076] Menu library cards list adjustment

### DIFF
--- a/themes/finna2/less/finna/navigation.less
+++ b/themes/finna2/less/finna/navigation.less
@@ -462,6 +462,11 @@
   .box-shadow(0 6px 12px rgba(0, 0, 0, .275));
 
   .card-selection {
+    @media (max-width: @screen-sm-max) {
+      overflow-y: scroll;
+      overflow-x: hidden;
+      max-height: 200px;
+    }
     p {
       padding-left: 15px;
       margin-bottom: 0px;


### PR DESCRIPTION
Now applies overflow scroll to library cards menu on media width <= 991px if list exceeds over 200px.