### PR TITLE
[ALLI-6971] Extend Subject search use ID's.

### DIFF
--- a/local/config/finna/config.ini.sample
+++ b/local/config/finna/config.ini.sample
@@ -1678,8 +1678,9 @@ url = "https://my.surveypal.com/Finnasurvey"
 
 ; Whether to change author-search links to authority-links.
 ; The link type is one of:
-;   - author  links to the authority page
-;   - search  performs a search filtered by authority ID
+;   - author         links to the authority page
+;   - search         performs a search filtered by authority ID
+;   - search-subject performs an OR search by topic_id_str_mv and topic
 ; authority_links[*] can be used to set the link type for all authority types.
 ; The global setting can be overridden with authority type specific settings
 ; (author or subject), for example: authority_links[author] = page

--- a/local/languages/finna/en-gb.ini
+++ b/local/languages/finna/en-gb.ini
@@ -2030,6 +2030,7 @@ age_rating_18 = "Not for persons under 18"
 Family Name = "Family"
 Personal Name = "Person"
 Corporate Name = "Community"
+Unknown Name = "Unknown"
 
 ; Record label tooltips
 record_label_tooltip_R2_restricted_metadata_available_html = "<h4>Contains protected metadata</h4><p>The material contains protected metadata. <a href="%%register%%" data-lightbox>Login to the Reading Room</a> for access."

--- a/local/languages/finna/fi.ini
+++ b/local/languages/finna/fi.ini
@@ -2017,7 +2017,7 @@ age_rating_18 = "Kielletty alle 18-vuotiailta"
 Family Name = "Suku"
 Personal Name = "Henkilö"
 Corporate Name = "Yhteisö"
-
+Unknown Name = "Tuntematon"
 
 ; Record label tooltips
 record_label_tooltip_R2_restricted_metadata_available_html = "<h4>Sisältää pääsyrajoitettuja henkilötietoja</h4><p>Aineistotiedot sisältävät pääsyrajoitettua tietoa. <a href="%%register%%" data-lightbox>Kirjaudu Tutkijasaliin</a> saadaksesi pääsyn. <a href="%%terms%%" data-lightbox>Aineistotiedon käyttöehdot</a></p>"

--- a/local/languages/finna/sv.ini
+++ b/local/languages/finna/sv.ini
@@ -1998,6 +1998,7 @@ age_rating_18 = "Förbjudet under 18 år"
 Family Name = "Släkt"
 Personal Name = "Person"
 Corporate Name = "Organisation"
+Unknown Name = "Okänd"
 
 ; Record label tooltips
 record_label_tooltip_R2_restricted_metadata_available_html = "<h4>Innehåller dataskyddade materialuppgifter</h4><p>Materialet innehåller dataskyddade materialuppgifter. <a href="%%register%%" data-lightbox>Logga in i forskarsalen</a> för att få åtkomst."

--- a/module/Finna/src/Finna/RecordDriver/FinnaRecordTrait.php
+++ b/module/Finna/src/Finna/RecordDriver/FinnaRecordTrait.php
@@ -301,6 +301,11 @@ trait FinnaRecordTrait
      */
     public function getAuthorityId($id, $type = '*')
     {
+        if (preg_match('/^https?:/', $id)) {
+            // Never prefix http(s) url's
+            return $id;
+        }
+
         if (!$this->datasourceSettings || !is_callable([$this, 'getDatasource'])) {
             return $id;
         }

--- a/module/Finna/src/Finna/RecordDriver/SolrEad3.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrEad3.php
@@ -1062,10 +1062,10 @@ class SolrEad3 extends SolrEad
                 ];
                 if ($id = $i['id'] ?? '') {
                     $data['id'] = $id;
-                    // Categorize non-URI ID's as Personal Names, since the
+                    // Categorize non-URI ID's as Unknown Names, since the
                     // actual authority format can not be determined from metadata.
                     $data['authType'] = preg_match('/^https?:/', $id)
-                        ? null : 'Personal Name';
+                        ? null : 'Unknown Name';
                 }
             } else {
                 return [$i['data']];

--- a/module/Finna/src/Finna/RecordDriver/SolrEad3.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrEad3.php
@@ -1008,6 +1008,17 @@ class SolrEad3 extends SolrEad
     }
 
     /**
+     * Get all subject headings associated with this record with extended data.
+     * (see getAllSubjectHeadings).
+     *
+     * @return array
+     */
+    public function getAllSubjectHeadingsExtended()
+    {
+        return $this->getAllSubjectHeadings(true);
+    }
+
+    /**
      * Get all subject headings associated with this record.  Each heading is
      * returned as an array of chunks, increasing from least specific to most
      * specific.
@@ -1027,9 +1038,15 @@ class SolrEad3 extends SolrEad
 
         // geographic names are returned in getRelatedPlacesExtended
         foreach (['genre', 'era'] as $field) {
-            if (isset($this->fields[$field])) {
-                $headings = array_merge($headings, $this->fields[$field]);
-            }
+            $headings = array_merge(
+                $headings,
+                array_map(
+                    function ($term) {
+                        return ['data' => $term];
+                    },
+                    $this->fields[$field] ?? []
+                )
+            );
         }
 
         // The default index schema doesn't currently store subject headings in a
@@ -1037,11 +1054,25 @@ class SolrEad3 extends SolrEad
         // Other record drivers (i.e. SolrMarc) can offer this data in a more
         // granular format.
         $callback = function ($i) use ($extended) {
-            return $extended
-                ? ['heading' => [$i], 'type' => '', 'source' => '']
-                : [$i];
+            if ($extended) {
+                $data = [
+                    'heading' => [$i['data']],
+                    'type' => 'topic',
+                    'source' => $i['source'] ?? ''
+                ];
+                if ($id = $i['id'] ?? '') {
+                    $data['id'] = $id;
+                    // Categorize non-URI ID's as Personal Names, since the
+                    // actual authority format can not be determined from metadata.
+                    $data['authType'] = preg_match('/^https?:/', $id)
+                        ? null : 'Personal Name';
+                }
+            } else {
+                return [$i['data']];
+            }
+            return $data;
         };
-        return array_map($callback, array_unique($headings));
+        return array_map($callback, $headings);
     }
 
     /**
@@ -1479,9 +1510,9 @@ class SolrEad3 extends SolrEad
     /**
      * Get topics.
      *
-     * @return string[]
+     * @return array
      */
