### PR TITLE
Postpone truncating record image license text until the field is visible.

### DIFF
--- a/themes/finna2/js/finna-image-paginator.js
+++ b/themes/finna2/js/finna-image-paginator.js
@@ -559,8 +559,9 @@ finna.imagePaginator = (function imagePaginator() {
       $('.image-details-container').addClass('hidden');
       var details = $('.image-details-container[data-img-index="' + imagePopup.attr('index') + '"]');
       details.removeClass('hidden');
-      var license = details.find('.truncate-field');
+      var license = details.find('.truncate-field, .copyright');
       if (license.length && !license.hasClass('truncated')) {
+        license.addClass("truncate-field");
         license.removeClass('truncate-done');
         finna.layout.initTruncate(details);
       }

--- a/themes/finna2/templates/RecordDriver/DefaultRecord/image-rights.phtml
+++ b/themes/finna2/templates/RecordDriver/DefaultRecord/image-rights.phtml
@@ -22,7 +22,7 @@
       </span> <p class="copyright-meaning"><a target="_blank" <?php if ($hasLink): ?>aria-label="<?=$this->escapeHtmlAttr($this->translate('external_online_link'))?>" href="<?=$this->escapeHtmlAttr($rights['link']) ?>"><?php else: ?> href="<?=$this->url('content-page', ['page' => 'terms'])?>"><?php endif; ?><?=$this->transEsc('usage_meaning') ?></a></p>
     </div>
   <?php endif ?>
-  <div class="copyright truncate-field">
+  <div class="copyright<?=$this->truncateLicense ? ' truncate-field' : ''?>">
     <?php if (isset($rights['description'])): ?>
       <?php foreach ($rights['description'] as $item): ?>
         <p><?=$this->transEsc($item) ?></p>

--- a/themes/finna2/templates/RecordDriver/DefaultRecord/record-image-popup-information.phtml
+++ b/themes/finna2/templates/RecordDriver/DefaultRecord/record-image-popup-information.phtml
@@ -163,7 +163,7 @@
   <?php if ($this->resolver('record/record-organisation-menu.phtml')): ?>
     <?=$this->render('record/record-organisation-menu.phtml') ?>
   <?php endif; ?>
-  <?= $this->context($this)->renderInContext('RecordDriver/DefaultRecord/image-rights.phtml', ['rights' => $rights]); ?>
+  <?= $this->context($this)->renderInContext('RecordDriver/DefaultRecord/image-rights.phtml', ['rights' => $rights, 'truncateLicense' => true]); ?>
   <div style="clear: both;"></div>
 </div>
 <?=

--- a/themes/finna2/templates/RecordDriver/DefaultRecord/record-image.phtml
+++ b/themes/finna2/templates/RecordDriver/DefaultRecord/record-image.phtml
@@ -21,7 +21,7 @@
         <?php if ($this->record($this->driver)->allowRecordImageDownload()): ?>
           <?= $this->context($this)->renderInContext('RecordDriver/DefaultRecord/image-download.phtml', ['index' => $ind, 'rights' => $rights, 'image' => $image, 'hiRes' => $image['highResolution'] ?? false]) ?>
         <?php endif; ?>
-      <?= $this->context($this)->renderInContext('RecordDriver/DefaultRecord/image-rights.phtml', ['imageRightsLabel' => $imageRightsLabel, 'rights' => $rights]); ?>
+      <?= $this->context($this)->renderInContext('RecordDriver/DefaultRecord/image-rights.phtml', ['imageRightsLabel' => $imageRightsLabel, 'rights' => $rights, 'truncateLicense' => $ind === 0]); ?>
       </div>
       <?php $ind++; ?>
     <?php endforeach; ?>


### PR DESCRIPTION
Nykyisin tietuesivun kuvien lisenssikentille ajetaan truncate, mikä on hidasta jos kuvia on tarpeeksi paljon (esim 5000). Tässä PR:ssä lisenssikentän truncate initoidaan tietuesivulla ensimmäiselle näkyvissä olevalle lisenssille, ja muille tarvittaessa kun kuvan thumbnailia on klikattu. 

Testaus:
- tietuesivu
- imagePopup
- .... missä muualla ?
