### PR TITLE
[ALLI-7030] RecordDriverRelated: search with filter

### DIFF
--- a/module/Finna/src/Finna/AjaxHandler/GetRecordDriverRelatedRecords.php
+++ b/module/Finna/src/Finna/AjaxHandler/GetRecordDriverRelatedRecords.php
@@ -121,15 +121,16 @@ class GetRecordDriverRelatedRecords extends \VuFind\AjaxHandler\AbstractBase
                         $field = $id['field'] ?? 'identifier';
                         // Search by id in the specified Solr field
                         $results = $this->searchRunner->run(
-                            ['lookfor' =>
-                                "{$field}:" . addcslashes($identifier, '"')],
-                            $source,
-                            function ($runner, $params, $searchId) use ($driver) {
+                            [], $source,
+                            function ($runner, $params, $searchId) use ($driver, $field, $identifier) {
                                 $params->setLimit(1);
                                 $params->setPage(1);
                                 $params->resetFacetConfig();
                                 $params->addFilter(
                                     'datasource_str_mv:' . $driver->getDatasource()
+                                );
+                                $params->addFilter(
+                                    "{$field}:" . addcslashes($identifier, '"')
                                 );
                                 $options = $params->getOptions();
                                 $options->disableHighlighting();

--- a/module/Finna/src/Finna/AjaxHandler/GetRecordDriverRelatedRecords.php
+++ b/module/Finna/src/Finna/AjaxHandler/GetRecordDriverRelatedRecords.php
@@ -122,8 +122,9 @@ class GetRecordDriverRelatedRecords extends \VuFind\AjaxHandler\AbstractBase
                         // Search by id in the specified Solr field
                         $results = $this->searchRunner->run(
                             [], $source,
-                            function ($runner, $params, $searchId) use 
-                                ($driver, $field, $identifier) {
+                            function ($runner, $params, $searchId) use (
+                                $driver, $field, $identifier
+                            ) {
                                 $params->setLimit(1);
                                 $params->setPage(1);
                                 $params->resetFacetConfig();

--- a/module/Finna/src/Finna/AjaxHandler/GetRecordDriverRelatedRecords.php
+++ b/module/Finna/src/Finna/AjaxHandler/GetRecordDriverRelatedRecords.php
@@ -132,7 +132,8 @@ class GetRecordDriverRelatedRecords extends \VuFind\AjaxHandler\AbstractBase
                                     'datasource_str_mv:' . $driver->getDatasource()
                                 );
                                 $params->addFilter(
-                                    "{$field}:" . addcslashes($identifier, '"')
+                                    "{!cache=false}{$field}:"
+                                    . addcslashes($identifier, '"')
                                 );
                                 $options = $params->getOptions();
                                 $options->disableHighlighting();

--- a/module/Finna/src/Finna/AjaxHandler/GetRecordDriverRelatedRecords.php
+++ b/module/Finna/src/Finna/AjaxHandler/GetRecordDriverRelatedRecords.php
@@ -122,7 +122,7 @@ class GetRecordDriverRelatedRecords extends \VuFind\AjaxHandler\AbstractBase
                         // Search by id in the specified Solr field
                         $results = $this->searchRunner->run(
                             [], $source,
-                            function ($runner, $params, $searchId) use
+                            function ($runner, $params, $searchId) use 
                                 ($driver, $field, $identifier) {
                                 $params->setLimit(1);
                                 $params->setPage(1);

--- a/module/Finna/src/Finna/AjaxHandler/GetRecordDriverRelatedRecords.php
+++ b/module/Finna/src/Finna/AjaxHandler/GetRecordDriverRelatedRecords.php
@@ -121,19 +121,15 @@ class GetRecordDriverRelatedRecords extends \VuFind\AjaxHandler\AbstractBase
                         $field = $id['field'] ?? 'identifier';
                         // Search by id in the specified Solr field
                         $results = $this->searchRunner->run(
-                            [], $source,
-                            function ($runner, $params, $searchId) use (
-                                $driver, $field, $identifier
-                            ) {
+                            ['lookfor' =>
+                                "{$field}:" . addcslashes($identifier, '"')],
+                            $source,
+                            function ($runner, $params, $searchId) use ($driver) {
                                 $params->setLimit(1);
                                 $params->setPage(1);
                                 $params->resetFacetConfig();
                                 $params->addFilter(
                                     'datasource_str_mv:' . $driver->getDatasource()
-                                );
-                                $params->addFilter(
-                                    "{!cache=false}{$field}:"
-                                    . addcslashes($identifier, '"')
                                 );
                                 $options = $params->getOptions();
                                 $options->disableHighlighting();

--- a/module/Finna/src/Finna/AjaxHandler/GetRecordDriverRelatedRecords.php
+++ b/module/Finna/src/Finna/AjaxHandler/GetRecordDriverRelatedRecords.php
@@ -122,7 +122,8 @@ class GetRecordDriverRelatedRecords extends \VuFind\AjaxHandler\AbstractBase
                         // Search by id in the specified Solr field
                         $results = $this->searchRunner->run(
                             [], $source,
-                            function ($runner, $params, $searchId) use ($driver, $field, $identifier) {
+                            function ($runner, $params, $searchId) use
+                                ($driver, $field, $identifier) {
                                 $params->setLimit(1);
                                 $params->setPage(1);
                                 $params->resetFacetConfig();

--- a/module/FinnaSearch/src/FinnaSearch/Backend/Solr/LuceneSyntaxHelper.php
+++ b/module/FinnaSearch/src/FinnaSearch/Backend/Solr/LuceneSyntaxHelper.php
@@ -88,7 +88,7 @@ class LuceneSyntaxHelper extends \VuFindSearch\Backend\Solr\LuceneSyntaxHelper
 
         // Don't normalize ISBN when targeting 'identifier' field
         // (required for GetRecordDriverRelatedRecords to work).
-        if (!preg_match("/identifier:.+/", $searchString)) {
+        if (!preg_match('/identifier:.+/', $searchString)) {
             $searchString = $this->normalizeISBN($searchString);
         }
 

--- a/module/FinnaSearch/src/FinnaSearch/Backend/Solr/LuceneSyntaxHelper.php
+++ b/module/FinnaSearch/src/FinnaSearch/Backend/Solr/LuceneSyntaxHelper.php
@@ -85,7 +85,12 @@ class LuceneSyntaxHelper extends \VuFindSearch\Backend\Solr\LuceneSyntaxHelper
     {
         $searchString = parent::normalizeSearchString($searchString);
         $searchString = $this->normalizeUnicodeForm($searchString);
-        $searchString = $this->normalizeISBN($searchString);
+
+        // Don't normalize ISBN when targeting 'identifier' field
+        // (required for GetRecordDriverRelatedRecords to work).
+        if (!preg_match("/identifier:.*/", $searchString)) {
+            $searchString = $this->normalizeISBN($searchString);
+        }
 
         foreach ($this->searchFilters as $i => $filter) {
             if (preg_match("/$filter/", $searchString)) {

--- a/module/FinnaSearch/src/FinnaSearch/Backend/Solr/LuceneSyntaxHelper.php
+++ b/module/FinnaSearch/src/FinnaSearch/Backend/Solr/LuceneSyntaxHelper.php
@@ -88,7 +88,7 @@ class LuceneSyntaxHelper extends \VuFindSearch\Backend\Solr\LuceneSyntaxHelper
 
         // Don't normalize ISBN when targeting 'identifier' field
         // (required for GetRecordDriverRelatedRecords to work).
-        if (!preg_match("/identifier:.*/", $searchString)) {
+        if (!preg_match("/identifier:.+/", $searchString)) {
             $searchString = $this->normalizeISBN($searchString);
         }
 


### PR DESCRIPTION
Nykyinen versio ei jostain syystä löydä kaikkia tietueita kun haussa `identifier:<id>` laitetaan lookfor/q -parametriin. filter-parametrilla toimii.

Esim. tästä puutuu ensimmäinen relations>relation:
http://finna-dev-fe.csc.fi/edge2/Collection/ahaa-ng.1087175949#details