### PR TITLE
[ALLI-6669] LRMI: revise logic for selecting preview image

### DIFF
--- a/module/Finna/src/Finna/RecordDriver/SolrLrmi.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrLrmi.php
@@ -411,7 +411,7 @@ class SolrLrmi extends SolrQdc
                     if ((string)$materialUrlFormat === 'application/pdf') {
                         // PDF version of material
                         $pdfUrl = (string)$materialUrl;
-                    } else if (!$url) {
+                    } elseif (!$url) {
                         // Material in original format
                         $url = $this->isDownloadableFileFormat($format)
                             ? (string)$materialUrl : '';

--- a/module/Finna/src/Finna/RecordDriver/SolrLrmi.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrLrmi.php
@@ -58,6 +58,16 @@ class SolrLrmi extends SolrQdc
     ];
 
     /**
+     * File formats that can be used as preview images when converted to PDF.
+     *
+     * @var array
+     */
+    protected $previewableConvertedFileFormats = [
+        'pdf', 'pptx', 'ppt', 'docx', 'html',
+        'odt', 'rtf', 'txt', 'odp', 'png', 'jpg', 'doc'
+    ];
+
+    /**
      * Usage rights map
      *
      * @var array
@@ -344,7 +354,11 @@ class SolrLrmi extends SolrQdc
                 $pdfs = array_filter(
                     $materials,
                     function ($material) {
-                        return !empty($material['pdfUrl']);
+                        return !empty($material['pdfUrl'])
+                            && in_array(
+                                $material['format'],
+                                $this->previewableConvertedFileFormats
+                            );
                     }
                 );
             }

--- a/module/Finna/src/Finna/RecordDriver/SolrLrmi.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrLrmi.php
@@ -59,12 +59,13 @@ class SolrLrmi extends SolrQdc
 
     /**
      * File formats that can be used as preview images when converted to PDF.
+     * The formats are prioritized according to their position in the array.
      *
      * @var array
      */
     protected $previewableConvertedFileFormats = [
-        'pdf', 'pptx', 'ppt', 'docx', 'html',
-        'odt', 'rtf', 'txt', 'odp', 'png', 'jpg', 'doc'
+        'pptx', 'ppt', 'odp', 'docx', 'doc',
+        'odt', 'rtf', 'txt', 'png', 'jpg', 'html'
     ];
 
     /**
@@ -353,6 +354,7 @@ class SolrLrmi extends SolrQdc
 
             // ... if not found, try materials that have been converted to PDF
             if (!$pdfUrl) {
+                $currentPriority = null;
                 foreach ($materials as $material) {
                     if (!empty($material['pdfUrl'])
                         && in_array(
@@ -360,8 +362,20 @@ class SolrLrmi extends SolrQdc
                             $this->previewableConvertedFileFormats
                         )
                     ) {
-                        $pdfUrl = $material['pdfUrl'];
-                        break;
+                        $priority = array_search(
+                            $material['format'],
+                            $this->previewableConvertedFileFormats
+                        );
+                        if ($priority === false) {
+                            continue;
+                        }
+                        if (!$currentPriority || $priority < $currentPriority) {
+                            $pdfUrl = $material['pdfUrl'];
+                            $currentPriority = $priority;
+                        }
+                        if ($priority === 0) {
+                            break;
+                        }
                     }
                 }
             }

--- a/module/Finna/src/Finna/RecordDriver/SolrLrmi.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrLrmi.php
@@ -350,9 +350,13 @@ class SolrLrmi extends SolrQdc
                 if (isset($prioritized[$format])) {
                     $priority = $prioritized[$format];
                     if (!$currentPriority || $priority < $currentPriority) {
-                        $pdfUrl = $format === 'pdf'
-                            ? $material['url'] : $material['pdfUrl'];
-                        $currentPriority = $priority;
+                        $url = $format === 'pdf'
+                            ? ($material['url'] ?? null)
+                            : ($material['pdfUrl'] ?? null);
+                        if ($url) {
+                            $pdfUrl = $url;
+                            $currentPriority = $priority;
+                        }
                     }
                     if ($priority === 0) {
                         break;

--- a/module/Finna/src/Finna/RecordDriver/SolrLrmi.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrLrmi.php
@@ -382,6 +382,7 @@ class SolrLrmi extends SolrQdc
     /**
      * Return array of materials with keys:
      * -url: download link for allowed file types, otherwise empty
+     * -pdfUrl: PDF version of material
      * -title: material title
      * -format: material format
      * -filesize: material file size in bytes


### PR DESCRIPTION
Muutos LRMI-tietueen esikatselukuvan valintaan.

Nykyisin esikatselukuvana käytetään joko
1. Tietueen varsinaista esikatselukuvaa (oletus) 
tai
2. Ensimmäistä PDF-muotoista materiaalia

Lisätään kolmas vaihtoehto, jota käytetään mikäli edellisiä ei löydy:

3. Materiaalin PDF-konvertoitu versio (kun materiaalin alkuperäinen formaatti on muu kuin PDF ja formaatti on hyväksyttyjen listalla). Konvertoitu URL löytyy: material > url@format=application/pdf, esim:
```
<material>
    <name lang="fi">Hermosto (v&#xE4;litt&#xE4;j&#xE4;aineet)</name>
    <name lang="sv">v&#xE4;litt&#xE4;j&#xE4;aineet</name>
    <name lang="en">v&#xE4;litt&#xE4;j&#xE4;aineet</name>
    <url>https://aoe.fi/api/download/vlittjaineet-1587645586671.docx</url>
    <url format="application/pdf">https://aoe.fi/api/pdf/content/vlittjaineet-1587645586671.pdf</url>
    <position>3</position>
    <format>application/vnd.openxmlformats-officedocument.wordprocessingml.document</format>
    <filesize>284468</filesize>
    <inLanguage>fi</inLanguage>
  </material>
```

Testaus (uudet tietueet testi-indeksissä, proto: http://finna-dev-fe.csc.fi/aoe-test):
- Konvertoidut URLit eivät tule näkyviin ladattavien urlien sekaan (tietueruudun alussa)
- Konveroitua urlia käyetään esikatselukuvana kun se on ainoa vaihtoehto (esim. aoe.739, aoe.362)
- Konvertoitua urlia ei käytetä mikäli alkuperäinen formaatti ei ole hyväksytty (esim. aoe.944)