### PR TITLE
Fix loadScripts (jQuery v3 compatibility)

### DIFF
--- a/themes/finna2/js/finna-layout.js
+++ b/themes/finna2/js/finna-layout.js
@@ -685,7 +685,7 @@ finna.layout = (function finnaLayout() {
             .on('load', scriptLoaded)
             .attr('async', 'true')
             .appendTo($('head'))
-            .on('load');
+            .trigger('load');
         }
       }
     } else if (typeof callback === 'function') {


### PR DESCRIPTION
Deprecated function .load() should be replaced by .trigger('load')