### PR TITLE
[ALLI-6768] EAD3: show origination name details.

### DIFF
--- a/module/Finna/src/Finna/RecordDriver/SolrEad3.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrEad3.php
@@ -274,46 +274,41 @@ class SolrEad3 extends SolrEad
             $originationLocaleResults = $originationResults = [];
             foreach ($origination->name ?? [] as $name) {
                 $attr = $name->attributes();
-                if (self::RELATOR_ARCHIVE_ORIGINATION === (string)$attr->relator
-                ) {
-                    $id = (string)$attr->identifier;
-                    $currentName = null;
-                    $names = $name->part ?? [];
-                    for ($i=0; $i < count($names); $i++) {
-                        $name = $names[$i];
-                        $attr = $name->attributes();
-                        $value = (string)$name;
-                        $localType = (string)$attr->localtype;
-                        $data = [
-                            'id' => $id, 'name' => $value, 'detail' => $localType
-                        ];
-                        if ($localType !== self::RELATOR_TIME_INTERVAL) {
-                            if ($nextEl = $names[$i + 1] ?? null) {
-                                $localType
-                                    = (string)$nextEl->attributes()->localtype;
-                                if ($localType === self::RELATOR_TIME_INTERVAL) {
-                                    // Pick relation time interval from
-                                    // next part-element
-                                    $date = (string)$nextEl;
-                                    if ($date !== self::RELATOR_UNKNOWN_TIME_INTERVAL
-                                    ) {
-                                        $data['date'] = $date;
-                                    }
-                                    $i++;
+                $id = (string)$attr->identifier;
+                $currentName = null;
+                $names = $name->part ?? [];
+                for ($i=0; $i < count($names); $i++) {
+                    $name = $names[$i];
+                    $attr = $name->attributes();
+                    $value = (string)$name;
+                    $localType = (string)$attr->localtype;
+                    $data = [
+                        'id' => $id, 'name' => $value, 'detail' => $localType
+                    ];
+                    if ($localType !== self::RELATOR_TIME_INTERVAL) {
+                        if ($nextEl = $names[$i + 1] ?? null) {
+                            $localType
+                                = (string)$nextEl->attributes()->localtype;
+                            if ($localType === self::RELATOR_TIME_INTERVAL) {
+                                // Pick relation time interval from
+                                // next part-element
+                                $date = (string)$nextEl;
+                                if ($date !== self::RELATOR_UNKNOWN_TIME_INTERVAL
+                                ) {
+                                    $data['date'] = $date;
                                 }
+                                $i++;
                             }
                         }
-                        $lang = $this->detectNodeLanguage($name);
-                        if ($lang['preferred']
-                            && !$searchNamesFn($data, $originationLocaleResults)
-                        ) {
-                            $originationLocaleResults[] = $data;
-                        }
-                        if ($lang['default']
-                            && !$searchNamesFn($data, $originationResults)
-                        ) {
-                            $originationResults[] = $data;
-                        }
+                    }
+                    $lang = $this->detectNodeLanguage($name);
+                    if ($lang['preferred']
+                        && !$searchNamesFn($data, $originationLocaleResults)
+                    ) {
+                        $originationLocaleResults[] = $data;
+                    }
+                    if (!$searchNamesFn($data, $originationResults)) {
+                        $originationResults[] = $data;
                     }
                 }
             }

--- a/module/Finna/src/Finna/RecordDriver/SolrEad3.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrEad3.php
@@ -256,6 +256,20 @@ class SolrEad3 extends SolrEad
 
         $localeResults = $results = [];
 
+        // For filtering out duplicate names
+        $searchNamesFn = function ($origination, $names) {
+            foreach ($names as $name) {
+                $detail1 = $origination['detail'] ?? null;
+                $detail2 = $name['detail'] ?? null;
+                if ($origination['name'] === $name['name']
+                    && ((!$detail1 || !$detail2) || ($detail1 === $detail2))
+                ) {
+                    return true;
+                }
+            }
+            return false;
+        };
+
         foreach ($record->did->origination ?? [] as $origination) {
             $originationLocaleResults = $originationResults = [];
             foreach ($origination->name ?? [] as $name) {
@@ -270,7 +284,9 @@ class SolrEad3 extends SolrEad
                         $attr = $name->attributes();
                         $value = (string)$name;
                         $localType = (string)$attr->localtype;
-                        $data = ['id' => $id, 'name' => $value];
+                        $data = [
+                            'id' => $id, 'name' => $value, 'detail' => $localType
+                        ];
                         if ($localType !== self::RELATOR_TIME_INTERVAL) {
                             if ($nextEl = $names[$i + 1] ?? null) {
                                 $localType
@@ -288,11 +304,15 @@ class SolrEad3 extends SolrEad
                             }
                         }
                         $lang = $this->detectNodeLanguage($name);
-                        if ($lang['preferred']) {
-                            $originationLocaleResults[$value] = $data;
+                        if ($lang['preferred']
+                            && !$searchNamesFn($data, $originationLocaleResults)
+                        ) {
+                            $originationLocaleResults[] = $data;
                         }
-                        if ($lang['default']) {
-                            $originationResults[$value] = $data;
+                        if ($lang['default']
+                            && !$searchNamesFn($data, $originationResults)
+                        ) {
+                            $originationResults[] = $data;
                         }
                     }
                 }
@@ -303,6 +323,7 @@ class SolrEad3 extends SolrEad
             $results = array_merge($results, $originationResults);
         }
 
+        // // Loop relations and filter out names already added from did->origination
         foreach ($record->relations->relation ?? [] as $relation) {
             $attr = $relation->attributes();
             foreach (['relationtype', 'href', 'arcrole'] as $key) {
@@ -317,18 +338,20 @@ class SolrEad3 extends SolrEad
             }
             $id = (string)$attr->href;
             if ($name = $this->getDisplayLabel($relation, 'relationentry', true)) {
-                if (!isset($localeResults[$name[0]])) {
-                    $localeResults[$name[0]] = ['id' => $id, 'name' => $name[0]];
+                $name = $name[0];
+                if (!$searchNamesFn(compact('name'), $localeResults)) {
+                    $localeResults[] = compact('id', 'name');
                 }
             }
             if ($name = $this->getDisplayLabel($relation, 'relationentry')) {
-                if (!isset($allResults[$name[0]])) {
-                    $allResults[$name[0]] = ['id' => $id, 'name' => $name[0]];
+                $name = $name[0];
+                if (!$searchNamesFn(compact('name'), $results)) {
+                    $results[] = compact('id', 'name');
                 }
             }
         }
 
-        return array_values($localeResults ?: $results);
+        return $localeResults ?: $results;
     }
 
     /**

--- a/themes/finna2/less/finna/authority.less
+++ b/themes/finna2/less/finna/authority.less
@@ -62,10 +62,15 @@ a.authority-link {
       }
     }
   }
-  .table-finna-record record-details {
+  .table-finna-record.record-details {
     .info {
       color: @gray;
       font-size: 0.9em;
+    }
+    .record-origination {
+      .author-description {
+        display: inline-block;
+      }
     }
   }
 }

--- a/themes/finna2/templates/RecordDriver/DefaultRecord/author-link-element.phtml
+++ b/themes/finna2/templates/RecordDriver/DefaultRecord/author-link-element.phtml
@@ -6,4 +6,4 @@
         $role = mb_strtolower($this->transEsc('CreatorRoles::' . $author['role']), 'UTF-8');
     }
 ?>
-<a href="<?=$this->record($record)->getLink('author', $author['name'])?>"><?=$this->escapeHtml($author['name'])?></a><?php if (!empty($author['date'])): ?><span class="author-date">, <?=$this->escapeHtml($author['date']) ?></span><?php endif; ?><?php if (!empty($role)): ?><span class="author-role">, <?=$role?></span><?php endif; ?><?php if (!empty($author['description'])): ?><span class="author-description"> (<?=$this->escapeHtml($author['description'])?>)</span><?php endif; ?>
+<a href="<?=$this->record($record)->getLink('author', $author['name'])?>"><?=$this->escapeHtml($author['name'])?></a><?php if (!empty($author['date'])): ?><span class="author-date">, <?=$this->escapeHtml($author['date']) ?></span><?php endif; ?><?php if (!empty($role)): ?><span class="author-role">, <?=$role?></span><?php endif; ?><?php if (!empty($author['description'])): ?> <span class="author-description">(<?=$this->escapeHtml($author['description'])?>)</span><?php endif; ?>

--- a/themes/finna2/templates/RecordDriver/DefaultRecord/data-origination.phtml
+++ b/themes/finna2/templates/RecordDriver/DefaultRecord/data-origination.phtml
@@ -1,5 +1,16 @@
 <?php $originationExt = $this->driver->tryMethod('getOriginationExtended'); //Don't add START and END comments ?>
 <?php foreach ($originationExt ?? [['name' => $data]] as $idx => $origination): ?>
+  <?php
+    $description = $origination['detail'] ?? '';
+    if ($date = $origination['date'] ?? '') {
+      if (!empty($description)) {
+        $description .= ', ';
+      }
+      $description .= $date;
+    }
+    $origination['description'] = $description;
+    unset($origination['date']);
+  ?>
   <?=$idx > 0 ? '<br/>' : ''?>
-  <?=$this->record($this->driver)->getAuthorityLinkElement('author', $origination['name'], $origination, ['showInlineInfo' => true, 'authorityType' => $author['type'] ?? null, 'date' => true])?>
+  <?=$this->record($this->driver)->getAuthorityLinkElement('author', $origination['name'], $origination, ['showInlineInfo' => true, 'authorityType' => $author['type'] ?? null, 'description' => true])?>
 <?php endforeach; ?>


### PR DESCRIPTION
- Näytetään arkistonmuodostajan nimen tarkenne tietuesivulla. Muutin authority-description -elementin inline-blokiksi niin että se ei rivitty keskeltä. 
- Ei filtteröidä origination->name@relatorin mukaan (yksa ei käytä niitä ja tämän pitäisi toimia myös Ahaassa)

Bugikorjauksia:
- typotettu `.table-finna-record.record-details` selectorin.
- Oletuksena palautetaan kaikki kieliversiot (ei vain näkymän kieliversion mukaisia): https://github.com/NatLibFi/NDL-VuFind2/pull/2031/files#diff-a7a8a3396cedb3aa3baac7bb8d1f7eb9beab156058fb34d1c8f5eebd1540ea5bL294

<img src="https://user-images.githubusercontent.com/3889/120599995-e696c380-c450-11eb-98c0-f341b26d9cfc.png" width="500px" />
