### PR TITLE
[ALLI-6134] Blacklist for hiding certain file formats from LIDO records

### DIFF
--- a/local/config/finna/config.ini.sample
+++ b/local/config/finna/config.ini.sample
@@ -677,7 +677,7 @@ lastname = SHIB_sn
 coverimages     = NatLibFi,OpenLibrary
 
 ; List of blacklisted formats to prevent from showing in LIDO records image section
-; lidoBlackList = 'tif,tiff,3d-pdf,3d model,glb,obj'
+; lidoFileFormatBlackList = 'tif,tiff,3d-pdf,3d model,glb,obj'
 
 ; This setting controls the image to display when no book cover is available.
 ; The path is relative to the base of your theme directory.

--- a/local/config/finna/config.ini.sample
+++ b/local/config/finna/config.ini.sample
@@ -677,7 +677,7 @@ lastname = SHIB_sn
 coverimages     = NatLibFi,OpenLibrary
 
 ; List of blacklisted formats to prevent from showing in LIDO records image section
-; lidoFileFormatBlackList = 'tif,tiff,3d-pdf,3d model,glb,obj'
+; lidoFileFormatBlackList = 'tif,tiff,3d-pdf,3d model,glb,obj,gltf'
 
 ; This setting controls the image to display when no book cover is available.
 ; The path is relative to the base of your theme directory.

--- a/local/config/finna/config.ini.sample
+++ b/local/config/finna/config.ini.sample
@@ -676,6 +676,9 @@ lastname = SHIB_sn
 ;coverimages     = Syndetics:MySyndeticsId,Amazon:MyAccessKeyId,Booksite,LibraryThing:MyLibraryThingId,Google,OpenLibrary,Summon:MySerialsSolutionsClientKey,Contentcafe:MyContentCafeID,NatLibFi,BookyFi,BTJ:customerId
 coverimages     = NatLibFi,OpenLibrary
 
+; List of blacklisted formats to prevent from showing in LIDO records image section
+; lidoBlackList = 'tif,tiff,3d-pdf,3d model,glb,obj'
+
 ; This setting controls the image to display when no book cover is available.
 ; The path is relative to the base of your theme directory.
 noCoverAvailableImage = images/noCover2.gif

