### PR TITLE
Fix check for id-search to work with advanced search.

### DIFF
--- a/module/Finna/src/Finna/Search/Solr/DeduplicationListener.php
+++ b/module/Finna/src/Finna/Search/Solr/DeduplicationListener.php
@@ -27,9 +27,9 @@
  */
 namespace Finna\Search\Solr;
 
-use VuFindSearch\Query\QueryGroup;
-
 use Laminas\EventManager\EventInterface;
+
+use VuFindSearch\Query\QueryGroup;
 
 /**
  * Solr merged record handling listener.

--- a/module/Finna/src/Finna/Search/Solr/DeduplicationListener.php
+++ b/module/Finna/src/Finna/Search/Solr/DeduplicationListener.php
@@ -27,6 +27,8 @@
  */
 namespace Finna\Search\Solr;
 
+use VuFindSearch\Query\QueryGroup;
+
 use Laminas\EventManager\EventInterface;
 
 /**
@@ -54,7 +56,9 @@ class DeduplicationListener extends \VuFind\Search\Solr\DeduplicationListener
         if ($backend === $this->backend) {
             // Check that we're not doing a known record search
             $query = $event->getParam('query');
-            if ($query && $query->getHandler() === 'id') {
+            if ($query && !($query instanceof QueryGroup)
+                && $query->getHandler() === 'id'
+            ) {
                 return $event;
             }
             $params = $event->getParam('params');

--- a/module/Finna/src/Finna/Search/Solr/SolrExtensionsListener.php
+++ b/module/Finna/src/Finna/Search/Solr/SolrExtensionsListener.php
@@ -33,6 +33,7 @@ use Laminas\EventManager\EventInterface;
 use Laminas\EventManager\SharedEventManagerInterface;
 use Laminas\ServiceManager\ServiceLocatorInterface;
 use VuFindSearch\Backend\BackendInterface;
+use VuFindSearch\Query\QueryGroup;
 
 /**
  * Finna Solr extensions listener.
@@ -264,7 +265,10 @@ class SolrExtensionsListener
             if ($params) {
                 // Check that search is not for a known record id
                 $query = $event->getParam('query');
-                if (!$query || $query->getHandler() !== 'id') {
+                if (!$query
+                    || $query instanceof QueryGroup
+                    || $query->getHandler() !== 'id'
+                ) {
                     $params->add('fq', '-hidden_component_boolean:true');
                 }
             }


### PR DESCRIPTION
Continued from: https://github.com/NatLibFi/NDL-VuFind2/commit/fc245c2f5a062b9222346ab2113721b68407f309

Make sure that the query is not a `QueryGroup` before calling `getHandler`.