### PR TITLE
[ALLI-6859] EAD: fix missing archive origination

### DIFF
--- a/module/Finna/src/Finna/RecordDriver/SolrEad.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrEad.php
@@ -314,8 +314,14 @@ class SolrEad extends SolrDefault
     public function getOrigination()
     {
         $record = $this->getXmlRecord();
-        return isset($record->did->origination)
-            ? (string)$record->did->origination->corpname : '';
+        if (isset($record->did->origination->corpname)) {
+            return (string)$record->did->origination->corpname;
+        } elseif (isset($record->did->origination->persname)) {
+            return (string)$record->did->origination->persname;
+        } elseif (isset($record->did->origination)) {
+            return (string)$record->did->origination;
+        }
+        return '';
     }
 
     /**

--- a/themes/finna2/templates/RecordDriver/DefaultRecord/data-origination.phtml
+++ b/themes/finna2/templates/RecordDriver/DefaultRecord/data-origination.phtml
@@ -1,2 +1,2 @@
 <?php $originationExt = $this->driver->tryMethod('getOriginationExtended'); //Don't add START and END comments ?>
-<?=$this->record($this->driver)->getAuthorityLinkElement('author', $originationExt ? $originationExt['name'] : $data, $originationExt ?? null, ['showInlineInfo' => true, 'authorityType' => $author['type'] ?? null])?>
+<?=$this->record($this->driver)->getAuthorityLinkElement('author', $originationExt ? $originationExt['name'] : $data, $originationExt ?? ['name' => $data], ['showInlineInfo' => true, 'authorityType' => $author['type'] ?? null])?>


### PR DESCRIPTION
- getAuthorityLinkElementin kutsusta puuttui EAD:n tapauksessa parametri (EAD3 menee getOriginationExtended:in kautta)
- lisätty pari uutta kohtaa arkistonmuodostajan etsimiseen did>originationista
