### PR TITLE
Don't vertically align authority link elements.

### DIFF
--- a/themes/finna2/less/finna/authority.less
+++ b/themes/finna2/less/finna/authority.less
@@ -29,14 +29,9 @@
     .title {
       margin-right: 10px;
     }
-    .date-info {
-    }
   }
 }
 a.authority-link {
-  .authority-label {
-    vertical-align: middle;
-  }
   display: inline-block;
   &::after {
     margin-left: 5px;
@@ -44,11 +39,7 @@ a.authority-link {
   i {
     margin-right: 0.1em;
     font-size: @iconFontSize;
-    vertical-align: middle;
   }
-}
-.authority-additional-data {
-  vertical-align: middle;
 }
 .record-information .record-core-metadata .recordAuthors .authority {
     display: inline-block;
@@ -265,7 +256,6 @@ a.authority-link {
           }
           i {
             color: @link-color;
-            vertical-align: middle;
             font-size: 1.8em;
           }
         }


### PR DESCRIPTION
This doesn't work with surrounding elements such as format or additional information. See e.g. https://kansalliskirjasto.finna-test.fi/toimijavirityksia/AuthorityRecord/melinda.(FI-ASTERI-N)000082452/AuthorityRecordsAuthor#tabnav for an example of bad alignment.