### PR TITLE
Properly detect active author-id facet

### DIFF
--- a/module/Finna/src/Finna/Search/Solr/Params.php
+++ b/module/Finna/src/Finna/Search/Solr/Params.php
@@ -685,9 +685,15 @@ class Params extends \VuFind\Search\Solr\Params
      */
     public function hasAuthorIdFilter()
     {
-        foreach ($this->getFilterList() as $key => $val) {
-            if (in_array($key, ['authority_id_label', 'Author'])) {
-                return true;
+        foreach ($this->getFilterList() as $field => $facets) {
+            foreach ($facets as $facet) {
+                if (in_array(
+                    $facet['field'],
+                    $this->authorityHelper->getAuthorIdFacets()
+                )
+                ) {
+                    return true;
+                }
             }
         }
         return false;

--- a/themes/finna2/templates/Recommend/AuthorityRecommend.phtml
+++ b/themes/finna2/templates/Recommend/AuthorityRecommend.phtml
@@ -1,20 +1,20 @@
 <?php
-$data = $this->recommend->getRecommendations();
+if (!$data = $this->recommend->getRecommendations()) {
+  return;
+}
 $activeRecord = $activeInd = null;
-if ($data) {
-  if ($activeId = $this->recommend->getActiveRecommendation()) {
-    foreach ($data as $ind => $rec) {
-        if ($activeId === $rec->getUniqueID()) {
-            $activeInd = $ind;
-            $activeRecord = $rec;
-            break;
-        }
+if ($activeId = $this->recommend->getActiveRecommendation()) {
+  foreach ($data as $ind => $rec) {
+    if ($activeId === $rec->getUniqueID()) {
+      $activeInd = $ind;
+      $activeRecord = $rec;
+      break;
     }
   }
-  if (!$activeRecord) {
-    $activeInd = count($data) ? count($data) - 1 : 0;
-    $activeRecord = $data[$activeInd];
-  }
+}
+if (!$activeRecord) {
+  $activeInd = count($data) ? count($data) - 1 : 0;
+  $activeRecord = $data[$activeInd];
 }
 $results = $this->recommend->getResults();
 $that = $this;

--- a/themes/finna2/templates/Recommend/AuthorityRecommend.phtml
+++ b/themes/finna2/templates/Recommend/AuthorityRecommend.phtml
@@ -1,5 +1,5 @@
 <?php
-if (!$data = $this->recommend->getRecommendations()) {
+if (!($data = $this->recommend->getRecommendations())) {
   return;
 }
 $activeRecord = $activeInd = null;


### PR DESCRIPTION
Korjaa bugin missä normaali Author-fasetti pääsi läpi `hasAuthorIdFilter` tarkistuksesta ja kaatoi `AuthorityRecommend` sivupohjan.

Sivupohjan muutos ei ole pakollinen, mutta selkeyttää koodia keskeyttämällä heti kun suosituksia ei ole saatavissa.