-    protected function getTopics()
+    protected function getTopics() : array
     {
         $record = $this->getXmlRecord();
 
@@ -1489,6 +1520,7 @@ class SolrEad3 extends SolrEad
         if (isset($record->controlaccess->subject)) {
             foreach ([true, false] as $obeyPreferredLanguage) {
                 foreach ($record->controlaccess->subject as $subject) {
+                    $attr = $subject->attributes();
                     if (isset($subject->attributes()->relator)
                         && (string)$subject->attributes()->relator !== 'aihe'
                     ) {
@@ -1498,7 +1530,14 @@ class SolrEad3 extends SolrEad
                         $subject, 'part', $obeyPreferredLanguage
                     )
                     ) {
-                        $topics[] = $topic[0];
+                        if (!$topic[0]) {
+                            continue;
+                        }
+                        $topics[] = [
+                            'data' => $topic[0],
+                            'id' => (string)$attr->identifier,
+                            'source' => (string)$attr->source
+                        ];
                     }
                 }
                 if (!empty($topics)) {

--- a/module/Finna/src/Finna/Search/Solr/AuthorityHelper.php
+++ b/module/Finna/src/Finna/Search/Solr/AuthorityHelper.php
@@ -81,6 +81,14 @@ class AuthorityHelper
     const LINK_TYPE_SEARCH = 'search';
 
     /**
+     * Authority link type: search results filtered by topic_id_tr_mv (either
+     * an internal authority index id or external URI (YSO etc)).
+     *
+     * @var string
+     */
+    const LINK_TYPE_SEARCH_SUBJECT = 'search-subject';
+
+    /**
      * Record loader
      *
      * @var \VuFind\Record\Loader
@@ -332,7 +340,12 @@ class AuthorityHelper
             $setting = self::LINK_TYPE_SEARCH;
         }
         return
-            in_array($setting, [self::LINK_TYPE_PAGE, self::LINK_TYPE_SEARCH])
+            in_array(
+                $setting, [
+                    self::LINK_TYPE_PAGE, self::LINK_TYPE_SEARCH,
+                    self::LINK_TYPE_SEARCH_SUBJECT
+                ]
+            )
             ? $setting : null;
     }
 

--- a/module/Finna/src/Finna/View/Helper/Root/RecordDataFormatter.php
+++ b/module/Finna/src/Finna/View/Helper/Root/RecordDataFormatter.php
@@ -366,8 +366,8 @@ class RecordDataFormatter extends \VuFind\View\Helper\Root\RecordDataFormatter
             'Related Materials', 'Related Places', 'Scale', 'Secondary Authors',
             'Sound', 'Source of Acquisition', 'Standard Codes',
             'Studios', 'Subject Actor', 'Subject Date',
-            'Subject Detail', 'Subject Place', 'Subjects',
-            'subjects_extended', 'System Format', 'Terms of Use',
+            'Subject Detail', 'Subject Place', 'subjects_extended',
+            'System Format', 'Terms of Use',
             'Time Period', 'Time Period of Creation', 'Trade Availability Note',
             'Uncontrolled Title', 'Uniform Title', 'Unit IDs'
         ];

--- a/themes/finna2/less/global/finnaicons.less
+++ b/themes/finna2/less/global/finnaicons.less
@@ -492,6 +492,7 @@ table .iconlabel {
 .cc-nd-eu:before {
     content: "\e865";
 }
+.iconlabel.format-unknownname:before,
 .iconlabel.format-personalname:before {
     font-family: finnaicons;
     content: "\e922";
@@ -877,6 +878,7 @@ i.bigger {
 .fa-videodisc:before      {content:"\f109"} // .fa-laptop
 .fa-videoreel:before      {content:"\f03d"} // .fa-video-camera
 
+.fa-authority-unknownname:before,
 .fa-authority-personalname:before {
     font-family: finnaicons;
     content: "\e922";

--- a/themes/finna2/templates/RecordDriver/DefaultRecord/data-allSubjectHeadingsExtended.phtml
+++ b/themes/finna2/templates/RecordDriver/DefaultRecord/data-allSubjectHeadingsExtended.phtml
@@ -17,10 +17,16 @@
       ?>
       <?= $first ? '' : ' &#8594; '?>
       <?php $subject = trim($subject . ' ' . $subfield); ?>
-      <?php if ($authType && $authId): ?>
-        <?=$this->record($this->driver)->getAuthorityLinkElement('subject', $subfield, ['name' => $subject, 'id' => $authId], ['authorityType' => $authType, 'class' => ['backlink'], 'title' => $subfield])?>
+      <?php if ($authId && $authType && $this->record($this->driver)->isAuthorityEnabled()): ?>
+        <?php // Authority linking is enabled. Use Authority helper to render a link element, possibly together with inline authority info ?>
+        <?=$this->record($this->driver)->getAuthorityLinkElement('subject', $subfield, ['name' => $subject, 'id' => $authId], ['authorityType' => $authType, 'class' => ['backlink'], 'title' => $subfield, 'showInlineInfo' => true])?>
       <?php else: ?>
-        <a class="backlink" title="<?=$this->escapeHtmlAttr($subject)?>" href="<?=$this->record($this->driver)->getLink('subject', $subject)?>">
+        <?php // Authority linking is disabled. Use Record helper to render a subject or a subject-id search URL ?>
+        <?php
+          $linkType = $authId ? 'authority-search-subject' : 'subject';
+          $linkParams = $authId ? ['id' => $authId] : [];
+        ?>
+        <a class="backlink" title="<?=$this->escapeHtmlAttr($subject)?>" href="<?=$this->record($this->driver)->getLink($linkType, $subject, $linkParams)?>">
           <?=trim($this->escapeHtml($subfield))?>
         </a>
       <?php endif ?>

--- a/themes/finna2/templates/RecordDriver/DefaultRecord/link-authority-search-subject.phtml
+++ b/themes/finna2/templates/RecordDriver/DefaultRecord/link-authority-search-subject.phtml
@@ -1,2 +1,2 @@
 <?php // No ending line feed ?><?php $searchRoute = $this->searchOptions($this->driver->getSourceIdentifier())->getSearchAction(); ?>
-<?=$this->url($searchRoute, [], ['query' => ['lookfor' => sprintf('%s:("%s")^100000 OR topic:%s', \Finna\Search\Solr\AuthorityHelper::TOPIC_ID_FACET, $this->id, $this->lookfor)]])?>
+<?=$this->url($searchRoute, [], ['query' => ['lookfor' => sprintf('topic:%s OR %s:("%s")^100000', $this->lookfor, \Finna\Search\Solr\AuthorityHelper::TOPIC_ID_FACET, $this->id)]])?>

--- a/themes/finna2/templates/RecordDriver/DefaultRecord/link-authority-search-subject.phtml
+++ b/themes/finna2/templates/RecordDriver/DefaultRecord/link-authority-search-subject.phtml
@@ -1,0 +1,2 @@
+<?php // No ending line feed ?><?php $searchRoute = $this->searchOptions($this->driver->getSourceIdentifier())->getSearchAction(); ?>
+<?=$this->url($searchRoute, [], ['query' => ['lookfor' => sprintf('%s:("%s")^100000 OR topic:%s', \Finna\Search\Solr\AuthorityHelper::TOPIC_ID_FACET, $this->id, $this->lookfor)]])?>


### PR DESCRIPTION
Laajentaa Aiheet-tietuekentän hakulinkkeihin tuen tunnisteelle (auktoriteetti-indeksin tunniste tai ulkoinen URI).
Uusi haku on mallia `topic:<asiasana> OR topic_id_str_mv:<id>` ja se määritellään omassa templatessaan.

Haku yliajaa normaalin Subject-haun mikäli getAllSubjectHeadings palauttaa tunnisteen (Marc, EAD3). Kun toimija-linkitys on päällä, käytetään uutta topic-id hakua kun authority_links -asetuksen arvo on `search-subject`.

Mukana myös asiasana-tunnisteiden toteutus EAD3:lle. Osa näistä muutoksista on mukana aiemmassa PR:ssä (luultavasti konfliktoi) https://github.com/NatLibFi/NDL-VuFind2/pull/2017

Liittyy myös @aleksip n ontologia-taskiin: https://jira.kansalliskirjasto.fi/browse/ALLI-6901.

Esimerkkejä: 
- http://finna-dev-fe.csc.fi/edge2/Record/ahaa-ng.851133713_2348188453#details
- https://finna.fi/Record/fikka.3321098 
- https://finna.fi/Record/fikka.3961358

Pohdintaa:
- Hakulauseke jää ikävästi näkyviin hakulaatiikkoon. author2_id_str_mv -haussa on käytetty filteriä, mutta se ei ehkä toimi tässä painotuksen vuoksi? Uusi hakutyyppi tms?
- Edelliseen liittyen, pitäisikö kentän painotus siirtää asetuksiin niin voidaan muokata helposti?

