### PR TITLE
EAD3: record images and ExternalData tab

### DIFF
--- a/module/Finna/src/Finna/RecordDriver/SolrEad3.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrEad3.php
@@ -473,18 +473,18 @@ class SolrEad3 extends SolrEad
     public function getExternalData()
     {
         $fullResImages = $this->getFullResImages();
-        $OCRImages = $this->getOCRImages();
+        $ocrImages = $this->getOCRImages();
         $physicalItems = $this->getPhysicalItems();
         $digitized
-            = !empty($fullResImages) || !empty($OCRImages)
+            = !empty($fullResImages) || !empty($ocrImages)
             || !empty($this->getAllImages());
 
         $result = ['items' => []];
         if (!empty($fullResImages)) {
             $result['items']['fullResImages'] = $fullResImages;
         }
-        if (!empty($OCRImages)) {
-            $result['items']['OCRImages'] = $OCRImages;
+        if (!empty($ocrImages)) {
+            $result['items']['OCRImages'] = $ocrImages;
         }
         if (!empty($physicalItems)) {
             $result['items']['physicalItems'] = $physicalItems;

--- a/module/Finna/src/Finna/RecordDriver/SolrEad3.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrEad3.php
@@ -472,11 +472,14 @@ class SolrEad3 extends SolrEad
      */
     public function getExternalData()
     {
-        return [
-            'fullResImages' => $this->getFullResImages(),
-            'OCRImages' => $this->getOCRImages(),
-            'physicalItems' => $this->getPhysicalItems()
-        ];
+        $fullResImages = $this->getFullResImages();
+        $OCRImages = $this->getOCRImages();
+        $physicalItems = $this->getPhysicalItems();
+        $digitized
+            = !empty($fullResImages) || !empty($OCRImages)
+            || !empty($this->getAllImages());
+
+        return compact('fullResImages', 'OCRImages', 'physicalItems', 'digitized');
     }
 
     /**

--- a/module/Finna/src/Finna/RecordDriver/SolrEad3.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrEad3.php
@@ -531,11 +531,13 @@ class SolrEad3 extends SolrEad
                     }
                     if (isset($attr->localtype)) {
                         $localtype = (string)$attr->localtype;
-                    }
-                    if (!$localtype || !isset(self::IMAGE_MAP[$localtype])) {
+                        if (!isset(self::IMAGE_MAP[$localtype])) {
+                            continue;
+                        }
+                        $size = self::IMAGE_MAP[$localtype];
+                    } elseif (!$localtype) {
                         continue;
                     }
-                    $size = self::IMAGE_MAP[$localtype];
                     $size = $size === self::IMAGE_FULLRES
                         ? self::IMAGE_LARGE : $size;
                     if (!isset($images[$size])) {

--- a/module/Finna/src/Finna/RecordDriver/SolrEad3.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrEad3.php
@@ -479,7 +479,7 @@ class SolrEad3 extends SolrEad
             = !empty($fullResImages) || !empty($ocrImages)
             || !empty($this->getAllImages());
 
-        $result = ['items' => []];
+        $result = [];
         if (!empty($fullResImages)) {
             $result['items']['fullResImages'] = $fullResImages;
         }
@@ -488,9 +488,6 @@ class SolrEad3 extends SolrEad
         }
         if (!empty($physicalItems)) {
             $result['items']['physicalItems'] = $physicalItems;
-        }
-        if (empty($result['items'])) {
-            unset($result['items']);
         }
         $result['digitized'] = $digitized;
 

--- a/module/Finna/src/Finna/RecordDriver/SolrEad3.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrEad3.php
@@ -479,7 +479,22 @@ class SolrEad3 extends SolrEad
             = !empty($fullResImages) || !empty($OCRImages)
             || !empty($this->getAllImages());
 
-        return compact('fullResImages', 'OCRImages', 'physicalItems', 'digitized');
+        $result = ['items' => []];
+        if (!empty($fullResImages)) {
+            $result['items']['fullResImages'] = $fullResImages;
+        }
+        if (!empty($OCRImages)) {
+            $result['items']['OCRImages'] = $OCRImages;
+        }
+        if (!empty($physicalItems)) {
+            $result['items']['physicalItems'] = $physicalItems;
+        }
+        if (empty($result['items'])) {
+            unset($result['items']);
+        }
+        $result['digitized'] = $digitized;
+
+        return $result;
     }
 
     /**

--- a/module/Finna/src/Finna/RecordTab/ExternalData.php
+++ b/module/Finna/src/Finna/RecordTab/ExternalData.php
@@ -62,7 +62,10 @@ class ExternalData extends \VuFind\RecordTab\AbstractBase
      */
     public function isActive()
     {
-        if (empty($this->driver->tryMethod('getExternalData'))) {
+        $data = $this->driver->tryMethod('getExternalData');
+        if (empty($data)
+            || (empty($data['items']) && $data['digitized'])
+        ) {
             $this->enabled = false;
         }
         return $this->enabled;

--- a/themes/finna2/templates/RecordTab/externaldata.phtml
+++ b/themes/finna2/templates/RecordTab/externaldata.phtml
@@ -1,10 +1,11 @@
 <?php
 $data = $this->driver->getExternalData();
+$digitized = $data['digitized'];
 $fullResImages = $data['fullResImages'] ?? null;
 $OCRImages = $data['OCRImages'] ?? null;
 $physicalItems = $data['physicalItems'] ?? null;
 ?>
-<?php if (!$fullResImages && !$OCRImages): ?>
+<?php if (!$digitized): ?>
   <p><?= $this->translate('external_data_not_digitized_html', ['%%url%%' => $this->recordLink()->getActionUrl($this->driver, 'Feedback')]) ?></p>
 <?php endif ?>
 

--- a/themes/finna2/templates/RecordTab/externaldata.phtml
+++ b/themes/finna2/templates/RecordTab/externaldata.phtml
@@ -1,9 +1,10 @@
 <?php
 $data = $this->driver->getExternalData();
 $digitized = $data['digitized'];
-$fullResImages = $data['fullResImages'] ?? null;
-$OCRImages = $data['OCRImages'] ?? null;
-$physicalItems = $data['physicalItems'] ?? null;
+$items = $data['items'] ?? [];
+$fullResImages = $items['fullResImages'] ?? null;
+$OCRImages = $items['OCRImages'] ?? null;
+$physicalItems = $items['physicalItems'] ?? null;
 ?>
 <?php if (!$digitized): ?>
   <p><?= $this->translate('external_data_not_digitized_html', ['%%url%%' => $this->recordLink()->getActionUrl($this->driver, 'Feedback')]) ?></p>

--- a/themes/finna2/templates/RecordTab/externaldata.phtml
+++ b/themes/finna2/templates/RecordTab/externaldata.phtml
@@ -3,7 +3,7 @@ $data = $this->driver->getExternalData();
 $digitized = $data['digitized'];
 $items = $data['items'] ?? [];
 $fullResImages = $items['fullResImages'] ?? null;
-$OCRImages = $items['OCRImages'] ?? null;
+$ocrImages = $items['OCRImages'] ?? null;
 $physicalItems = $items['physicalItems'] ?? null;
 ?>
 <?php if (!$digitized): ?>
@@ -14,8 +14,8 @@ $physicalItems = $items['physicalItems'] ?? null;
   <?= $this->partial('RecordTab/external_data_table.phtml', ['type' => 'fullres_images', 'data' => $fullResImages]); ?>
 <?php endif; ?>
 
-<?php if ($OCRImages): ?>
-  <?= $this->partial('RecordTab/external_data_table.phtml', ['type' => 'ocr', 'data' => $OCRImages]); ?>
+<?php if ($ocrImages): ?>
+  <?= $this->partial('RecordTab/external_data_table.phtml', ['type' => 'ocr', 'data' => $ocrImages]); ?>
 <?php endif; ?>
 
 


### PR DESCRIPTION
- Korjaus: `localtype` attribuuttia yritettiin mapata kahteen keraan:
https://github.com/NatLibFi/NDL-VuFind2/compare/dev...samuli:ead3-fix-record-image-localtype?expand=1#diff-a7a8a3396cedb3aa3baac7bb8d1f7eb9beab156058fb34d1c8f5eebd1540ea5bL535 
- Muutos: Aineistot-välilehdellä näytetään "ei digitoitu" teksti vain jos tietueesta ei ole saatavilla kuvia missään koossa. Aiemmin pelkkä näyttökuva ei riittänyt. Välilehti kätketään jos aineistoja ei ole ja ei ole tarvetta näyttää "ei digitoitu" tekstiä.