### PR TITLE
EAD3: fix translation key

### DIFF
--- a/local/languages/finna/en-gb.ini
+++ b/local/languages/finna/en-gb.ini
@@ -6,7 +6,7 @@
 Accept cookies = "Accept cookies"
 accept_request_terms_html = "I agree to the terms and conditions"
 Access Restrictions = "Access Conditions"
-access_restrictions_ahaa_general = ""
+access_restrictions_general = ""
 access_restrictions_ahaa_KR1 = ""
 access_restrictions_ahaa_KR3 = ""
 access_restrictions_ahaa_KR4 = ""

--- a/local/languages/finna/fi.ini
+++ b/local/languages/finna/fi.ini
@@ -6,7 +6,7 @@
 Accept cookies = "Hyväksy evästeet"
 accept_request_terms_html = "Hyväksyn käyttöehdot"
 Access Restrictions = "Käyttöoikeudet"
-access_restrictions_ahaa_general = "Käyttörajoitustieto"
+access_restrictions_general = "Käyttörajoitustieto"
 access_restrictions_ahaa_KR1 = "Rajoituksen peruste"
 access_restrictions_ahaa_KR3 = "Lisätietoa käyttörajoituksesta"
 access_restrictions_ahaa_KR4 = "Rajoituksen kesto"

--- a/local/languages/finna/sv.ini
+++ b/local/languages/finna/sv.ini
@@ -6,7 +6,7 @@
 Accept cookies = "Acceptera cookies"
 accept_request_terms_html = "Jag godkänner användarvillkoren"
 Access Restrictions = "Användarrättigheter"
-access_restrictions_ahaa_general = ""
+access_restrictions_general = ""
 access_restrictions_ahaa_KR1 = ""
 access_restrictions_ahaa_KR3 = ""
 access_restrictions_ahaa_KR4 = ""


### PR DESCRIPTION
general-avaimessa ei ole mukana "ahaa"ta:
https://github.com/NatLibFi/NDL-VuFind2/blob/dev/module/Finna/src/Finna/RecordDriver/SolrEad3.php#L741
https://github.com/NatLibFi/NDL-VuFind2/blob/dev/module/Finna/src/Finna/RecordDriver/SolrEad3.php#L758