### PR TITLE
Add object-fit contain rule to nonzoomable popup images

### DIFF
--- a/themes/finna2/less/finna/image-popup.less
+++ b/themes/finna2/less/finna/image-popup.less
@@ -202,6 +202,7 @@
             img {
                 max-height: 100%;
                 display: block;
+                object-fit: contain;
             }
             .leaflet-map-image {
                 background-color: #424242;


### PR DESCRIPTION
Prevents images from stretching on the newest versions of ios browsers.