### PR TITLE
[ALLI-6325] Add support for using all view types together with Show All in embedded userlist

### DIFF
--- a/module/Finna/src/Finna/AjaxHandler/GetUserList.php
+++ b/module/Finna/src/Finna/AjaxHandler/GetUserList.php
@@ -76,8 +76,10 @@ class GetUserList extends \VuFind\AjaxHandler\AbstractBase
         $offset = $params->fromPost('offset', $params->fromQuery('offset'));
         $indexStart
             = $params->fromPost('indexStart', $params->fromQuery('indexStart'));
+        $view
+            = $params->fromPost('view', $params->fromQuery('view'));
 
-        $html = $this->helper->loadMore($id, $offset, $indexStart);
+        $html = $this->helper->loadMore($id, $offset, $indexStart, $view);
         return $this->formatResponse(compact('html'));
     }
 }

--- a/module/Finna/src/Finna/Form/Form.php
+++ b/module/Finna/src/Finna/Form/Form.php
@@ -610,7 +610,7 @@ class Form extends \VuFind\Form\Form
      */
     protected function getFormElementSettingFields()
     {
-        $fields = parent::getFormSettingFields();
+        $fields = parent::getFormElementSettingFields();
         $fields[] = 'recipient';
 
         return $fields;

--- a/module/Finna/src/Finna/View/Helper/Root/UserListEmbed.php
+++ b/module/Finna/src/Finna/View/Helper/Root/UserListEmbed.php
@@ -156,7 +156,6 @@ class UserListEmbed extends \Zend\View\Helper\AbstractHelper
                 'total' => $total,
                 'showAllLink' =>
                     ($opt['showAllLink'] ?? false)
-                    && $view === 'grid'
                     && $opt['limit'] < $total,
                 'title' =>
                     (isset($opt['title']) && $opt['title'] === false)
@@ -184,7 +183,7 @@ class UserListEmbed extends \Zend\View\Helper\AbstractHelper
      *
      * @return string
      */
-    public function loadMore($id, $offset, $startIndex)
+    public function loadMore($id, $offset, $startIndex, $view = 'grid')
     {
         // These need to differ from Search/Results so that
         // list notes are shown...
@@ -202,7 +201,7 @@ class UserListEmbed extends \Zend\View\Helper\AbstractHelper
         $limit = $resultsTotal - 1;
 
         return $this->__invoke(
-            ['id' => $id, 'page' => 1, 'limit' => $limit, 'view' => 'grid'],
+            ['id' => $id, 'page' => 1, 'limit' => $limit, 'view' => $view],
             $offset,
             $startIndex
         );

--- a/module/Finna/src/Finna/View/Helper/Root/UserListEmbed.php
+++ b/module/Finna/src/Finna/View/Helper/Root/UserListEmbed.php
@@ -177,9 +177,10 @@ class UserListEmbed extends \Zend\View\Helper\AbstractHelper
     /**
      * Returns HTML for a set of user list result items.
      *
-     * @param int $id         List id
-     * @param int $offset     Record offset
-     * @param int $startIndex Result item offset in DOM
+     * @param int    $id         List id
+     * @param int    $offset     Record offset
+     * @param int    $startIndex Result item offset in DOM
+     * @param string $view       Result view type
      *
      * @return string
      */

--- a/themes/finna2/js/finna-image-paginator.js
+++ b/themes/finna2/js/finna-image-paginator.js
@@ -220,7 +220,7 @@ finna.imagePaginator = (function imagePaginator() {
     _.trigger.off('setPaginatorIndex').on('setPaginatorIndex', function setIndex(event, index) {
       _.setPaginatorIndex(index);
     });
-    _.trigger.off('unVeilNextAndPrev').on('unVeilNextAndPrev', function setIndex(event, index) {
+    _.trigger.off('unVeilNextAndPrev').on('unVeilNextAndPrev', function unVeilNextAndPrev(event, index) {
       _.unVeilNextAndPrev(index);
     });
 

--- a/themes/finna2/js/finna-image-paginator.js
+++ b/themes/finna2/js/finna-image-paginator.js
@@ -108,6 +108,7 @@ finna.imagePaginator = (function imagePaginator() {
   function reindexPaginators() {
     $('.image-popup-trigger').each(function reindexPaginator(index) {
       $(this).trigger('setPaginatorIndex', index);
+      $(this).trigger('unVeilNextAndPrev', index);
     });
   }
 
@@ -218,6 +219,9 @@ finna.imagePaginator = (function imagePaginator() {
 
     _.trigger.off('setPaginatorIndex').on('setPaginatorIndex', function setIndex(event, index) {
       _.setPaginatorIndex(index);
+    });
+    _.trigger.off('unVeilNextAndPrev').on('unVeilNextAndPrev', function setIndex(event, index) {
+      _.unVeilNextAndPrev(index);
     });
 
     if (!_.isList) {

--- a/themes/finna2/js/finna-layout.js
+++ b/themes/finna2/js/finna-layout.js
@@ -374,8 +374,10 @@ finna.layout = (function finnaLayout() {
     });
   }
 
-  function initCondensedList() {
-    $('.condensed-collapse-toggle').click(function onClickCollapseToggle(event) {
+  function initCondensedList(_holder) {
+    var holder = typeof _holder === 'undefined' ? $(document) : _holder;
+
+    holder.find('.condensed-collapse-toggle').off('click').on('click', function onClickCollapseToggle(event) {
       if ((event.target.nodeName) !== 'A' && (event.target.nodeName) !== 'MARK') {
         $(this).nextAll('.condensed-collapse-data').first().slideToggle(120, 'linear');
         $('.fa-arrow-right', this).toggleClass('fa-arrow-down');
@@ -820,6 +822,7 @@ finna.layout = (function finnaLayout() {
   var my = {
     getOrganisationPageLink: getOrganisationPageLink,
     isTouchDevice: isTouchDevice,
+    initCondensedList: initCondensedList,
     initTruncate: initTruncate,
     initLocationService: initLocationService,
     initHierarchicalFacet: initHierarchicalFacet,

--- a/themes/finna2/js/finna-layout.js
+++ b/themes/finna2/js/finna-layout.js
@@ -377,7 +377,7 @@ finna.layout = (function finnaLayout() {
   function initCondensedList(_holder) {
     var holder = typeof _holder === 'undefined' ? $(document) : _holder;
 
-    holder.find('.condensed-collapse-toggle').off('click').on('click', function onClickCollapseToggle(event) {
+    holder.find('.condensed-collapse-toggle').off('click').click(function onClickCollapseToggle(event) {
       if ((event.target.nodeName) !== 'A' && (event.target.nodeName) !== 'MARK') {
         $(this).nextAll('.condensed-collapse-data').first().slideToggle(120, 'linear');
         $('.fa-arrow-right', this).toggleClass('fa-arrow-down');

--- a/themes/finna2/js/finna-layout.js
+++ b/themes/finna2/js/finna-layout.js
@@ -381,7 +381,7 @@ finna.layout = (function finnaLayout() {
       if ((event.target.nodeName) !== 'A' && (event.target.nodeName) !== 'MARK') {
         $(this).nextAll('.condensed-collapse-data').first().slideToggle(120, 'linear');
         $('.fa-arrow-right', this).toggleClass('fa-arrow-down');
-        var holder = $(this).parent().parent();
+        holder = $(this).parent().parent();
         holder.toggleClass('open');
         if (holder.hasClass('open') && !holder.hasClass('opened')) {
           holder.addClass('opened');

--- a/themes/finna2/js/finna-userlist-embed.js
+++ b/themes/finna2/js/finna-userlist-embed.js
@@ -1,4 +1,4 @@
-/*global VuFind, finna */
+/*global VuFind, finna, checkSaveStatuses */
 finna.userListEmbed = (function userListEmbed() {
   var my = {
     init: function init() {
@@ -9,7 +9,6 @@ finna.userListEmbed = (function userListEmbed() {
         var showMore = embed.find('.show-more');
         var spinner = embed.find('.fa-spinner');
         embed.find('.btn.load-more').click(function initLoadMore() {
-          var resultsContainer = embed.find('.search-grid');
           spinner.removeClass('hide').show();
 
           var btn = $(this);
@@ -20,6 +19,11 @@ finna.userListEmbed = (function userListEmbed() {
           var view = btn.data('view');
 
           btn.hide();
+
+          var resultsContainer = embed.find(
+            view === 'grid' ? '.search-grid' : '.result-view-' + view
+          );
+
           $.getJSON(
             VuFind.path + '/AJAX/JSON?method=getUserList',
             {
@@ -38,6 +42,15 @@ finna.userListEmbed = (function userListEmbed() {
               
               finna.myList.init();
               finna.imagePaginator.reindexPaginators();
+              finna.layout.initCondensedList(resultsContainer);
+              finna.layout.initTruncate();
+              finna.openUrl.initLinks(resultsContainer);
+              finna.itemStatus.initItemStatuses(resultsContainer);
+              finna.itemStatus.initDedupRecordSelection(resultsContainer);
+              finna.record.initRecordVersions(resultsContainer);
+              VuFind.lightbox.bind(resultsContainer);
+              VuFind.cart.init(resultsContainer);
+              checkSaveStatuses(resultsContainer);
             })
             .fail(function onLoadListFail() {
               btn.show();

--- a/themes/finna2/less/finna/search.less
+++ b/themes/finna2/less/finna/search.less
@@ -209,7 +209,7 @@ mark, .highlight {
     margin-top: 2px;
   }
 }
-
+.main.template-dir-content.template-name-content .public-list-embed .result,
 .result {
   .media-left,
   .media-right {

--- a/themes/finna2/templates/Helpers/userlist.phtml
+++ b/themes/finna2/templates/Helpers/userlist.phtml
@@ -19,7 +19,8 @@
       </div>
     </div>
   <?php endif; ?>
-  <div class="public-list-view results result-view-<?=$this->escapeHtmlAttr($this->params->getView())?>">
+  <?php $view = $this->params->getView(); ?>
+  <div class="public-list-view results result-view-<?=$this->escapeHtmlAttr($view)?>">
     <?= $this->partial('search/list-' . $this->view . '.phtml',
     [
       'results' => $this->results,
@@ -39,7 +40,7 @@
              ]
         ); ?>
         </div>
-        <button class="btn btn-outline-primary load-more" aria-label="<?= $this->transEsc('See all')?>" data-id="<?= $this->escapeHtmlAttr($this->id)?>" data-start-index="<?= $this->escapeHtmlAttr($this->indexStart + $limit)?>" data-offset="<?= $this->escapeHtmlAttr($limit + 1)?>"><?= $this->transEsc('See all'); ?></button>
+        <button class="btn btn-outline-primary load-more" aria-label="<?= $this->transEsc('See all')?>" data-id="<?= $this->escapeHtmlAttr($this->id)?>" data-start-index="<?= $this->escapeHtmlAttr($this->indexStart + $limit)?>" data-offset="<?= $this->escapeHtmlAttr($limit + 1)?>" data-view="<?= $this->escapeHtmlAttr($view)?>"><?= $this->transEsc('See all'); ?></button>
         <i class="fa fa-spinner fa-spin hide"></i>
       </div>
     <?php endif; ?>


### PR DESCRIPTION
Aiemmin Näytä kaikki -nappi toimi ainoastaan kun `view` asetus oli `grid`. PR:n myötä kaikkia view-tyyppejä voi käyttää `showAllLink` asetuksen kanssa.

Testaus kaikilla view-tyypeillä:
```
<?= $this->userlistEmbed(['id' => 123, 'limit' => 3, 'view' => 'grid', 'showAllLink' => true]); ?>
<?= $this->userlistEmbed(['id' => 123, 'limit' => 3, 'view' => 'list', 'showAllLink' => true]); ?>
<?= $this->userlistEmbed(['id' => 123, 'limit' => 3, 'view' => 'condensed', 'showAllLink' => true]); ?>
<?= $this->userlistEmbed(['id' => 123, 'limit' => 3, 'view' => 'compact', 'showAllLink' => true]); ?>
```

Näytä kaikki -napin (ajax-)lataamissa tietueissa pitäisi toimia js:llä initoitavat toiminnot (saatavuustiedot, lisää suosikkeihin, ostoskori jne) samalla tavalla kuin sivun latauksen yhteydessä näytettävillä tietueilla.