### PR TITLE
Fix searchresults holdings collapse

### DIFF
--- a/themes/finna2/templates/ajax/status-full.phtml
+++ b/themes/finna2/templates/ajax/status-full.phtml
@@ -327,7 +327,7 @@ if (!$disableTitleHold
 finna.layout.initTruncate($('.holding-details'));
 VuFind.lightbox.bind($('.holding-details'));
 
-var item = $('.hiddenId[value="{$id}"]').closest('.record-container');
+var item = $('.hiddenId[value="{$this->escapeHtmlAttr($id)}"]').closest('.record-container');
 item.find('.holdings-container.collapsible > .header').click(function onClickCollapsibleHeader() {
   $(this).next('.holdings').toggleClass('collapsed');
   $(this).find('.fa.arrow:first.right')

--- a/themes/finna2/templates/ajax/status-full.phtml
+++ b/themes/finna2/templates/ajax/status-full.phtml
@@ -326,6 +326,17 @@ if (!$disableTitleHold
   $js = <<<JS
 finna.layout.initTruncate($('.holding-details'));
 VuFind.lightbox.bind($('.holding-details'));
+
+var item = $('.hiddenId[value="{$id}"]').closest('.record-container');
+item.find('.holdings-container.collapsible > .header').click(function onClickCollapsibleHeader() {
+  $(this).next('.holdings').toggleClass('collapsed');
+  $(this).find('.fa.arrow:first.right')
+    .removeClass('fa-arrow-down fa-arrow-right')
+    .addClass('fa-arrow-' + ($(this).next('.holdings').hasClass('collapsed') ? 'right' : 'down'));
+  $(this).find('.fa.arrow:first.down')
+    .removeClass('fa-arrow-down fa-arrow-up')
+    .addClass('fa-arrow-' + ($(this).next('.holdings').hasClass('collapsed') ? 'down' : 'up'));
+});
 JS;
   echo $this->inlineScript(\Laminas\View\Helper\HeadScript::SCRIPT, $js, 'SET');
 ?>


### PR DESCRIPTION
Functionality restored from:
https://github.com/NatLibFi/NDL-VuFind2/commit/c84d5d73f9570ad7d6922364ef0e6d1e20ae3bfd#diff-cf9ded2cadb9d8a2cc9ff27421a7d1c6L60