### PR TITLE
Fix bug in collecting labels to content page navi items

### DIFF
--- a/themes/finna2/js/finna-layout.js
+++ b/themes/finna2/js/finna-layout.js
@@ -150,7 +150,7 @@ finna.layout = (function finnaLayout() {
           .appendTo($('.content-navigation-menu'));
         $('<a>')
           .attr('href', link)
-          .text($('h2', this).text())
+          .text($('h2', this).first().text())
           .appendTo($p);
       });
     }


### PR DESCRIPTION
Sisältösivun sivu-navigaation itemin labeliin poimitaan kaikki yksittäisen content-sectionin h2-elementit.
Bugi ilmenee mikäli samaan osioon lisää useamman h2:n tai jos jokin upoke käyttää h2-elementtejä (esim. FeedTabs).

