### PR TITLE
[ALLI-6993] EACCPF: show alternative name forms

### DIFF
--- a/module/Finna/src/Finna/RecordDriver/SolrAuthEaccpf.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrAuthEaccpf.php
@@ -70,7 +70,7 @@ class SolrAuthEacCpf extends SolrAuthDefault
             foreach ($name->part ?? [] as $part) {
                 $localType = (string)$part->attributes()->localType;
                 if ($localType === 'http://rdaregistry.info/Elements/a/P50103') {
-                    $titles[] = ['data' => $part[0]];
+                    $titles[] = ['data' => (string)$part];
                 }
             }
         }

--- a/module/Finna/src/Finna/RecordDriver/SolrAuthEaccpf.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrAuthEaccpf.php
@@ -67,7 +67,12 @@ class SolrAuthEacCpf extends SolrAuthDefault
         $titles = [];
         $path = 'cpfDescription/identity/nameEntryParallel/nameEntry';
         foreach ($this->getXmlRecord()->xpath($path) as $name) {
-            $titles[] = $name->part[0];
+            foreach ($name->part ?? [] as $part) {
+                $localType = (string)$part->attributes()->localType;
+                if ($localType === 'http://rdaregistry.info/Elements/a/P50103') {
+                    $titles[] = ['data' => $part[0]];
+                }
+            }
         }
         return $titles;
     }


### PR DESCRIPTION
Esimerkki:
http://finna-dev-fe.csc.fi/edge2/AuthorityRecord/ahaa-eac.EAC_592319341#details

```
 <nameEntryParallel>
        <useDates>
          <dateRange>
            <fromDate>unknown</fromDate>
            <toDate>open</toDate>
          </dateRange>
        </useDates>
        <nameEntry lang="fin">
          <part localType="http://rdaregistry.info/Elements/a/P50103">MC Testitapaus</part>
          <part localType="TONI1">MC Testitapaus</part>
        </nameEntry>
      </nameEntryParallel>
```
