### PR TITLE
[ALLI-6363] Feedbackforms: fix email subject to use recipient field label

### DIFF
--- a/module/Finna/src/Finna/Form/Form.php
+++ b/module/Finna/src/Finna/Form/Form.php
@@ -221,6 +221,26 @@ class Form extends \VuFind\Form\Form
     }
 
     /**
+     * Return form email message subject.
+     *
+     * @param array $postParams Posted form data
+     *
+     * @return string
+     */
+    public function getEmailSubject($postParams)
+    {
+        if (!$recipient = $this->getRecipientFromFormData($postParams)) {
+            return parent::getEmailSubject($postParams);
+        }
+
+        // Replace posted recipient field value with label
+        $recipientField = $this->getRecipientField($this->formElementConfig);
+        $postParams[$recipientField] = $recipient['name'];
+
+        return parent::getEmailSubject($postParams);
+    }
+
+    /**
      * Resolve email recipient based on posted form data.
      *
      * @param array $postParams Posted form data


### PR DESCRIPTION
Testaus:

Sähköpostin otsikon tulisi olla "Subject (label-1)" kun valikosta on valittu ensimmäinen optio:
```
emailSubject: Subject (%%library%%)
fields:
  - name: library
    recipient: true
    type: select
    options:
      - value: email+1@foo.com
        label: label-1
      - value: email+2@foo.com
        label: label-2
    label: feedback_choose_library