### PR TITLE
[ALLI-6718] EAD3: fix filtering of fullres images.

### DIFF
--- a/module/Finna/src/Finna/RecordDriver/SolrEad3.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrEad3.php
@@ -502,8 +502,9 @@ class SolrEad3 extends SolrEad
                 }
                 $attr = $daoset->attributes();
                 $localtype = (string)($attr->localtype ?? null);
-                $size = self::IMAGE_MAP[$localtype] ?? self::IMAGE_FULLRES;
-                $size = $size === self::IMAGE_FULLRES ? self::IMAGE_LARGE : $size;
+                $localtype = self::IMAGE_MAP[$localtype] ?? self::IMAGE_FULLRES;
+                $size = $localtype === self::IMAGE_FULLRES
+                      ? self::IMAGE_LARGE : $localtype;
                 if (!isset($images[$size])) {
                     $image[$size] = [];
                 }
@@ -530,7 +531,8 @@ class SolrEad3 extends SolrEad
                         'rights' => null,
                         'url' => $href,
                         'descId' => $descId,
-                        'sort' => (string)$attr->label
+                        'sort' => (string)$attr->label,
+                        'type' => $localtype
                     ];
                 }
             }
@@ -869,6 +871,9 @@ class SolrEad3 extends SolrEad
         $images = $this->getAllImages();
         $items = [];
         foreach ($images as $img) {
+            if (!isset($img['type']) || $img['type'] !== self::IMAGE_FULLRES) {
+                continue;
+            }
             $items[]
                 = ['label' => $img['description'], 'url' => $img['urls']['large']];
         }

--- a/themes/finna2/templates/RecordTab/externaldata.phtml
+++ b/themes/finna2/templates/RecordTab/externaldata.phtml
@@ -5,8 +5,7 @@ $OCRImages = $data['OCRImages'] ?? null;
 $physicalItems = $data['physicalItems'] ?? null;
 ?>
 <?php if (!$fullResImages && !$OCRImages): ?>
-  <?= $this->translate('external_data_not_digitized_html', ['%%url%%' => $this->recordLink()->getActionUrl($this->driver, 'Feedback')]) ?>
-  <?php return; ?>
+  <p><?= $this->translate('external_data_not_digitized_html', ['%%url%%' => $this->recordLink()->getActionUrl($this->driver, 'Feedback')]) ?></p>
 <?php endif ?>
 
 <?php if ($fullResImages): ?>


### PR DESCRIPTION
- Aineistot-välilehden täysresoluutiokuvat-kohdassa ei tarkistettu kuvan tyyppiä.
- Poistin samalla sivupohjasta virheellisen keskeytyksen, minkä vuoksi physicalItems-osiota ei näytetty jos muut kohdat puuttuivat.
- p-tagi bottom-marginin vuoksi.