### PR TITLE
R2: ShibbolethLogoutNotification

### DIFF
--- a/module/Finna/config/module.config.php
+++ b/module/Finna/config/module.config.php
@@ -239,6 +239,7 @@ $config = [
             'Finna\Controller\RecordController' => 'VuFind\Controller\AbstractBaseWithConfigFactory',
             'Finna\Controller\CollectionController' => 'VuFind\Controller\AbstractBaseWithConfigFactory',
             'Finna\Controller\SearchController' => 'VuFind\Controller\AbstractBaseFactory',
+            'Finna\Controller\ShibbolethLogoutNotificationController' => 'Finna\Controller\ShibbolethLogoutNotificationControllerFactory',
             'Finna\Controller\ListController' => 'Finna\Controller\ListControllerFactory',
         ],
         'aliases' => [
@@ -281,6 +282,7 @@ $config = [
             'VuFind\Controller\PrimoRecordController' => 'Finna\Controller\PrimoRecordController',
             'VuFind\Controller\RecordController' => 'Finna\Controller\RecordController',
             'VuFind\Controller\SearchController' => 'Finna\Controller\SearchController',
+            'VuFind\Controller\ShibbolethLogoutNotificationController' => 'Finna\Controller\ShibbolethLogoutNotificationController',
 
             // Legacy:
             'PCI' => 'Finna\Controller\PrimoController',

--- a/module/Finna/src/Finna/Bootstrapper.php
+++ b/module/Finna/src/Finna/Bootstrapper.php
@@ -28,6 +28,8 @@
  */
 namespace Finna;
 
+use Finna\Service\RemsService;
+
 use Laminas\Console\Console;
 use Laminas\Mvc\MvcEvent;
 
@@ -260,15 +262,14 @@ class Bootstrapper
      */
     protected function initSuomifiLoginListener()
     {
+        if (!$this->isR2Enabled()) {
+            return;
+        }
         $sm = $this->event->getApplication()->getServiceManager();
         $callback = function ($event) use ($sm) {
-            $r2Config = $sm->get(\VuFind\Config\PluginManager::class)->get('R2');
-            if (!($r2Config->R2->enabled ?? false)) {
-                return;
-            }
             // Open REMS registration form after Suomifi login
             $lightboxUrl = $sm->get('ViewHelperManager')
-                ->get('url')->__invoke('feedback-form', ['id' => 'R2Register']);
+                ->get('url')->__invoke('r2feedback-form', ['id' => 'R2Register']);
 
             $followup = $sm->get(\Laminas\Mvc\Controller\PluginManager::class)
                 ->get(\VuFind\Controller\Plugin\Followup::class);
@@ -291,18 +292,99 @@ class Bootstrapper
      */
     protected function initSuomifiLogoutListener()
     {
+        if (!$this->isR2Enabled()) {
+            return;
+        }
         $sm = $this->event->getApplication()->getServiceManager();
         $callback = function ($event) use ($sm) {
-            $r2Config = $sm->get(\VuFind\Config\PluginManager::class)->get('R2');
-            if (!($r2Config->R2->enabled ?? false)) {
-                return;
-            }
-            $rems = $sm->get(\Finna\Service\RemsService::class);
-            $rems->onLogout();
+            // Close REMS appliations before Suomifi logout
+            $sm->get(RemsService::class)->onLogout();
         };
 
         $sm->get('SharedEventManager')->attach(
             'Finna\Auth\Suomifi', \Finna\Auth\Suomifi::EVENT_LOGOUT, $callback
         );
+    }
+
+    /**
+     * Set up REMS session expiration warning listener.
+     *
+     * @return void
+     */
+    protected function initRemsSessionExpirationWarningListener()
+    {
+        if (!$this->isR2Enabled()) {
+            return;
+        }
+        $sm = $this->event->getApplication()->getServiceManager();
+        $callback = function ($event) use ($sm) {
+            $session = new \Laminas\Session\Container(
+                \Finna\View\Helper\Root\SystemMessages::SESSION_NAME,
+                $sm->get(\Laminas\Session\SessionManager::class)
+            );
+            $messages = $session['messages'] ?? [];
+
+            $key = 'R2_session_expiring';
+            unset($session->messages[$key]);
+
+            if ($sm->get(\Finna\Service\RemsService::class)->hasUserAccess()) {
+                $expirationTime
+                    = $sm->get(RemsService::class)->getSessionExpirationTime();
+
+                if ($expirationTime) {
+                    // Add warning to session variable.
+                    // The message is displayed by SystemMessages
+                    $format = 'H:i';
+                    $time = $sm->get(\VuFind\Date\Converter::class)
+                        ->convertToDisplayTime(
+                            $format, date($format, $expirationTime->getTimeStamp())
+                        );
+                    $messages[$key] = ['%%expire%%' => $time];
+                    $session->messages = $messages;
+                }
+            }
+        };
+
+        $this->events->attach('dispatch', $callback, 9000);
+    }
+
+    /**
+     * Set up REMS registration listener.
+     *
+     * @return void
+     */
+    protected function initRemsRegistrationListener()
+    {
+        if (!$this->isR2Enabled()) {
+            return;
+        }
+        $sm = $this->event->getApplication()->getServiceManager();
+        $callback = function ($event) use ($sm) {
+            $table = $sm->get(\VuFind\Db\Table\PluginManager::class)
+                ->get('ExternalSession');
+            $params = $event->getParams();
+            if ($remsUserId = ($params['user'] ?? null)) {
+                $sessionId
+                    = $sm->get(\Laminas\Session\SessionManager::class)->getId();
+                $table->addSessionMapping("{$sessionId}REMS", $remsUserId);
+            }
+        };
+
+        $sm->get('SharedEventManager')->attach(
+            'Finna\Service\RemsService',
+            \Finna\Service\RemsService::EVENT_USER_REGISTERED, $callback
+        );
+    }
+
+    /**
+     * Check if R2 search is enabled.
+     *
+     * @return bool
+     */
+    protected function isR2Enabled()
+    {
+        $sm = $this->event->getApplication()->getServiceManager();
+        $r2Config = $sm->get(\VuFind\Config\PluginManager::class)->get('R2');
+        return $r2Config->R2->enabled ?? false;
     }
 }

--- a/module/Finna/src/Finna/Bootstrapper.php
+++ b/module/Finna/src/Finna/Bootstrapper.php
@@ -318,10 +318,10 @@ class Bootstrapper
         }
         $sm = $this->event->getApplication()->getServiceManager();
         $callback = function ($event) use ($sm) {
-            $table = $sm->get(\VuFind\Db\Table\PluginManager::class)
-                ->get('ExternalSession');
             $params = $event->getParams();
             if ($remsUserId = ($params['user'] ?? null)) {
+                $table = $sm->get(\VuFind\Db\Table\PluginManager::class)
+                    ->get('ExternalSession');
                 $sessionId
                     = $sm->get(\Laminas\Session\SessionManager::class)->getId();
                 $table->addSessionMapping("{$sessionId}REMS", $remsUserId);

--- a/module/Finna/src/Finna/Controller/ShibbolethLogoutNotificationController.php
+++ b/module/Finna/src/Finna/Controller/ShibbolethLogoutNotificationController.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Shibboleth Logout Notification API Controller
+ *
+ * PHP version 7
+ *
+ * Copyright (C) The National Library of Finland 2020.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * @category VuFind
+ * @package  Controller
+ * @author   Ere Maijala <ere.maijala@helsinki.fi>
+ * @author   Samuli Sillanpää <samuli.sillanpaa@helsinki.fi>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org Main Site
+ */
+namespace Finna\Controller;
+
+use Laminas\ServiceManager\ServiceLocatorInterface;
+
+/**
+ * Handles Shibboleth back-channel logout notifications.
+ *
+ * @category VuFind
+ * @package  Controller
+ * @author   Ere Maijala <ere.maijala@helsinki.fi>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org Main Site
+ */
+class ShibbolethLogoutNotificationController
+    extends \VuFind\Controller\ShibbolethLogoutNotificationController
+{
+    /**
+     * Is R2 search enabled?
+     *
+     * @var bool
+     */
+    protected $r2Enabled;
+
+    /**
+     * Constructor
+     *
+     * @param ServiceLocatorInterface $sm        Service locator
+     * @param bool                    $r2Enabled Is R2 search enabled?
+     */
+    public function __construct(ServiceLocatorInterface $sm, $r2Enabled)
+    {
+        $this->r2Enabled = $r2Enabled;
+        parent::__construct($sm);
+    }
+
+    /**
+     * Logout notification handler
+     *
+     * @param string $sessionId External session id
+     *
+     * @return void
+     */
+    public function logoutNotification($sessionId)
+    {
+        if ($this->r2Enabled) {
+            $table = $this->getTable('ExternalSession');
+            $row = $table->getByExternalSessionId(trim($sessionId));
+            if (empty($row)) {
+                return;
+            }
+
+            $remsId = $row['session_id'] . 'REMS';
+            $remsRow = $table->select(['session_id' => $remsId])->current();
+            if ($remsUsername = ($remsRow['external_session_id'] ?? '')) {
+                $this->serviceLocator->get(\Finna\Service\RemsService::class)
+                    ->closeOpenApplicationsForUser($remsUsername);
+            }
+        }
+        parent::logoutNotification($sessionId);
+    }
+}

--- a/module/Finna/src/Finna/Controller/ShibbolethLogoutNotificationControllerFactory.php
+++ b/module/Finna/src/Finna/Controller/ShibbolethLogoutNotificationControllerFactory.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Shibboleth Logout Notification controller factory.
+ *
+ * PHP version 7
+ *
+ * Copyright (C) The National Library of Finland 2020.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * @category VuFind
+ * @package  Controller
+ * @author   Samuli Sillanpää <samuli.sillanpaa@helsinki.fi>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development Wiki
+ */
+namespace Finna\Controller;
+
+use Interop\Container\ContainerInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
+
+/**
+ * Shibboleth Logout Notification controller factory.
+ *
+ * @category VuFind
+ * @package  Controller
+ * @author   Samuli Sillanpää <samuli.sillanpaa@helsinki.fi>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development Wiki
+ */
+class ShibbolethLogoutNotificationControllerFactory implements FactoryInterface
+{
+    /**
+     * Create an object
+     *
+     * @param ContainerInterface $container     Service manager
+     * @param string             $requestedName Service being created
+     * @param null|array         $options       Extra options (optional)
+     *
+     * @return object
+     *
+     * @throws ServiceNotFoundException if unable to resolve the service.
+     * @throws ServiceNotCreatedException if an exception is raised when
+     * creating a service.
+     * @throws ContainerException if any other error occurs
+     */
+    public function __invoke(ContainerInterface $container, $requestedName,
+        array $options = null
+    ) {
+        if (!empty($options)) {
+            throw new \Exception('Unexpected options sent to factory.');
+        }
+        return new $requestedName(
+            $container,
+            $container->get(\Finna\Service\R2SupportService::class)->isEnabled()
+        );
+    }
+}


### PR DESCRIPTION
Uutta:
- Käyttäjän REMS-hakemusten sulkeminen ShibbolethLogoutNotificationControllerissa
    - Kun käyttäjä on rekisteröity REMSiin tallennetaan uusi rivi ExternalSession-tauluun.
    - Controllerissa haetaan käyttäjän REMS-tunniste ja pyydetään RemsServiceä sulkemaan käyttäjän avoimet hakemukset.

Riippuvuudet:
  - [x] https://github.com/NatLibFi/NDL-VuFind2/pull/1728