### PR TITLE
LIDO: filter duplicate summary items

### DIFF
--- a/module/Finna/src/Finna/RecordDriver/SolrLido.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrLido.php
@@ -1305,7 +1305,7 @@ class SolrLido extends \VuFind\RecordDriver\SolrDefault
             $results[] = (string)($this->fields['description']) != $title
                 ? (string)$this->fields['description'] : '';
         }
-        return $results;
+        return array_unique($results);
     }
 
     /**


### PR DESCRIPTION
Metadatassa voi olla sama teksti useassa eri kentässä (ja lisäksi indeksin description-kentässä).
Esimerkki: mip.94583 (duplikaatti näkyy kuvapoparissa).