### PR TITLE
 Add filename to downloaded highres image.

### DIFF
--- a/module/Finna/src/Finna/Controller/CoverController.php
+++ b/module/Finna/src/Finna/Controller/CoverController.php
@@ -104,7 +104,9 @@ class CoverController extends \VuFind\Controller\CoverController
             $highResolution = $images[$index]['highResolution'] ?? [];
             if (isset($highResolution[$size][$format]['url'])) {
                 $url = $highResolution[$size][$format]['url'];
-                $res = $this->loader->loadExternalImage($url, $format);
+                $res = $this->loader->loadExternalImage(
+                    $url, $format, "{$id}_{$index}_{$size}.{$format}"
+                );
                 if (!$res) {
                     $response->setStatusCode(500);
                 }

--- a/module/Finna/src/Finna/Controller/CoverController.php
+++ b/module/Finna/src/Finna/Controller/CoverController.php
@@ -89,7 +89,7 @@ class CoverController extends \VuFind\Controller\CoverController
     public function downloadAction()
     {
         $this->sessionSettings->disableWrite(); // avoid session write timing bug
-        $allowedSizes = ['original', 'master', 'large'];
+        $allowedSizes = ['original', 'master'];
         $params = $this->params();
         $size = $params->fromQuery('size');
         $format = $params->fromQuery('format', 'jpg');
@@ -101,19 +101,10 @@ class CoverController extends \VuFind\Controller\CoverController
             );
             $index = (int)$params->fromQuery('index');
             $images = $driver->getAllImages();
-            $highResolution = $size !== 'large';
-            $url = null;
-            if ($highResolution) {
-                $url
-                    = $images[$index]['highResolution'][$size][$format]['url']
-                    ?? null;
-            } else {
-                $url = $images[$index]['urls'][$size] ?? null;
-            }
-            if ($url) {
-                $res = $this->loader->loadExternalImage(
-                    $url, $format, "{$id}_{$index}_{$size}.{$format}"
-                );
+            $highResolution = $images[$index]['highResolution'] ?? [];
+            if (isset($highResolution[$size][$format]['url'])) {
+                $url = $highResolution[$size][$format]['url'];
+                $res = $this->loader->loadExternalImage($url, $format);
                 if (!$res) {
                     $response->setStatusCode(500);
                 }

--- a/module/Finna/src/Finna/Controller/CoverController.php
+++ b/module/Finna/src/Finna/Controller/CoverController.php
@@ -89,7 +89,7 @@ class CoverController extends \VuFind\Controller\CoverController
     public function downloadAction()
     {
         $this->sessionSettings->disableWrite(); // avoid session write timing bug
-        $allowedSizes = ['original', 'master'];
+        $allowedSizes = ['original', 'master', 'large'];
         $params = $this->params();
         $size = $params->fromQuery('size');
         $format = $params->fromQuery('format', 'jpg');
@@ -101,10 +101,19 @@ class CoverController extends \VuFind\Controller\CoverController
             );
             $index = (int)$params->fromQuery('index');
             $images = $driver->getAllImages();
-            $highResolution = $images[$index]['highResolution'] ?? [];
-            if (isset($highResolution[$size][$format]['url'])) {
-                $url = $highResolution[$size][$format]['url'];
-                $res = $this->loader->loadExternalImage($url, $format);
+            $highResolution = $size !== 'large';
+            $url = null;
+            if ($highResolution) {
+                $url
+                    = $images[$index]['highResolution'][$size][$format]['url']
+                    ?? null;
+            } else {
+                $url = $images[$index]['urls'][$size] ?? null;
+            }
+            if ($url) {
+                $res = $this->loader->loadExternalImage(
+                    $url, $format, "{$id}_{$index}_{$size}.{$format}"
+                );
                 if (!$res) {
                     $response->setStatusCode(500);
                 }

--- a/module/Finna/src/Finna/Cover/Loader.php
+++ b/module/Finna/src/Finna/Cover/Loader.php
@@ -175,12 +175,13 @@ class Loader extends \VuFind\Cover\Loader
      * Loads an external image from provider and sends it to browser
      * in chunks. Used for big image files
      *
-     * @param string $url    to load
-     * @param string $format type of the image to load
+     * @param string $url      to load
+     * @param string $format   type of the image to load
+     * @param string $filename filename for the downloaded image
      *
      * @return bool
      */
-    public function loadExternalImage($url, $format)
+    public function loadExternalImage($url, $format, $filename)
     {
         $contentType = '';
         switch ($format) {
@@ -193,6 +194,7 @@ class Loader extends \VuFind\Cover\Loader
             break;
         }
         header("Content-Type: $contentType");
+        header("Content-disposition: attachment; filename=\"{$filename}\"");
         $client = $this->httpService->createClient(
             $url, \Zend\Http\Request::METHOD_GET, 300
         );


### PR DESCRIPTION
Korjauksen jälkeen Firefoxin pitäisi tallentaa ladattu korkearesoluutiokuva tiedostopäätteen kanssa.

Testaus:
/Record/museovirasto_testi.36E2ABC878385708266F884817B09903 > tietuekuva 12 > Lataa kuva -valikosta > Korkearesoluutiokuva

Selaimen pitäisi pyytää tallentamaan tiedosto tiedostopäätteen kanssa: `museovirasto_testi.36E2ABC878385708266F884817B09903_11_original.tif`