### PR TITLE
[ALLI-6956] EAD3: display all originations

### DIFF
--- a/module/Finna/src/Finna/RecordDriver/SolrEad3.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrEad3.php
@@ -254,7 +254,7 @@ class SolrEad3 extends SolrEad
 
         $localeResults = $results = [];
 
-        foreach ($record->did->origination as $origination) {
+        foreach ($record->did->origination ?? [] as $origination) {
             $originationLocaleResults = $originationResults = [];
             foreach ($origination->name ?? [] as $name) {
                 $attr = $name->attributes();

--- a/module/Finna/src/Finna/RecordDriver/SolrEad3.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrEad3.php
@@ -120,6 +120,9 @@ class SolrEad3 extends SolrEad
     // Relator attribute for archive origination
     const RELATOR_ARCHIVE_ORIGINATION = 'Arkistonmuodostaja';
 
+    const RELATOR_TIME_INTERVAL = 'suhteen ajallinen kattavuus';
+    const RELATOR_UNKNOWN_TIME_INTERVAL = 'unknown - open';
+
     // unitid is shown when label-attribute is missing or is one of:
     const UNIT_IDS = [
         'Tekninen', 'Analoginen', 'Vanha analoginen', 'Vanha tekninen',
@@ -217,12 +220,28 @@ class SolrEad3 extends SolrEad
     /**
      * Get origination
      *
-     * @return string
+     * @return string|null
      */
-    public function getOrigination()
+    public function getOrigination() : ?string
     {
-        if ($origination = $this->getOriginationExtended()) {
-            return $origination['name'];
+        $originations = $this->getOriginations();
+        return $originations[0] ?? null;;
+    }
+
+    /**
+     * Get all originations
+     *
+     * @return array|null
+     */
+    public function getOriginations() : ?array
+    {
+        if ($originations = $this->getOriginationExtended()) {
+            return array_map(
+                function ($origination) {
+                    return $origination['name'];
+                },
+                $originations
+            );
         }
         return null;
     }
@@ -230,11 +249,56 @@ class SolrEad3 extends SolrEad
     /**
      * Get extended origination info
      *
-     * @return array
+     * @return array|null
      */
-    public function getOriginationExtended()
+    public function getOriginationExtended() : ?array
     {
         $record = $this->getXmlRecord();
+
+        $localeResults = $results = [];
+
+        foreach ($record->did->origination as $origination) {
+            $originationLocaleResults = $originationResults = [];
+            foreach ($origination->name ?? [] as $name) {
+                $attr = $name->attributes();
+                if (self::RELATOR_ARCHIVE_ORIGINATION === (string)$attr->relator
+                ) {
+                    $id = (string)$attr->identifier;
+                    $currentName = null;
+                    $names = $name->part ?? [];
+                    for ($i=0; $i<count($names); $i++) {
+                        $name = $names[$i];
+                        $attr = $name->attributes();
+                        $value = (string)$name;
+                        $localType = (string)$attr->localtype;
+                        $data = ['id' => $id, 'name' => $value];
+                        if ($localType !== self::RELATOR_TIME_INTERVAL) {
+                            if ($nextEl = $names[$i+1] ?? null) {
+                                if ((string)$nextEl->attributes()->localtype === self::RELATOR_TIME_INTERVAL) {
+                                    // Pick relation time interval from next part-element
+                                    $date = (string)$nextEl;
+                                    if ($date !== self::RELATOR_UNKNOWN_TIME_INTERVAL) {
+                                        $data['date'] = $date;
+                                    }
+                                    $i++;
+                                }
+                            }
+                        }
+                        $lang = $this->detectNodeLanguage($name);
+                        if ($lang['preferred']) {
+                            $originationLocaleResults[$value] = $data;
+                        }
+                        if ($lang['default']) {
+                            $originationResults[$value] = $data;
+                        }
+                    }
+                }
+            }
+            $localeResults = array_merge(
+                $localeResults, $originationLocaleResults ?: $originationResults
+            );
+            $results = array_merge($results, $originationResults);
+        }
 
         foreach ($record->relations->relation ?? [] as $relation) {
             $attr = $relation->attributes();
@@ -248,22 +312,20 @@ class SolrEad3 extends SolrEad
             ) {
                 continue;
             }
-            if ($name = $this->getDisplayLabel($relation, 'relationentry')) {
-                $id = (string)$attr->href;
-                return ['name' => $name[0], 'id' => $id];
+            $id = (string)$attr->href;
+            if ($name = $this->getDisplayLabel($relation, 'relationentry', true)) {
+                if (!isset($localeResults[$name[0]])) {
+                    $localeResults[$name[0]] = ['id' => $id, 'name' => $name[0]];
+                }
             }
-        }
-        foreach ($record->did->origination->name ?? [] as $name) {
-            $attr = $name->attributes();
-            if (self::RELATOR_ARCHIVE_ORIGINATION === (string)$attr->relator
-            ) {
-                if ($name = $this->getDisplayLabel($name)) {
-                    $id = (string)$attr->identifier;
-                    return ['name' => $name[0], 'id' => $id];
+            if ($name = $this->getDisplayLabel($relation, 'relationentry')) {
+                if (!isset($allResults[$name[0]])) {
+                    $allResults[$name[0]] = ['id' => $id, 'name' => $name[0]];
                 }
             }
         }
-        return null;
+
+        return array_values($localeResults ?: $results) ?: null;
     }
 
     /**

--- a/module/Finna/src/Finna/RecordDriver/SolrEad3.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrEad3.php
@@ -274,10 +274,14 @@ class SolrEad3 extends SolrEad
                         $data = ['id' => $id, 'name' => $value];
                         if ($localType !== self::RELATOR_TIME_INTERVAL) {
                             if ($nextEl = $names[$i+1] ?? null) {
-                                if ((string)$nextEl->attributes()->localtype === self::RELATOR_TIME_INTERVAL) {
-                                    // Pick relation time interval from next part-element
+                                $localType
+                                    = (string)$nextEl->attributes()->localtype;
+                                if ($localType === self::RELATOR_TIME_INTERVAL) {
+                                    // Pick relation time interval from
+                                    // next part-element
                                     $date = (string)$nextEl;
-                                    if ($date !== self::RELATOR_UNKNOWN_TIME_INTERVAL) {
+                                    if ($date !==self::RELATOR_UNKNOWN_TIME_INTERVAL
+                                    ) {
                                         $data['date'] = $date;
                                     }
                                     $i++;

--- a/module/Finna/src/Finna/RecordDriver/SolrEad3.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrEad3.php
@@ -225,7 +225,7 @@ class SolrEad3 extends SolrEad
     public function getOrigination() : ?string
     {
         $originations = $this->getOriginations();
-        return $originations[0] ?? null;;
+        return $originations[0] ?? null;
     }
 
     /**
@@ -266,21 +266,21 @@ class SolrEad3 extends SolrEad
                     $id = (string)$attr->identifier;
                     $currentName = null;
                     $names = $name->part ?? [];
-                    for ($i=0; $i<count($names); $i++) {
+                    for ($i=0; $i < count($names); $i++) {
                         $name = $names[$i];
                         $attr = $name->attributes();
                         $value = (string)$name;
                         $localType = (string)$attr->localtype;
                         $data = ['id' => $id, 'name' => $value];
                         if ($localType !== self::RELATOR_TIME_INTERVAL) {
-                            if ($nextEl = $names[$i+1] ?? null) {
+                            if ($nextEl = $names[$i + 1] ?? null) {
                                 $localType
                                     = (string)$nextEl->attributes()->localtype;
                                 if ($localType === self::RELATOR_TIME_INTERVAL) {
                                     // Pick relation time interval from
                                     // next part-element
                                     $date = (string)$nextEl;
-                                    if ($date !==self::RELATOR_UNKNOWN_TIME_INTERVAL
+                                    if ($date !== self::RELATOR_UNKNOWN_TIME_INTERVAL
                                     ) {
                                         $data['date'] = $date;
                                     }

--- a/module/Finna/src/Finna/RecordDriver/SolrEad3.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrEad3.php
@@ -220,38 +220,35 @@ class SolrEad3 extends SolrEad
     /**
      * Get origination
      *
-     * @return string|null
+     * @return string
      */
-    public function getOrigination() : ?string
+    public function getOrigination() : string
     {
         $originations = $this->getOriginations();
-        return $originations[0] ?? null;
+        return $originations[0] ?? '';
     }
 
     /**
      * Get all originations
      *
-     * @return array|null
+     * @return array
      */
-    public function getOriginations() : ?array
+    public function getOriginations() : array
     {
-        if ($originations = $this->getOriginationExtended()) {
-            return array_map(
-                function ($origination) {
-                    return $origination['name'];
-                },
-                $originations
-            );
-        }
-        return null;
+        return array_map(
+            function ($origination) {
+                return $origination['name'];
+            },
+            $this->getOriginationExtended()
+        );
     }
 
     /**
      * Get extended origination info
      *
-     * @return array|null
+     * @return array
      */
-    public function getOriginationExtended() : ?array
+    public function getOriginationExtended() : array
     {
         $record = $this->getXmlRecord();
 
@@ -329,7 +326,7 @@ class SolrEad3 extends SolrEad
             }
         }
 
-        return array_values($localeResults ?: $results) ?: null;
+        return array_values($localeResults ?: $results);
     }
 
     /**

--- a/themes/finna2/templates/RecordDriver/DefaultRecord/data-origination.phtml
+++ b/themes/finna2/templates/RecordDriver/DefaultRecord/data-origination.phtml
@@ -1,2 +1,5 @@
 <?php $originationExt = $this->driver->tryMethod('getOriginationExtended'); //Don't add START and END comments ?>
-<?=$this->record($this->driver)->getAuthorityLinkElement('author', $originationExt ? $originationExt['name'] : $data, $originationExt ?? ['name' => $data], ['showInlineInfo' => true, 'authorityType' => $author['type'] ?? null])?>
+<?php foreach ($originationExt ?? [['name' => $data]] as $idx => $origination): ?>
+  <?=$idx > 0 ? '<br/>' : ''?>
+  <?=$this->record($this->driver)->getAuthorityLinkElement('author', $origination['name'], $origination, ['showInlineInfo' => true, 'authorityType' => $author['type'] ?? null, 'date' => true])?>
+<?php endforeach; ?>

--- a/themes/finna2/templates/RecordDriver/SolrEad/result-condensed.phtml
+++ b/themes/finna2/templates/RecordDriver/SolrEad/result-condensed.phtml
@@ -73,8 +73,8 @@
       <div class="result-body">
         <?php if ($originations = $this->driver->tryMethod('getOriginations', [], $this->driver->getOrigination())): $originations = (array)$originations; ?>
             <span class="archive-label"><?=$this->transEsc('Archive Origination')?>:</span>
-            <?php $originationCount = count($originations); foreach ($originations as $i => $origination): ?>
-            <a href="<?=$this->url('search-results')?>?lookfor=%22<?=urlencode($origination)?>%22&amp;type=Author"><?=$this->escapeHtml($origination)?></a><?=$i + 1 < $originationCount ? ' ; ' : ''?>
+            <?php foreach ($originations as $i => $origination): ?>
+              <?=$i > 0 ? ' ; ' : ''?><a href="<?=$this->url('search-results')?>?lookfor=%22<?=urlencode($origination)?>%22&amp;type=Author"><?=$this->escapeHtml($origination)?></a>
             <?php endforeach; ?>
             <br/>
           <?php endif; ?>

--- a/themes/finna2/templates/RecordDriver/SolrEad/result-condensed.phtml
+++ b/themes/finna2/templates/RecordDriver/SolrEad/result-condensed.phtml
@@ -74,7 +74,7 @@
         <?php if ($originations = $this->driver->tryMethod('getOriginations', [], $this->driver->getOrigination())): $originations = (array)$originations; ?>
             <span class="archive-label"><?=$this->transEsc('Archive Origination')?>:</span>
             <?php foreach ($originations as $i => $origination): ?>
-              <?=$i > 0 ? ' ; ' : ''?><a href="<?=$this->url('search-results')?>?lookfor=%22<?=urlencode($origination)?>%22&amp;type=Author"><?=$this->escapeHtml($origination)?></a>
+              <?=$i > 0 ? ' ; ' : ''?><a href="<?=$this->escapeHtmlAttr($this->url('search-results', [], ['query' => ['lookfor' => $origination, 'type' => 'Author']]))?>"><?=$this->escapeHtml($origination)?></a>
             <?php endforeach; ?>
             <br/>
           <?php endif; ?>

--- a/themes/finna2/templates/RecordDriver/SolrEad/result-condensed.phtml
+++ b/themes/finna2/templates/RecordDriver/SolrEad/result-condensed.phtml
@@ -71,9 +71,11 @@
     <?php endif; ?>
     <div class="media-body">
       <div class="result-body">
-        <?php if ($origination = $this->driver->getOrigination()): ?>
+        <?php if ($originations = $this->driver->tryMethod('getOriginations', [], $this->driver->getOrigination())): $originations = (array)$originations; ?>
             <span class="archive-label"><?=$this->transEsc('Archive Origination')?>:</span>
-            <a href="<?=$this->url('search-results')?>?lookfor=%22<?=urlencode($origination)?>%22&amp;type=Author"><?=$this->escapeHtml($origination)?></a>
+            <?php $originationCount = count($originations); foreach ($originations as $i => $origination): ?>
+            <a href="<?=$this->url('search-results')?>?lookfor=%22<?=urlencode($origination)?>%22&amp;type=Author"><?=$this->escapeHtml($origination)?></a><?=$i + 1 < $originationCount ? ' ; ' : ''?>
+            <?php endforeach; ?>
             <br/>
           <?php endif; ?>
           <?php if (!($fondsOrCollection = in_array('Document/ArchiveFonds', $this->driver->getFormats()) || in_array('Document/ArchiveCollection', $this->driver->getFormats()))): ?>

--- a/themes/finna2/templates/RecordDriver/SolrEad/result-email.phtml
+++ b/themes/finna2/templates/RecordDriver/SolrEad/result-email.phtml
@@ -13,8 +13,8 @@
 <?= $this->translate('Title'); ?>: <?= !empty($title) ? $title : $this->translate('Title not available'); ?>
 <?php if (!$this->translationEmpty('Archive Repository')): ?><?= $this->transEsc('Archive Repository')?>:<?php endif; ?>
 <?= PHP_EOL . $this->escapeHtml($this->organisationDisplayName($this->driver)) ?>
-<?php if ($origination = $this->driver->getOrigination()): ?>
-<?= PHP_EOL . $this->transEsc('Archive Origination')?>: <?=$this->escapeHtml($origination)?>
+<?php if ($originations = $this->driver->trymethod('getOriginations', [], $this->driver->getOrigination())): ?>
+<?= PHP_EOL . $this->transEsc('Archive Origination')?>: <?=implode(', ', array_map($this->escapeHtml, (array)$originations))?>
 <?php endif; ?>
 <?php if (!($fondsOrCollection = in_array('Document/ArchiveFonds', $formats) || in_array('Document/ArchiveCollection', $formats))): ?>
   <?php if ($this->driver->isPartOfArchiveSeries()): ?>

--- a/themes/finna2/templates/RecordDriver/SolrEad/result-list.phtml
+++ b/themes/finna2/templates/RecordDriver/SolrEad/result-list.phtml
@@ -58,7 +58,7 @@ if ($img):
             <?php $originations = $this->driver->tryMethod('getOriginations', [], $this->driver->getOrigination()); if ($originations): ?>
                 <br/><span class="archive-label"><?=$this->transEsc('Archive Origination')?>:</span>
               <?php $originations = (array)$originations; foreach ($originations as $i => $origination): ?>
-                <?=$i > 0 ? ' ; ' : ''?><a href="<?=$this->url('search-results')?>?lookfor=%22<?=urlencode($origination)?>%22&amp;type=Author"><?=$this->escapeHtml($origination)?></a>
+                <?=$i > 0 ? ' ; ' : ''?><a href="<?=$this->escapeHtmlAttr($this->url('search-results', [], ['query' => ['lookfor' => $origination, 'type' => 'Author']]))?>"><?=$this->escapeHtml($origination)?></a>
               <?php endforeach; ?>
             <?php endif; ?>
             <?php if (!($fondsOrCollection = in_array('Document/ArchiveFonds', $this->driver->getFormats()) || in_array('Document/ArchiveCollection', $this->driver->getFormats()))): ?>

--- a/themes/finna2/templates/RecordDriver/SolrEad/result-list.phtml
+++ b/themes/finna2/templates/RecordDriver/SolrEad/result-list.phtml
@@ -55,9 +55,11 @@ if ($img):
             <?php // The funky comparison below is due to Laminas translator not supporting empty values (see ExtendedIniReader) ?>
             <?php if (!$this->translationEmpty('Archive Repository')): ?><span class="small"><?=$this->transEsc('Archive Repository')?>:</span><?php endif; ?>
             <?=$this->escapeHtml($this->organisationDisplayName($this->driver)) ?>
-            <?php if ($origination = $this->driver->getOrigination()): ?>
-              <br/><span class="archive-label"><?=$this->transEsc('Archive Origination')?>:</span>
-              <a href="<?=$this->url('search-results')?>?lookfor=%22<?=urlencode($origination)?>%22&amp;type=Author"><?=$this->escapeHtml($origination)?></a>
+            <?php $originations = $this->driver->tryMethod('getOriginations', [], $this->driver->getOrigination()); if ($originations): ?>
+                <br/><span class="archive-label"><?=$this->transEsc('Archive Origination')?>:</span>
+              <?php $originations = (array)$originations; $originationCount = count($originations); foreach ($originations as $i => $origination): ?>
+                <a href="<?=$this->url('search-results')?>?lookfor=%22<?=urlencode($origination)?>%22&amp;type=Author"><?=$this->escapeHtml($origination)?></a><?=$i + 1 < $originationCount ? ' ; ' : ''?>
+              <?php endforeach; ?>
             <?php endif; ?>
             <?php if (!($fondsOrCollection = in_array('Document/ArchiveFonds', $this->driver->getFormats()) || in_array('Document/ArchiveCollection', $this->driver->getFormats()))): ?>
               <?php $parentSource = $this->driver->getSourceIdentifier(); ?>

--- a/themes/finna2/templates/RecordDriver/SolrEad/result-list.phtml
+++ b/themes/finna2/templates/RecordDriver/SolrEad/result-list.phtml
@@ -57,8 +57,8 @@ if ($img):
             <?=$this->escapeHtml($this->organisationDisplayName($this->driver)) ?>
             <?php $originations = $this->driver->tryMethod('getOriginations', [], $this->driver->getOrigination()); if ($originations): ?>
                 <br/><span class="archive-label"><?=$this->transEsc('Archive Origination')?>:</span>
-              <?php $originations = (array)$originations; $originationCount = count($originations); foreach ($originations as $i => $origination): ?>
-                <a href="<?=$this->url('search-results')?>?lookfor=%22<?=urlencode($origination)?>%22&amp;type=Author"><?=$this->escapeHtml($origination)?></a><?=$i + 1 < $originationCount ? ' ; ' : ''?>
+              <?php $originations = (array)$originations; foreach ($originations as $i => $origination): ?>
+                <?=$i > 0 ? ' ; ' : ''?><a href="<?=$this->url('search-results')?>?lookfor=%22<?=urlencode($origination)?>%22&amp;type=Author"><?=$this->escapeHtml($origination)?></a>
               <?php endforeach; ?>
             <?php endif; ?>
             <?php if (!($fondsOrCollection = in_array('Document/ArchiveFonds', $this->driver->getFormats()) || in_array('Document/ArchiveCollection', $this->driver->getFormats()))): ?>


### PR DESCRIPTION
Listataan kaikki arkistonmuodostajat. 
AHAAn origination-elementit erotellaan localtype-attribuutin mukaan nimiin ja aikatietoihin. 

http://finna-dev-fe.csc.fi/edge2/Record/ahaa-ng.851133713?_=1621255999868&lng=fi

```
<origination>
      <name localtype="http://www.rdaregistry.info/Elements/u/#P60672" relator="Arkistonmuodostaja" identifier="EAC_592905922">
        <part localtype="Ensisijainen nimi" lang="fin">Tapanilat (suku)</part>
        <part localtype="suhteen ajallinen kattavuus">unknown - open</part>
      </name>
    </origination>
    <origination>
      <name localtype="http://www.rdaregistry.info/Elements/u/#P60672" relator="Arkistonmuodostaja" identifier="EAC_851133747">
        <part localtype="Ensisijainen nimi" lang="fin">Finnatestin organisaatio</part>
        <part localtype="suhteen ajallinen kattavuus">unknown - open</part>
        <part localtype="Varianttinimi" lang="swe">Finnatest organisation</part>
        <part localtype="suhteen ajallinen kattavuus">unknown - open</part>
        <part localtype="Aikaisempi nimi" lang="fin">Finnatestin testiorganisaatio</part>
        <part localtype="suhteen ajallinen kattavuus">unknown - open</part>
      </name>
    </origination>
  </did>
``'