### PR TITLE
[ALLI-6862] Show flashmessage if patron is not found

### DIFF
--- a/module/Finna/src/Finna/ILS/Driver/KohaRest.php
+++ b/module/Finna/src/Finna/ILS/Driver/KohaRest.php
@@ -802,11 +802,18 @@ class KohaRest extends \VuFind\ILS\Driver\KohaRest
             ]
         );
 
-        if (200 === $result['code'] && !empty($result['data'][0])) {
-            return [
-                'success' => true,
-                'token' => $result['data'][0]['patron_id']
-            ];
+        if (200 === $result['code']) {
+            if (!empty($result['data'][0])) {
+                return [
+                    'success' => true,
+                    'token' => $result['data'][0]['patron_id']
+                ];
+            } else {
+                return [
+                    'success' => false,
+                    'error' => 'Patron not found'
+                ];
+            }
         }
 
         if (404 !== $result['code']) {


### PR DESCRIPTION
test: LibraryCards/Recover?target=fikka

Should return properly back to page if no patron is found instead of throwing an error.