### PR TITLE
[ALLI-6996] EAD3: filter displayed unitids

### DIFF
--- a/module/Finna/src/Finna/RecordDriver/SolrEad3.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrEad3.php
@@ -120,6 +120,12 @@ class SolrEad3 extends SolrEad
     // Relator attribute for archive origination
     const RELATOR_ARCHIVE_ORIGINATION = 'Arkistonmuodostaja';
 
+    // unitid is shown when label-attribute is missing or is one of:
+    const UNIT_IDS = [
+        'Tekninen', 'Analoginen', 'Vanha analoginen', 'Vanha tekninen',
+        'Diaarinumero', 'Asiaryhmän numero'
+    ];
+
     /**
      * Get the institutions holding the record.
      *
@@ -448,6 +454,9 @@ class SolrEad3 extends SolrEad
         $manyIds = count($xml->did->unitid) > 1;
         foreach ($xml->did->unitid as $id) {
             $label = $fallbackDisplayLabel = (string)$id->attributes()->label;
+            if ($label && !in_array($label, self::UNIT_IDS)) {
+                continue;
+            }
             $displayLabel = null;
             if ($label) {
                 $displayLabel = "Unit ID:$label";


### PR DESCRIPTION
Tämä vaikuttaa vain AHAAseen koska Yksa ja FSD eivät käytä label-attribuuttia.

Esim:
http://finna-dev-fe.csc.fi/edge2/Record/ahaa-ng.2496713561_2498887534#details
http://finna-dev-fe.csc.fi/edge2/Record/ta_yksa.136997003095300_160630100170500
https://finna.fi/Record/fsd.FSD_FSD1140#details
 