### PR TITLE
Remove unused call to AuthorityHelper facet formatting from SearchController.

### DIFF
--- a/module/Finna/src/Finna/Controller/SearchController.php
+++ b/module/Finna/src/Finna/Controller/SearchController.php
@@ -626,23 +626,4 @@ class SearchController extends \VuFind\Controller\SearchController
 
         return $view;
     }
-
-    /**
-     * Returns a list of all items associated with one facet for the lightbox
-     *
-     * Parameters:
-     * facet        The facet to retrieve
-     * searchParams Facet search params from $results->getUrlQuery()->getParams()
-     *
-     * @return mixed
-     */
-    public function facetListAction()
-    {
-        $view = parent::facetListAction();
-        $facetHelper = $this->serviceLocator->get(
-            \Finna\Search\Solr\AuthorityHelper::class
-        );
-        $view->data = $facetHelper->formatFacets($view->facet, $view->data);
-        return $view;
-    }
 }


### PR DESCRIPTION
Formatting is performed in Solr/Params and SideFacets.