### PR TITLE
[ALLI-6968] AWS: Make it possible to pay less than full balance.

### DIFF
--- a/local/config/finna/AxiellWebServices.ini.sample
+++ b/local/config/finna/AxiellWebServices.ini.sample
@@ -197,6 +197,9 @@ currency = 'EUR'
 ; expression enclosed in slashes (e.g. '/^Lasku - Lasku\b/')
 nonPayable[] = '/^Lasku - Lasku\b/'
 nonPayable[] = '/^Muu maksu/'
+; Whether the paid amount must match the payable amount. Default is true. If false,
+; payments of less than the full amount are accepted.
+;exactBalanceRequired = false
 
 ; valid value is 'driver'.
 [updateTransactionHistoryState]

--- a/module/Finna/src/Finna/Controller/FinnaOnlinePaymentControllerTrait.php
+++ b/module/Finna/src/Finna/Controller/FinnaOnlinePaymentControllerTrait.php
@@ -221,7 +221,8 @@ trait FinnaOnlinePaymentControllerTrait
             && $payableOnline['payable'] && $payableOnline['amount']
         ) {
             // Payment started, check that fee list has not been updated
-            if (($paymentConfig['exactBalanceRequired'] ?? true)
+            if ((($paymentConfig['exactBalanceRequired'] ?? true)
+                || !empty($paymentConfig['creditUnsupported']))
                 && $this->checkIfFinesUpdated($patron, $payableOnline['amount'])
             ) {
                 // Fines updated, redirect and show updated list.

--- a/module/Finna/src/Finna/ILS/Driver/AxiellWebServices.php
+++ b/module/Finna/src/Finna/ILS/Driver/AxiellWebServices.php
@@ -1575,7 +1575,10 @@ class AxiellWebServices extends \VuFind\ILS\Driver\AbstractBase
         if (isset($this->config[$function])) {
             $functionConfig = $this->config[$function];
             if ('onlinePayment' === $function) {
-                $functionConfig['exactBalanceRequired'] = true;
+                if (!isset($functionConfig['exactBalanceRequired'])) {
+                    $functionConfig['exactBalanceRequired'] = true;
+                }
+                $functionConfig['creditUnsupported'] = true;
             }
         } else {
             $functionConfig = false;


### PR DESCRIPTION
AWS näkyy toimivan niin, että maksut merkitään maksetuiksi siihen asti, kun varoja riittää. Viimeiseen maksuun jää sitten mahdollisesti aiempaa pienempi määrä. Kuitenkaan ei voi maksaa enempää kuin on maksettavissa, vaan silloin maksu vain katoaa, joten se pitää erikseen estää.