### PR TITLE
[ALLI-6116] Remove <head> from description

### DIFF
--- a/module/Finna/src/Finna/AjaxHandler/GetDescription.php
+++ b/module/Finna/src/Finna/AjaxHandler/GetDescription.php
@@ -146,6 +146,12 @@ class GetDescription extends \VuFind\AjaxHandler\AbstractBase
                     if ('UTF-8' !== $encoding) {
                         $content = utf8_encode($content);
                     }
+                    // Remove head tag, so no titles will be printed.
+                    $content = preg_replace(
+                        '/<head[^>]*>(.*?)<\/head>/s',
+                        '',
+                        $content
+                    );
 
                     $content = preg_replace('/.*<.B>(.*)/', '\1', $content);
                     $content = strip_tags($content);
@@ -154,7 +160,6 @@ class GetDescription extends \VuFind\AjaxHandler\AbstractBase
                     $content = preg_replace(
                         '/(\r\n|\n|\r){3,}/', '<br><br>', $content
                     );
-
                     file_put_contents($localFile, $content);
 
                     return $this->formatResponse(['html' => $content]);

--- a/module/Finna/src/Finna/AjaxHandler/GetDescription.php
+++ b/module/Finna/src/Finna/AjaxHandler/GetDescription.php
@@ -160,6 +160,7 @@ class GetDescription extends \VuFind\AjaxHandler\AbstractBase
                     $content = preg_replace(
                         '/(\r\n|\n|\r){3,}/', '<br><br>', $content
                     );
+
                     file_put_contents($localFile, $content);
 
                     return $this->formatResponse(['html' => $content]);


### PR DESCRIPTION
Removes the <head> section from html response as it might contain some tags which are not wanted in the description field.