### PR TITLE
[ALLI-6788] Mikromarc LibraryUnits request fix

### DIFF
--- a/module/Finna/src/Finna/ILS/Driver/Mikromarc.php
+++ b/module/Finna/src/Finna/ILS/Driver/Mikromarc.php
@@ -2071,8 +2071,8 @@ class Mikromarc extends \VuFind\ILS\Driver\AbstractBase implements
 
         $page = 0;
         $data = [];
-        $fetch = true;
-        while ($fetch) {
+        $nextPage = true;
+        do {
             $client->setUri($apiUrl);
             $response = $client->send();
             $result = $response->getBody();
@@ -2105,7 +2105,7 @@ class Mikromarc extends \VuFind\ILS\Driver\AbstractBase implements
             }
 
             // More results available?
-            if ($next = !empty($decodedResult['@odata.nextLink'])) {
+            if ($nextPage = !empty($decodedResult['@odata.nextLink'])) {
                 $client->setParameterPost([]);
                 $client->setParameterGet([]);
                 $apiUrl = $decodedResult['@odata.nextLink'];
@@ -2121,11 +2121,9 @@ class Mikromarc extends \VuFind\ILS\Driver\AbstractBase implements
                 $data = array_merge($data, $decodedResult);
             }
 
-            if (!$next) {
-                $fetch = false;
-            }
             $page++;
-        }
+        } while ($nextPage);
+
         return $returnCode ? [$response->getStatusCode(), $data]
             : $data;
     }

--- a/module/Finna/src/Finna/ILS/Driver/Mikromarc.php
+++ b/module/Finna/src/Finna/ILS/Driver/Mikromarc.php
@@ -2105,11 +2105,7 @@ class Mikromarc extends \VuFind\ILS\Driver\AbstractBase implements
             }
 
             // More results available?
-            if ($next = !empty($decodedResult['@odata.nextLink'])
-                && !strpos(
-                    $decodedResult['@odata.nextLink'], 'LibraryUnits?$skip=100'
-                )
-            ) {
+            if ($next = !empty($decodedResult['@odata.nextLink'])) {
                 $client->setParameterPost([]);
                 $client->setParameterGet([]);
                 $apiUrl = $decodedResult['@odata.nextLink'];

--- a/module/Finna/src/Finna/ILS/Driver/Mikromarc.php
+++ b/module/Finna/src/Finna/ILS/Driver/Mikromarc.php
@@ -2071,7 +2071,7 @@ class Mikromarc extends \VuFind\ILS\Driver\AbstractBase implements
 
         $page = 0;
         $data = [];
-        $nextPage = true;
+        $nextPage = false;
         do {
             $client->setUri($apiUrl);
             $response = $client->send();


### PR DESCRIPTION
Allow Mikromarc to properly list all libraryunits

Test: Record/vaasa.1073201

Test with and without this pr to see the difference in available holdings