### PR TITLE
[ALLI-7059] EAD3: separate item history from summary

### DIFF
--- a/module/Finna/src/Finna/RecordDriver/SolrEad3.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrEad3.php
@@ -1697,9 +1697,8 @@ class SolrEad3 extends SolrEad
     protected function getSummaryWithData($withLinks = false) : array
     {
         $xml = $this->getXmlRecord();
-
+        $result = $localeResult = [];
         if (!empty($xml->scopecontent)) {
-            $result = $localeResult = [];
             $preferredLangCodes = $this->mapLanguageCode($this->preferredLanguage);
             foreach ($xml->scopecontent as $el) {
                 if (isset($el->attributes()->encodinganalog)) {

--- a/module/Finna/src/Finna/RecordDriver/SolrEad3.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrEad3.php
@@ -1734,13 +1734,25 @@ class SolrEad3 extends SolrEad
             return $res;
         }
         $summary = parent::getSummary();
-        if ($withLinks) {
-            return array_map(
-                function ($text) {
-                    return compact('text');
-                },
-                $summary
-            );
+
+        // Return parent summary text only if it differs from item history
+        // (otherwise it gets displayed multiple times on record page).
+        $itemHistory = trim($this->getItemHistory());
+        $summary = array_filter(
+            $summary,
+            function ($item) use ($itemHistory) {
+                return trim($item) !== $itemHistory;
+            }
+        );
+        if ($summary) {
+            if ($withLinks) {
+                return array_map(
+                    function ($text) {
+                        return compact('text');
+                    },
+                    $summary
+                );
+            }
         }
         return $summary;
     }


### PR DESCRIPTION
EAD3-ajuri palauttaa (parentin kautta) indeksin description-kentän getSummary:ssä. Tarkistetaan ennen palauttamista että tämä eroaa "Aineiston syntyhistoriasta" niin että tekstiä ei näytetä ruudulla kahteen kertaan.

Ennen:

<img src="https://user-images.githubusercontent.com/3889/125439834-e05bb48c-4758-48aa-b5f4-6234f620f930.png" width="500" />

Jälkeen:

<img src="https://user-images.githubusercontent.com/3889/125443690-d24edb0a-931d-4b83-aaa9-9486b24e090d.png" width="500" />

Lisäksi bugikorjaus result/localeResult -muuttujien scopeen.
