### PR TITLE
Revert toggle-image-information less rule removal

### DIFF
--- a/themes/finna2/less/finna/record.less
+++ b/themes/finna2/less/finna/record.less
@@ -555,7 +555,7 @@ a.authority {
   font-size: 1.05em;
   margin-bottom: 10px;
 }
-.show-details-button, .hide-details-button {
+.show-details-button, .hide-details-button, .toggle-image-information {
   margin-top: 5px;
   margin-bottom: 5px;
   cursor: pointer;


### PR DESCRIPTION
Well, this should not have been removed.