### PR TITLE
EACCPF: handle missing title

### DIFF
--- a/module/Finna/src/Finna/RecordDriver/SolrAuthEaccpf.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrAuthEaccpf.php
@@ -51,15 +51,27 @@ class SolrAuthEacCpf extends SolrAuthDefault
      */
     public function getTitle()
     {
+        $firstTitle = null;
         $record = $this->getXmlRecord();
-        if (isset($record->cpfDescription->identity->nameEntry->part)) {
-            foreach ($record->cpfDescription->identity->nameEntry->part as $part) {
+        if (isset($record->cpfDescription->identity->nameEntry)) {
+            $languages = $this->mapLanguageCode($this->getLocale());
+            $name = $record->cpfDescription->identity->nameEntry;
+            if (!isset($name->part)) {
+                return '';
+            }
+            $lang = (string)$name->attributes()->lang;
+            foreach ($name->part as $part) {
                 if ($title = (string)$part) {
-                    return $title;
+                    if (!$firstTitle) {
+                        $firstTitle = $title;
+                    }
+                    if ($lang && in_array($lang, $languages)) {
+                        return $title;
+                    }
                 }
             }
         }
-        return '';
+        return $firstTitle ?? '';
     }
 
     /**

--- a/module/Finna/src/Finna/RecordDriver/SolrAuthEaccpf.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrAuthEaccpf.php
@@ -51,7 +51,7 @@ class SolrAuthEacCpf extends SolrAuthDefault
      */
     public function getTitle()
     {
-        $firstTitle = null;
+        $firstTitle = '';
         $record = $this->getXmlRecord();
         if (isset($record->cpfDescription->identity->nameEntry)) {
             $languages = $this->mapLanguageCode($this->getLocale());
@@ -71,7 +71,7 @@ class SolrAuthEacCpf extends SolrAuthDefault
                 }
             }
         }
-        return $firstTitle ?? '';
+        return $firstTitle;
     }
 
     /**

--- a/module/Finna/src/Finna/RecordDriver/SolrAuthEaccpf.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrAuthEaccpf.php
@@ -47,14 +47,19 @@ class SolrAuthEacCpf extends SolrAuthDefault
     /**
      * Get authority title
      *
-     * @return string|null
+     * @return string
      */
     public function getTitle()
     {
         $record = $this->getXmlRecord();
-        return isset($record->cpfDescription->identity->nameEntry->part[0])
-            ? (string)$record->cpfDescription->identity->nameEntry->part[0]
-            : null;
+        if (isset($record->cpfDescription->identity->nameEntry->part)) {
+            foreach ($record->cpfDescription->identity->nameEntry->part as $part) {
+                if ($title = (string)$part) {
+                    return $title;
+                }
+            }
+        }
+        return '';
     }
 
     /**


### PR DESCRIPTION
Tarkistetaan onko nameEntry->part tyhjä. Lisäksi käytetään kielivalinnan mukaista nameEntryä jos sellainen löytyy.
getTitlen paluuarvo muutettu stringiksi (vastaa VuFindin SolrAuthDefaultia) niin että puuttuva title ei kaada metatagien asettamista. 

Esim: http://finna-dev-fe.csc.fi/edge2/AuthorityRecord/ahaa-eac.EAC_1593759990#details