### PR TITLE
R2: RemsService updates 

### DIFF
--- a/local/config/finna/Rems.ini.sample
+++ b/local/config/finna/Rems.ini.sample
@@ -14,6 +14,7 @@ resourceItem =
 
 
 [RegistrationForm]
+id =
 
 ; REMS registration form field id's
 field[firstname] = firstname

--- a/local/config/finna/Rems.ini.sample
+++ b/local/config/finna/Rems.ini.sample
@@ -12,6 +12,10 @@ catalogItem =
 ; Resource item id
 resourceItem =
 
+; Session maximum age in minutes (R2 index closes the session)
+sessionMaxAge = 480
+; Show warning X minutes before session expires.
+sessionExpirationWarning = 15
 
 [RegistrationForm]
 id =

--- a/module/Finna/src/Finna/Service/RemsService.php
+++ b/module/Finna/src/Finna/Service/RemsService.php
@@ -501,7 +501,7 @@ class RemsService implements
      *
      * @param bool $requireRegistration Require the user to be registered to REMS
      * during the session?
-     * 
+     *
      * @return void
      */
     public function closeOpenApplications($requireRegistration = true)

--- a/module/Finna/src/Finna/Service/RemsService.php
+++ b/module/Finna/src/Finna/Service/RemsService.php
@@ -428,6 +428,9 @@ class RemsService implements
         $this->session->{RemsService::SESSION_USAGE_PURPOSE}
             = $formParams['usage_purpose_text'];
 
+        // Refresh permission session variables
+        $this->getAccessPermission(true);
+
         return true;
     }
 

--- a/module/Finna/src/Finna/Service/RemsService.php
+++ b/module/Finna/src/Finna/Service/RemsService.php
@@ -222,9 +222,11 @@ class RemsService implements
             return null;
         }
 
