### PR TITLE
[ALLI-6991] EACCPF: Display localized occupations

### DIFF
--- a/module/Finna/src/Finna/RecordDriver/SolrAuthEaccpf.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrAuthEaccpf.php
@@ -41,7 +41,9 @@ namespace Finna\RecordDriver;
  */
 class SolrAuthEacCpf extends SolrAuthDefault
 {
-    use SolrAuthFinnaTrait;
+    use SolrAuthFinnaTrait {
+        getOccupations as _getOccupations;
+    }
     use XmlReaderTrait;
 
     /**
@@ -169,7 +171,7 @@ class SolrAuthEacCpf extends SolrAuthDefault
                 }
             }
         }
-        return $result ?: $this->fields['occupation'] ?? [];
+        return $result ?: $this->_getOccupations();
     }
 
 

--- a/module/Finna/src/Finna/RecordDriver/SolrAuthEaccpf.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrAuthEaccpf.php
@@ -154,7 +154,7 @@ class SolrAuthEacCpf extends SolrAuthDefault
     {
         $result = [];
         $record = $this->getXmlRecord();
-        if (isset($record->cpfDescription->description->occupations)) {
+        if (isset($record->cpfDescription->description->occupations->occupation)) {
             $languages = $this->mapLanguageCode($this->getLocale());
             foreach ($record->cpfDescription->description->occupations->occupation
                 as $occupation

--- a/module/Finna/src/Finna/RecordDriver/SolrAuthEaccpf.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrAuthEaccpf.php
@@ -144,6 +144,36 @@ class SolrAuthEacCpf extends SolrAuthDefault
     }
 
     /**
+     * Return occupations.
+     *
+     * @return array
+     */
+    public function getOccupations()
+    {
+        $result = [];
+        $record = $this->getXmlRecord();
+        if (isset($record->cpfDescription->description->occupations)) {
+            $result = [];
+            $languages = $this->mapLanguageCode($this->getLocale());
+            foreach ($record->cpfDescription->description->occupations->occupation
+                as $occupation
+            ) {
+                if (!isset($occupation->term)) {
+                    continue;
+                }
+                $term = $occupation->term;
+                $attr = $term->attributes();
+                if ($attr->lang && in_array((string)$attr->lang, $languages)
+                ) {
+                    $result[] = (string)$term;
+                }
+            }
+        }
+        return $result ?: $this->fields['occupation'] ?? [];
+    }
+
+
+    /**
      * Set preferred language for display strings.
      *
      * @param string $language Language

--- a/module/Finna/src/Finna/RecordDriver/SolrAuthEaccpf.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrAuthEaccpf.php
@@ -154,19 +154,24 @@ class SolrAuthEacCpf extends SolrAuthDefault
     {
         $result = [];
         $record = $this->getXmlRecord();
-        if (isset($record->cpfDescription->description->occupations->occupation)) {
+        if (isset($record->cpfDescription->description->occupations)) {
             $languages = $this->mapLanguageCode($this->getLocale());
-            foreach ($record->cpfDescription->description->occupations->occupation
-                as $occupation
+            foreach ($record->cpfDescription->description->occupations
+                as $occupations
             ) {
-                if (!isset($occupation->term)) {
+                if (!isset($occupations->occupation)) {
                     continue;
                 }
-                $term = $occupation->term;
-                $attr = $term->attributes();
-                if ($attr->lang && in_array((string)$attr->lang, $languages)
-                ) {
-                    $result[] = (string)$term;
+                foreach ($occupations->occupation as $occupation) {
+                    if (!isset($occupation->term)) {
+                        continue;
+                    }
+                    $term = $occupation->term;
+                    $attr = $term->attributes();
+                    if ($attr->lang && in_array((string)$attr->lang, $languages)
+                    ) {
+                        $result[] = (string)$term;
+                    }
                 }
             }
         }

--- a/module/Finna/src/Finna/RecordDriver/SolrAuthEaccpf.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrAuthEaccpf.php
@@ -173,7 +173,6 @@ class SolrAuthEacCpf extends SolrAuthDefault
         return $result ?: $this->_getOccupations();
     }
 
-
     /**
      * Set preferred language for display strings.
      *

--- a/module/Finna/src/Finna/RecordDriver/SolrAuthEaccpf.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrAuthEaccpf.php
@@ -155,7 +155,6 @@ class SolrAuthEacCpf extends SolrAuthDefault
         $result = [];
         $record = $this->getXmlRecord();
         if (isset($record->cpfDescription->description->occupations)) {
-            $result = [];
             $languages = $this->mapLanguageCode($this->getLocale());
             foreach ($record->cpfDescription->description->occupations->occupation
                 as $occupation


### PR DESCRIPTION
Ammattien näyttäminen käyttäjän kielivalinnan mukaan.

Esimerkki metadatasta:
http://finna-dev-fe.csc.fi/edge2/AuthorityRecord/ahaa-eac.EAC_2326071819

```
<occupations>
  <occupation>
    <term vocabularySource="http://urn.fi/URN:NBN:fi:au:mts:m2418" lang="eng">farmer</term>
  </occupation>
  <occupation>
    <term vocabularySource="http://urn.fi/URN:NBN:fi:au:mts:m2418" lang="fin">maanviljelij&#xE4;</term>
  </occupation>
  <occupation>
    <term vocabularySource="http://urn.fi/URN:NBN:fi:au:mts:m2418" lang="swe">jordbrukare</term>
  </occupation>
</occupations>
```