### PR TITLE
Record image: simplify handling of record source.

### DIFF
--- a/module/Finna/src/Finna/View/Helper/Root/RecordImage.php
+++ b/module/Finna/src/Finna/View/Helper/Root/RecordImage.php
@@ -124,13 +124,14 @@ class RecordImage extends \Laminas\View\Helper\AbstractHelper
         $urlHelper = $this->getView()->plugin('url');
         $imageParams = $images[$index]['urls']['large']
             ?? $images[$index]['urls']['medium'];
-        $imageParams = array_merge($imageParams, $params);
-
+        $imageParams = array_merge(
+            $imageParams, $params,
+            ['source' => $this->record->getDriver()->getSourceIdentifier()]
+        );
         $url = $urlHelper(
             'cover-show', [], $canonical ? ['force_canonical' => true] : []
         ) . '?' . http_build_query($imageParams);
         $pdf = $images[$index]['pdf'] ?? false;
-
         return compact('url', 'pdf');
     }
 
@@ -180,7 +181,10 @@ class RecordImage extends \Laminas\View\Helper\AbstractHelper
         $urlHelper = $this->getView()->plugin('url');
 
         $imageParams = $images[$index]['urls']['master'];
-        $imageParams = array_merge($imageParams, $params);
+        $imageParams = array_merge(
+            $imageParams, $params,
+            ['source' => $this->record->getDriver()->getSourceIdentifier()]
+        );
 
         $url = $urlHelper(
             'cover-show', [], $canonical ? ['force_canonical' => true] : []
@@ -214,12 +218,11 @@ class RecordImage extends \Laminas\View\Helper\AbstractHelper
      *                           are found
      * @param bool   $includePdf Whether to include first PDF file when no image
      *                           links are found
-     * @param string $source     Record source
      *
      * @return array
      */
     public function getAllImagesAsCoverLinks($language, $params = [],
-        $thumbnails = true, $includePdf = true, $source = DEFAULT_SEARCH_BACKEND
+        $thumbnails = true, $includePdf = true
     ) {
         $imageParams = [
             'small' => [],
@@ -247,7 +250,8 @@ class RecordImage extends \Laminas\View\Helper\AbstractHelper
                         array_merge(
                             $params,
                             $imageParams[$imageType],
-                            ['source' => $source]
+                            ['source' =>
+                             $this->record->getDriver()->getSourceIdentifier()]
                         )
                     );
             }
@@ -262,7 +266,6 @@ class RecordImage extends \Laminas\View\Helper\AbstractHelper
      * @param array  $params      Optional array of image parameters as
      *                            an associative array of parameter =>
      *                            value pairs: - w  Width - h  Height
-     * @param string $source      Record source
      * @param array  $extraParams Optional extra parameters:
      *                            - boolean $disableModal
      *                            Whether to disable FinnaPopup modal
@@ -274,7 +277,7 @@ class RecordImage extends \Laminas\View\Helper\AbstractHelper
      * @return string
      */
     public function render(
-        $type = 'list', $params = null, $source = 'Solr', $extraParams = []
+        $type = 'list', $params = null, $extraParams = []
     ) {
         $disableModal = $extraParams['disableModal'] ?? false;
         $imageRightsLabel = $extraParams['imageRightsLabel'] ?? 'Image Rights';
@@ -282,7 +285,7 @@ class RecordImage extends \Laminas\View\Helper\AbstractHelper
 
         $view = $this->getView();
         $images = $this->getAllImagesAsCoverLinks(
-            $view->layout()->userLang, $params, true, true, $source
+            $view->layout()->userLang, $params, true, true
         );
         if ($images && $view->layout()->templateDir === 'combined') {
             // Limit combined results to a single image

--- a/module/Finna/src/Finna/View/Helper/Root/RecordImage.php
+++ b/module/Finna/src/Finna/View/Helper/Root/RecordImage.php
@@ -44,12 +44,12 @@ class RecordImage extends \Laminas\View\Helper\AbstractHelper
     /**
      * Record view helper
      *
-     * @var Record
+     * @var Laminas\View\Helper\Record
      */
     protected $record;
 
     /**
-     * Assign record image URLs to the view and return the view helper.
+     * Assign record image URLs to the view and return header view helper.
      *
      * @param \Finna\View\Helper\Root\Record $record Record helper.
      *

--- a/module/Finna/src/Finna/View/Helper/Root/RecordImage.php
+++ b/module/Finna/src/Finna/View/Helper/Root/RecordImage.php
@@ -304,9 +304,8 @@ class RecordImage extends \Laminas\View\Helper\AbstractHelper
      *
      * @return string
      */
-    public function renderImage(
-        $type = 'list', $params = null, $extraParams = []
-    ) {
+    public function renderImage($type = 'list', $params = null, $extraParams = [])
+    {
         $disableModal = $extraParams['disableModal'] ?? false;
         $imageRightsLabel = $extraParams['imageRightsLabel'] ?? 'Image Rights';
         $numOfImages = $extraParams['numOfImages'] ?? null;

--- a/module/Finna/src/Finna/View/Helper/Root/RecordImage.php
+++ b/module/Finna/src/Finna/View/Helper/Root/RecordImage.php
@@ -284,28 +284,7 @@ class RecordImage extends \Laminas\View\Helper\AbstractHelper
     public function render(
         $type = 'list', $params = null, $source = 'Solr', $extraParams = []
     ) {
-        $disableModal = $extraParams['disableModal'] ?? false;
-        $imageRightsLabel = $extraParams['imageRightsLabel'] ?? 'Image Rights';
-        $numOfImages = $extraParams['numOfImages'] ?? null;
-
-        $view = $this->getView();
-        $images = $this->getAllImagesAsCoverLinks(
-            $view->layout()->userLang, $params, true, true, $source
-        );
-        if ($images && $view->layout()->templateDir === 'combined') {
-            // Limit combined results to a single image
-            $images = [$images[0]];
-        }
-
-        $context = [
-            'type' => $type,
-            'images' => $images,
-            'disableModal' => $disableModal,
-            'imageRightsLabel' => $imageRightsLabel,
-            'numOfImages' => $numOfImages
-        ];
-
-        return $this->record->renderTemplate('record-image.phtml', $context);
+        return $this->renderImage($type, $params, $extraParams);
     }
 
     /**
@@ -328,9 +307,28 @@ class RecordImage extends \Laminas\View\Helper\AbstractHelper
     public function renderImage(
         $type = 'list', $params = null, $extraParams = []
     ) {
-        return $this->render(
-            $type, $params, $this->record->getDriver()->getSourceIdentifier(),
-            $extraParams
+        $disableModal = $extraParams['disableModal'] ?? false;
+        $imageRightsLabel = $extraParams['imageRightsLabel'] ?? 'Image Rights';
+        $numOfImages = $extraParams['numOfImages'] ?? null;
+
+        $view = $this->getView();
+        $images = $this->getAllImagesAsCoverLinks(
+            $view->layout()->userLang, $params, true, true,
+            $this->record->getDriver()->getSourceIdentifier()
         );
+        if ($images && $view->layout()->templateDir === 'combined') {
+            // Limit combined results to a single image
+            $images = [$images[0]];
+        }
+
+        $context = [
+            'type' => $type,
+            'images' => $images,
+            'disableModal' => $disableModal,
+            'imageRightsLabel' => $imageRightsLabel,
+            'numOfImages' => $numOfImages
+        ];
+
+        return $this->record->renderTemplate('record-image.phtml', $context);
     }
 }

--- a/themes/finna2/templates/RecordDriver/DefaultRecord/record-image-information.phtml
+++ b/themes/finna2/templates/RecordDriver/DefaultRecord/record-image-information.phtml
@@ -6,7 +6,7 @@
   <div class="cover-wrapper">
     <?php /* Display thumbnail if appropriate: */ ?>
     <?php if ($img): ?>
-      <?=$img->render(
+      <?=$img->renderImage(
         'record', $localSizes,
         ['disableModal' => $this->disableModal ?? null, 'imageRightsLabel' => $this->imageRightsLabel ?? null, 'numOfImages' => $numOfImages ?? null]
       ) ?>

--- a/themes/finna2/templates/RecordDriver/DefaultRecord/record-image-information.phtml
+++ b/themes/finna2/templates/RecordDriver/DefaultRecord/record-image-information.phtml
@@ -7,7 +7,7 @@
     <?php /* Display thumbnail if appropriate: */ ?>
     <?php if ($img): ?>
       <?=$img->render(
-        'record', $localSizes, $this->source ?? null,
+        'record', $localSizes,
         ['disableModal' => $this->disableModal ?? null, 'imageRightsLabel' => $this->imageRightsLabel ?? null, 'numOfImages' => $numOfImages ?? null]
       ) ?>
     <?php endif;?>

--- a/themes/finna2/templates/RecordDriver/SolrAuthDefault/core.phtml
+++ b/themes/finna2/templates/RecordDriver/SolrAuthDefault/core.phtml
@@ -13,7 +13,7 @@
     ob_start(); ?>
     <div class="media-<?=$thumbnailAlignment ?>">
       <?=$this->record($this->driver)->renderTemplate('record-image-information.phtml', [
-        'img' => $img, 'disableModal' => true, 'source' => 'SolrAuth', 'imageRightsLabel' => 'Image Rights Authority',
+        'img' => $img, 'disableModal' => true, 'imageRightsLabel' => 'Image Rights Authority',
         'numOfImages' => ['mobile' => 4, 'normal' => 4]
       ]);?>
       <?php if ($this->resolver('record/record-organisation-menu.phtml')): ?>

--- a/themes/finna2/templates/RecordDriver/SolrAuthDefault/result-condensed.phtml
+++ b/themes/finna2/templates/RecordDriver/SolrAuthDefault/result-condensed.phtml
@@ -7,7 +7,7 @@
   $thumbnailAlignment = $this->record($this->driver)->getThumbnailAlignment('result');
   if ($img):
     ob_start(); ?>
-    <?=$img->render('list', ['small' => ['w' => 100, 'h' => 100], 'medium' => ['w' => 250]], $this->driver->getSourceIdentifier()) ?>
+    <?=$img->render('list', ['small' => ['w' => 100, 'h' => 100], 'medium' => ['w' => 250]]) ?>
     <?php $thumbnail = ob_get_contents(); ?>
   <?php ob_end_clean(); ?>
 <?php endif;?>

--- a/themes/finna2/templates/RecordDriver/SolrAuthDefault/result-condensed.phtml
+++ b/themes/finna2/templates/RecordDriver/SolrAuthDefault/result-condensed.phtml
@@ -7,7 +7,7 @@
   $thumbnailAlignment = $this->record($this->driver)->getThumbnailAlignment('result');
   if ($img):
     ob_start(); ?>
-    <?=$img->render('list', ['small' => ['w' => 100, 'h' => 100], 'medium' => ['w' => 250]]) ?>
+    <?=$img->renderImage('list', ['small' => ['w' => 100, 'h' => 100], 'medium' => ['w' => 250]]) ?>
     <?php $thumbnail = ob_get_contents(); ?>
   <?php ob_end_clean(); ?>
 <?php endif;?>

--- a/themes/finna2/templates/RecordDriver/SolrAuthDefault/result-list.phtml
+++ b/themes/finna2/templates/RecordDriver/SolrAuthDefault/result-list.phtml
@@ -6,7 +6,7 @@
   $thumbnailAlignment = $this->record($this->driver)->getThumbnailAlignment('result');
   $coverDetails = $this->record($this->driver)->getCoverDetails('result-list', 'medium', $this->recordLink()->getUrl($this->driver));
   if ($img) {
-    $thumbnail = $img->render('list', ['small' => ['w' => 100, 'h' => 100], 'medium' => ['w' => 250, 'h' => 250]], $this->driver->getSourceIdentifier());
+    $thumbnail = $img->render('list', ['small' => ['w' => 100, 'h' => 100], 'medium' => ['w' => 250, 'h' => 250]]);
   }
 ?>
 <div class="record-container<?=$this->driver->supportsAjaxStatus()?' ajaxItem ':''?> list-view">

--- a/themes/finna2/templates/RecordDriver/SolrAuthDefault/result-list.phtml
+++ b/themes/finna2/templates/RecordDriver/SolrAuthDefault/result-list.phtml
@@ -6,7 +6,7 @@
   $thumbnailAlignment = $this->record($this->driver)->getThumbnailAlignment('result');
   $coverDetails = $this->record($this->driver)->getCoverDetails('result-list', 'medium', $this->recordLink()->getUrl($this->driver));
   if ($img) {
-    $thumbnail = $img->render('list', ['small' => ['w' => 100, 'h' => 100], 'medium' => ['w' => 250, 'h' => 250]]);
+    $thumbnail = $img->renderImage('list', ['small' => ['w' => 100, 'h' => 100], 'medium' => ['w' => 250, 'h' => 250]]);
   }
 ?>
 <div class="record-container<?=$this->driver->supportsAjaxStatus()?' ajaxItem ':''?> list-view">

--- a/themes/finna2/templates/ajax/authority-recommend.phtml
+++ b/themes/finna2/templates/ajax/authority-recommend.phtml
@@ -47,7 +47,7 @@ $coreFields = $formatter->getDefaults('authorityRecommend');
   ?>
   <?=$this->record($this->driver)->renderTemplate(
     'record-image-information.phtml',
-    ['img' => $img, 'disableModal' => true, 'source' => 'SolrAuth', 'imageRightsLabel' => 'Image Rights Authority',
+    ['img' => $img, 'disableModal' => true, 'imageRightsLabel' => 'Image Rights Authority',
      'numOfImages' => ['mobile' => 4, 'normal' => 4]]);
   ?>
   </div>


### PR DESCRIPTION
Nykyisin RecordImage-helpperin render-metodille tulee antaa tietueen source mikäli tämä on eri kuin Solr. Parametri voidaan kuitenkin selvittää suoraan helpperissä käyttämällä driverin `getSourceIdentifieriä`, mikä yksinkertaistaa sivupohjia.

Muutos vaikuttaa toimijatietueisiin. Tulevaisuudessa NKR- ja AOE -tietueisiin, joilla on oma source.

Testaus: 
- tietuekuvat näkyvät oikein 
    - Solr-haku: tietuesivu, hakutulos, modaali
    - Toimija-haku (esim. kavin tietueilla): toimijasivu /AuthorityRecord, toimijahakutulos
    - Solr-haun AuthorityRecommend-suosittelija (kavin tietueilla): 
          - config.ini > Authority > authority_links[*] = search
- korkeareso-kuvan lataaminen toimii