-        if ($registeredTime
-            = ($this->session->{RemsService::SESSION_USER_REGISTERED_TIME} ?: null)
-        ) {
+        $registeredTime
+            = ($this->session->{RemsService::SESSION_USER_REGISTERED_TIME}
+            ?? null);
+
+        if ($registeredTime) {
             $sessionAge = (time() - $registeredTime) / 60;
             if (($sessionAge + $sessionWarning) > $sessionMaxAge) {
                 $interval = date_interval_create_from_date_string(
@@ -407,9 +409,12 @@ class RemsService implements
         $params =  [
             'application-id' => $applicationId,
             'field-values' =>  [
-                ['form' => $formId, 'field' => $fieldIds['firstname'], 'value' => $firstname],
-                ['form' => $formId, 'field' => $fieldIds['lastname'], 'value' => $lastname],
-                ['form' => $formId, 'field' => $fieldIds['email'], 'value' => $email],
+                ['form' => $formId,
+                 'field' => $fieldIds['firstname'], 'value' => $firstname],
+                ['form' => $formId,
+                 'field' => $fieldIds['lastname'], 'value' => $lastname],
+                ['form' => $formId,
+                 'field' => $fieldIds['email'], 'value' => $email],
                 ['form' => $formId, 'field' => $fieldIds['usage_purpose'],
                  'value' => $formParams['usage_purpose']],
                 ['form' => $formId, 'field' => $fieldIds['age'],

--- a/module/Finna/src/Finna/Service/RemsService.php
+++ b/module/Finna/src/Finna/Service/RemsService.php
@@ -285,7 +285,7 @@ class RemsService implements
             $usagePurpose = null;
 
             $fieldIds = $this->config->RegistrationForm->field;
-            $fields = $application['application/form']['form/fields'];
+            $fields = $application['application/forms'][0]['form/fields'];
             foreach ($fields as $field) {
                 if ($field['field/id'] === $fieldIds['usage_purpose']) {
                     $usagePurpose = $field['field/value'];
@@ -349,21 +349,22 @@ class RemsService implements
         $applicationId = $response['application-id'];
 
         $fieldIds = $this->config->RegistrationForm->field;
+        $formId = (int)$this->config->RegistrationForm->id;
 
         // 3. Save draft
         $params =  [
             'application-id' => $applicationId,
             'field-values' =>  [
-                ['field' => $fieldIds['firstname'], 'value' => $firstname],
-                ['field' => $fieldIds['lastname'], 'value' => $lastname],
-                ['field' => $fieldIds['email'], 'value' => $email],
-                ['field' => $fieldIds['usage_purpose'],
+                ['form' => $formId, 'field' => $fieldIds['firstname'], 'value' => $firstname],
+                ['form' => $formId, 'field' => $fieldIds['lastname'], 'value' => $lastname],
+                ['form' => $formId, 'field' => $fieldIds['email'], 'value' => $email],
+                ['form' => $formId, 'field' => $fieldIds['usage_purpose'],
                  'value' => $formParams['usage_purpose']],
-                ['field' => $fieldIds['age'],
+                ['form' => $formId, 'field' => $fieldIds['age'],
                  'value' => $formParams['age'] ?? null],
-                ['field' => $fieldIds['license'],
+                ['form' => $formId, 'field' => $fieldIds['license'],
                  'value' => $formParams['license'] ?? null],
-                ['field' => $fieldIds['user_id'],
+                ['form' => $formId, 'field' => $fieldIds['user_id'],
                  'value' => $this->userIdentityNumber]
             ]
         ];
@@ -531,7 +532,7 @@ class RemsService implements
     protected function getApplication($id, $throw = false)
     {
         return $this->sendRequest(
-            "applications/$id", [], 'GET', RemsService::TYPE_USER,
+            "applications/$id/raw", [], 'GET', RemsService::TYPE_APPROVER,
             null, false, $throw
         );
     }

--- a/module/Finna/src/Finna/Service/RemsService.php
+++ b/module/Finna/src/Finna/Service/RemsService.php
@@ -548,6 +548,7 @@ class RemsService implements
         $this->authenticated = true;
         // Close applications without requiring the caller to be registered.
         $this->closeOpenApplications(false);
+        $this->userId = null;
     }
 
     /**

--- a/module/Finna/src/Finna/Service/RemsService.php
+++ b/module/Finna/src/Finna/Service/RemsService.php
@@ -620,6 +620,10 @@ class RemsService implements
             return [];
         }
 
+        if (empty($result)) {
+            return [];
+        }
+
         if ($statuses) {
             $statuses = array_map(
                 function ($status) {

--- a/module/Finna/src/Finna/Service/RemsService.php
+++ b/module/Finna/src/Finna/Service/RemsService.php
@@ -190,23 +190,6 @@ class RemsService implements
     }
 
     /**
-     * Is user session expired?
-     *
-     * @param bool $ignoreCache Ignore cache?
-     *
-     * @return bool
-     */
-    public function isSessionExpired($ignoreCache = false)
-    {
-        try {
-            return $this->getAccessPermission($ignoreCache)
-                === RemsService::STATUS_EXPIRED;
-        } catch (\Exception $e) {
-            return false;
-        }
-    }
-
-    /**
      * Return timestamp when REMS session expires if the expiration time
      * is within the configured threshold.
      *

--- a/module/Finna/src/Finna/Service/RemsService.php
+++ b/module/Finna/src/Finna/Service/RemsService.php
@@ -355,9 +355,12 @@ class RemsService implements
         $params =  [
             'application-id' => $applicationId,
             'field-values' =>  [
-                ['form' => $formId, 'field' => $fieldIds['firstname'], 'value' => $firstname],
-                ['form' => $formId, 'field' => $fieldIds['lastname'], 'value' => $lastname],
-                ['form' => $formId, 'field' => $fieldIds['email'], 'value' => $email],
+                ['form' => $formId,
+                 'field' => $fieldIds['firstname'], 'value' => $firstname],
+                ['form' => $formId,
+                 'field' => $fieldIds['lastname'], 'value' => $lastname],
+                ['form' => $formId,
+                 'field' => $fieldIds['email'], 'value' => $email],
                 ['form' => $formId, 'field' => $fieldIds['usage_purpose'],
                  'value' => $formParams['usage_purpose']],
                 ['form' => $formId, 'field' => $fieldIds['age'],

--- a/module/Finna/src/Finna/Service/RemsService.php
+++ b/module/Finna/src/Finna/Service/RemsService.php
@@ -479,6 +479,8 @@ class RemsService implements
                 = 'R2_register_form_usage_'
                   . $entitlementApplication['usagePurpose'];
         } else {
+            $this->session->{self::SESSION_USER_REGISTERED_TIME} = null;
+            $this->session->{self::SESSION_IS_REMS_REGISTERED} = null;
             return null;
         }
 
@@ -571,6 +573,10 @@ class RemsService implements
             break;
         default:
             $status = self::STATUS_CLOSED;
+        }
+        if ($status !== self::STATUS_APPROVED) {
+            $this->session->{self::SESSION_USER_REGISTERED_TIME} = null;
+            $this->session->{self::SESSION_IS_REMS_REGISTERED} = null;
         }
         $this->session->{self::SESSION_ACCESS_STATUS} = $status;
     }

--- a/module/Finna/src/Finna/Service/RemsService.php
+++ b/module/Finna/src/Finna/Service/RemsService.php
@@ -209,7 +209,7 @@ class RemsService implements
      * Return timestamp when REMS session expires if the expiration time
      * is within the configured threshold.
      *
-     * @return null|int
+     * @return null|DateTime
      */
     public function getSessionExpirationTime()
     {
@@ -247,6 +247,9 @@ class RemsService implements
      */
     public function isSearchLimitExceeded($type = 'daily')
     {
+        if (!$this->validateSearchLimit($type)) {
+            return false;
+        }
         $res = $this->session->{
             $type === 'daily'
                 ? self::SESSION_DAILY_LIMIT_EXCEEDED
@@ -606,6 +609,12 @@ class RemsService implements
      */
     public function setSearchLimitExceededFromConnector($type, $exceeded)
     {
+        if (!$this->validateSearchLimit($type)) {
+            $this->error(
+                "Error setting search limit exceeded with type $type"
+            );
+            return;
+        }
         if ($type === 'daily') {
             $this->session->{self::SESSION_DAILY_LIMIT_EXCEEDED} = $exceeded;
         } elseif ($type === 'monthly') {
@@ -912,5 +921,17 @@ class RemsService implements
         ];
 
         return $statusMap[$remsStatus] ?? 'unknown';
+    }
+
+    /**
+     * Validate search limit type.
+     *
+     * @param string $limit Limit
+     *
+     * @return bol
+     */
+    protected function validateSearchLimit($limit)
+    {
+        return in_array($limit, ['daily', 'monthly']);
     }
 }

--- a/module/Finna/src/Finna/Service/RemsServiceFactory.php
+++ b/module/Finna/src/Finna/Service/RemsServiceFactory.php
@@ -28,6 +28,7 @@
 namespace Finna\Service;
 
 use Interop\Container\ContainerInterface;
+use Laminas\EventManager\EventManager;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 
 /**
@@ -80,7 +81,8 @@ class RemsServiceFactory implements FactoryInterface
             $sessionContainer,
             $shibbolethSessionContainer['identity_number'] ?? null,
             $user ? $user->username : null,
-            $auth->isGranted('access.R2Authenticated')
+            $auth->isGranted('access.R2Authenticated'),
+            new EventManager($container->get('SharedEventManager'))
         );
     }
 }


### PR DESCRIPTION
Muutoksia RemsServiceen:
- REMSin päivittyneen APIn vaatimat muutokset.
- REMS-session aikakatkaisun hallinta: serviceltä voi kysyä pitääkö näyttää ennakkovaroitus katkaisusta.
- Serviceltä voi kysyä onko R2-indeksin hakujen maksimimäärä ylittynyt.
- ShibbolethLogoutNotifikaatiota varten seuraavat:
     - Käyttäjän rekisteröinnin jälkeen triggeroidaan eventti.
     - closeOpenApplication($userId), joka asettaa sendRequestin vaatimat `userId` ja `authenticated` muuttujat. Tätä kutsutaan vain ShibbolethLogoutNotificationControllerissa. Muualla käytetään edelleen closeOpenApplicationia milloin muuttujat haetaan sessiosta.
