### PR TITLE
[ALLI-6831] EAD3: online urls

### DIFF
--- a/module/Finna/src/Finna/RecordDriver/SolrEad3.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrEad3.php
@@ -62,6 +62,14 @@ class SolrEad3 extends SolrEad
         'thumbnail' => self::IMAGE_MEDIUM
     ];
 
+    // URLs that are displayed on ExternalData record tab
+    // (not below record title)
+    const EXTERNAL_DATA_URLS = [
+        'Bittikartta - Fullres - Jakelukappale',
+        'Bittikartta - Pikkukuva - Jakelukappale',
+        'OCR-data - Alto - Jakelukappale',
+    ];
+
     // Altformavail labels
     const ALTFORM_LOCATION = 'location';
     const ALTFORM_TYPE = 'type';
@@ -163,29 +171,32 @@ class SolrEad3 extends SolrEad
         $url = '';
         $record = $this->getXmlRecord();
         $preferredLangCodes = $this->mapLanguageCode($this->preferredLanguage);
-        foreach ($record->did->xpath('//daoset/dao') as $node) {
-            $attr = $node->attributes();
-            // Discard image urls (that are displayed on ExternalData record tab)
-            if ((isset($attr->linktitle)
-                && (string)$attr->linkrole === 'image/jpeg')
-                || !$attr->href
-            ) {
+        foreach ($record->did->xpath('//daoset') as $daoset) {
+            $localtype = (string)$daoset->attributes()->localtype;
+
+            if ($localtype && in_array($localtype, self::EXTERNAL_DATA_URLS)) {
                 continue;
             }
-            $lang = (string)$attr->lang;
-            $preferredLang = $lang && in_array($lang, $preferredLangCodes);
+            foreach ($daoset->dao as $node) {
+                $attr = $node->attributes();
+                if ((string)$attr->linkrole === 'image/jpeg' || !$attr->href) {
+                    continue;
+                }
+                $lang = (string)$attr->lang;
+                $preferredLang = $lang && in_array($lang, $preferredLangCodes);
 
-            $url = (string)$attr->href;
-            $desc = $attr->linktitle ?? $node->descriptivenote->p ?? $url;
+                $url = (string)$attr->href;
+                $desc = $attr->linktitle ?? $node->descriptivenote->p ?? $url;
 
-            if (!$this->urlBlocked($url, $desc)) {
-                $urlData = [
-                    'url' => $url,
-                    'desc' => (string)$desc
-                ];
-                $urls[] = $urlData;
-                if ($preferredLang) {
-                    $localeUrls[] = $urlData;
+                if (!$this->urlBlocked($url, $desc)) {
+                    $urlData = [
+                        'url' => $url,
+                        'desc' => (string)$desc
+                    ];
+                    $urls[] = $urlData;
+                    if ($preferredLang) {
+                        $localeUrls[] = $urlData;
+                    }
                 }
             }
         }


### PR DESCRIPTION
Parannuksia urlien näyttämiseen:
- Aineistot-välilehdelle tulevat urlit erotellaan daoset@localtype:n mukaan (toistaiseksi AHAA:n urlit)
- Thumbnail-urlien karsinta dao@linkrole:n avulla (tarvitaan kun urlissa ei ole oikeaa päätettä, esim. ta_yksa.136995209902000_160508796457000)
- Käytetään lokalisoitua labelia (dao>descriptivenote>p) kun saatavissa