--- a/module/Finna/src/Finna/RecordDriver/SolrLido.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrLido.php
@@ -232,7 +232,9 @@ class SolrLido extends \VuFind\RecordDriver\SolrDefault
             foreach ($resourceSet->resourceRepresentation as $representation) {
                 $linkResource = $representation->linkResource;
 
-                if (isset($linkResource->attributes()->formatResource)) {
+                if (isset($linkResource->attributes()->formatResource)
+                    && !empty($this->formatBlacklist)
+                ) {
                     $format = trim(
                         (string)$linkResource->attributes()->formatResource
                     );

--- a/module/Finna/src/Finna/RecordDriver/SolrLido.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrLido.php
@@ -63,9 +63,7 @@ class SolrLido extends \VuFind\RecordDriver\SolrDefault
      *
      * @var array
      */
-    protected $formatBlacklist = [
-        '3d-pdf', 'gltf', 'tif'
-    ];
+    protected $formatBlacklist = [];
 
     /**
      * Attach date converter
@@ -77,6 +75,25 @@ class SolrLido extends \VuFind\RecordDriver\SolrDefault
     public function attachDateConverter($dateConverter)
     {
         $this->dateConverter = $dateConverter;
+    }
+
+    /**
+     * Constructor
+     *
+     * @param \Zend\Config\Config $mainConfig     VuFind main configuration (omit for
+     * built-in defaults)
+     * @param \Zend\Config\Config $recordConfig   Record-specific configuration file
+     * (omit to use $mainConfig as $recordConfig)
+     * @param \Zend\Config\Config $searchSettings Search-specific configuration file
+     */
+    public function __construct($mainConfig = null, $recordConfig = null,
+        $searchSettings = null
+    ) {
+        if (isset($mainConfig['Content']['lidoBlackList'])) {
+            $blackList = $mainConfig['Content']['lidoBlackList'];
+            $this->formatBlacklist = explode(',', $blackList);
+        }
+        parent::__construct($mainConfig, $recordConfig, $searchSettings);
     }
 
     /**

--- a/module/Finna/src/Finna/RecordDriver/SolrLido.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrLido.php
@@ -63,7 +63,7 @@ class SolrLido extends \VuFind\RecordDriver\SolrDefault
      *
      * @var array
      */
-    protected $formatBlacklist = [];
+    protected $fileFormatBlackList = [];
 
     /**
      * Attach date converter
@@ -89,9 +89,9 @@ class SolrLido extends \VuFind\RecordDriver\SolrDefault
     public function __construct($mainConfig = null, $recordConfig = null,
         $searchSettings = null
     ) {
-        if (isset($mainConfig['Content']['lidoBlackList'])) {
-            $blackList = $mainConfig['Content']['lidoBlackList'];
-            $this->formatBlacklist = explode(',', $blackList);
+        if (isset($mainConfig['Content']['lidoFileFormatBlackList'])) {
+            $blackList = $mainConfig['Content']['lidoFileFormatBlackList'];
+            $this->fileFormatBlackList = explode(',', $blackList);
         }
         parent::__construct($mainConfig, $recordConfig, $searchSettings);
     }
@@ -232,14 +232,14 @@ class SolrLido extends \VuFind\RecordDriver\SolrDefault
             foreach ($resourceSet->resourceRepresentation as $representation) {
                 $linkResource = $representation->linkResource;
 
-                if (!empty($this->formatBlacklist)
+                if (!empty($this->fileFormatBlackList)
                     && isset($linkResource->attributes()->formatResource)
                 ) {
                     $format = trim(
                         (string)$linkResource->attributes()->formatResource
                     );
                     $formatDisallowed
-                        = in_array(strtolower($format), $this->formatBlacklist);
+                        = in_array(strtolower($format), $this->fileFormatBlackList);
                     if ($formatDisallowed) {
                         continue;
                     }

--- a/module/Finna/src/Finna/RecordDriver/SolrLido.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrLido.php
@@ -60,7 +60,7 @@ class SolrLido extends \VuFind\RecordDriver\SolrDefault
 
     /**
      * Blacklist for undisplayable file formats
-     * 
+     *
      * @var array
      */
     protected $formatBlacklist = [

--- a/module/Finna/src/Finna/RecordDriver/SolrLido.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrLido.php
@@ -262,7 +262,7 @@ class SolrLido extends \VuFind\RecordDriver\SolrDefault
                     $urls[$size] = $url;
                 }
             }
-            // If current set has no good images to show, continue to next one
+            // If current set has no images to show, continue to next one
             if (empty($urls)) {
                 continue;
             }

--- a/module/Finna/src/Finna/RecordDriver/SolrLido.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrLido.php
@@ -59,6 +59,15 @@ class SolrLido extends \VuFind\RecordDriver\SolrDefault
     protected $dateConverter;
 
     /**
+     * Blacklist for undisplayable file formats
+     * 
+     * @var array
+     */
+    protected $formatBlacklist = [
+        '3d-pdf', 'gltf'
+    ];
+
+    /**
      * Attach date converter
      *
      * @param \VuFind\Date\Converter $dateConverter Date Converter
@@ -170,6 +179,15 @@ class SolrLido extends \VuFind\RecordDriver\SolrDefault
         ) as $resourceSet) {
             if (empty($resourceSet->resourceRepresentation->linkResource)) {
                 continue;
+            }
+            $linkResource = $resourceSet->resourceRepresentation
+                ->linkResource;
+
+            if (isset($linkResource->attributes()->formatResource)) {
+                $format = trim((string)$linkResource->attributes()->formatResource);
+                if (in_array(strtolower($format), $this->formatBlacklist)) {
+                    continue;
+                }
             }
 
             // Process rights first since we may need to duplicate them if there

--- a/module/Finna/src/Finna/RecordDriver/SolrLido.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrLido.php
@@ -232,8 +232,8 @@ class SolrLido extends \VuFind\RecordDriver\SolrDefault
             foreach ($resourceSet->resourceRepresentation as $representation) {
                 $linkResource = $representation->linkResource;
 
-                if (isset($linkResource->attributes()->formatResource)
-                    && !empty($this->formatBlacklist)
+                if (!empty($this->formatBlacklist)
+                    && isset($linkResource->attributes()->formatResource)
                 ) {
                     $format = trim(
                         (string)$linkResource->attributes()->formatResource


### PR DESCRIPTION
Some format types creates an empty image in vufind, which is not viewable. Gives a possibility to hide wanted formats in LIDO type records.