### PR TITLE
[ALLI-6280] LIDO: display localized subject terms

### DIFF
--- a/module/Finna/src/Finna/RecordDriver/SolrLido.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrLido.php
@@ -980,7 +980,7 @@ class SolrLido extends \VuFind\RecordDriver\SolrDefault
         return $this->getDateRange('creation');
     }
 
-     /**
+    /**
      * Get all subject headings associated with this record.  Each heading is
      * returned as an array of chunks, increasing from least specific to most
      * specific.

--- a/module/Finna/src/Finna/RecordDriver/SolrLido.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrLido.php
@@ -980,6 +980,56 @@ class SolrLido extends \VuFind\RecordDriver\SolrDefault
         return $this->getDateRange('creation');
     }
 
+     /**
+     * Get all subject headings associated with this record.  Each heading is
+     * returned as an array of chunks, increasing from least specific to most
+     * specific.
+     *
+     * @param bool $extended Whether to return a keyed array with the following
+     * keys:
+     * - heading: the actual subject heading chunks
+     * - type: heading type
+     * - source: source vocabulary
+     *
+     * @return array
+     */
+    public function getAllSubjectHeadings($extended = false)
+    {
+        $preferredLangResults = $allResults = [];
+        $preferredLanguages = $this->getPreferredLanguageCodes();
+
+        foreach ($this->getXmlRecord()->xpath(
+            'lido/descriptiveMetadata/objectRelationWrap/subjectWrap/'
+            . 'subjectSet/subject/subjectConcept/term'
+        ) as $node) {
+            if ($term = trim((string)$node)) {
+                $attr = $node->attributes();
+                $allResults[] = $term;
+                if (in_array((string)$attr->lang, $preferredLanguages)) {
+                    $preferredLangResults[] = $term;
+                }
+            }
+        }
+        $headings = $preferredLangResults ?: $allResults;
+
+        foreach (['geographic', 'genre', 'era'] as $field) {
+            if (isset($this->fields[$field])) {
+                $headings = array_merge($headings, (array)$this->fields[$field]);
+            }
+        }
+
+        // The default index schema doesn't currently store subject headings in a
+        // broken-down format, so we'll just send each value as a single chunk.
+        // Other record drivers (i.e. SolrMarc) can offer this data in a more
+        // granular format.
+        $callback = function ($i) use ($extended) {
+            return $extended
+                ? ['heading' => [$i], 'type' => '', 'source' => '']
+                : [$i];
+        };
+        return array_map($callback, array_unique($headings));
+    }
+
     /**
      * Get subject actors
      *


### PR DESCRIPTION
VuFind-toteutus kuten aiemmin revertoidussa: https://github.com/NatLibFi/NDL-VuFind2/commit/ddad3e5df91b4dfd797964b478c1a5053d6a71f7

Vaatii asiasanojen pilkkomisen alla olevalla transformaatiolla, joka luo jokaista pilkulla eroteltua asiasanaa varten oman subjectSet-elementin:

```
<objectRelationWrap>
        <subjectWrap>
          <subjectSet>
            <displaySubject label="yso aihe">Talvi</displaySubject>
            <subject type="yso aihe">
              <subjectConcept>
                <term>Talvi</term>
              </subjectConcept>
            </subject>
          </subjectSet>
          <subjectSet>
            <displaySubject label="yso aihe">maisema</displaySubject>
            <subject type="yso aihe">
              <subjectConcept>
                <term>maisema</term>
              </subjectConcept>
            </subject>
          </subjectSet>
        ....
```

Testaus: https://finna.fi/Record/ktm.urn:uuid:7C61BCF9-E876-4CDF-B172-8F8312BAC1CC#details

Transformaation voi liittää mukaan nykyiseen muusa.xsl -tiedostoon.

```
<!-- create new subjectSet elements from comma-delimited subject/subjectConcept/terms -->
<xsl:template match="descriptiveMetadata/objectRelationWrap/subjectWrap/subjectSet">
  <xsl:choose>
    <xsl:when test="subject/subjectConcept/term">
      <xsl:call-template name="splitSubjectTerms" />
    </xsl:when>

    <xsl:otherwise>
      <subjectSet>
        <xsl:copy-of select="*"/>
      </subjectSet>
    </xsl:otherwise>

  </xsl:choose>
</xsl:template>

<xsl:template name="splitSubjectTerms">
  <xsl:param name="term" select="subject/subjectConcept/term"/>

  <xsl:if test="string-length($term) > 0">
    <xsl:variable name="nextTerm" select="substring-before(concat($term, ','), ',')"/>

    <xsl:element name="subjectSet">

      <xsl:element name="displaySubject">
        <xsl:copy-of select="displaySubject/@*" />
        <xsl:value-of select="normalize-space($nextTerm)" />
      </xsl:element>

      <xsl:element name="subject">
        <xsl:copy-of select="subject/@*" />

        <xsl:element name="subjectConcept">
          <xsl:copy-of select="subject/subjectConcept/@*" />

          <xsl:copy-of select="subject/subjectConcept/*[not(self::term)]" />

          <xsl:element name="term">
            <xsl:copy-of select="subject/subjectConcept/term/@*" />
            <xsl:value-of select="normalize-space($nextTerm)"/>
          </xsl:element>
        </xsl:element>
      </xsl:element>
    </xsl:element>
    
    <xsl:call-template name="splitSubjectTerms">
      <xsl:with-param name="term" select="substring-after($term, ',')"/>
    </xsl:call-template>
  </xsl:if>

</xsl:template>
```