### PR TITLE
[ALLI-6957] EAD3: title statements with urls

### DIFF
--- a/module/Finna/src/Finna/RecordDriver/SolrEad3.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrEad3.php
@@ -848,8 +848,43 @@ class SolrEad3 extends SolrEad
         if (!isset($xml->bibliography->p)) {
             return null;
         }
-        $label = $this->getDisplayLabel($xml->bibliography, 'p', true);
-        return $label ? $label[0] : null;
+        if ($label = $this->getDisplayLabel($xml->bibliography, 'p', true)) {
+            return $label[0];
+        } elseif ($label = $this->getDisplayLabel($xml->bibliography, 'p')) {
+            return $label[0];
+        }
+        return null;
+    }
+
+    /**
+     * Get the statement of responsibility that goes with the title.
+     * Returns an array of statements that contain the fields
+     * 'text' and 'url' (when available).
+     *
+     * @return array
+     */
+    public function getTitleStatementsExtended() : array
+    {
+        $xml = $this->getXmlRecord();
+        if (!isset($xml->bibliography->p)) {
+            return [];
+        }
+        $localeResults = $results = [];
+        foreach ($xml->bibliography->p ?? [] as $p) {
+            $text = (string)$p;
+            $url = isset($p->ref)
+                 ? (string)$p->ref->attributes()->href : null;
+            if ($this->urlBlocked($url, $text)) {
+                $url = null;
+            }
+            $data = compact('text', 'url');
+            $results[] = $data;
+            $lang = $this->detectNodeLanguage($p);
+            if ($lang['preferred']) {
+                $localeResults[] = $data;
+            }
+        }
+        return $localeResults ?: $results ?: [];
     }
 
     /**

--- a/module/Finna/src/Finna/View/Helper/Root/RecordDataFormatter.php
+++ b/module/Finna/src/Finna/View/Helper/Root/RecordDataFormatter.php
@@ -331,7 +331,7 @@ class RecordDataFormatter extends \VuFind\View\Helper\Root\RecordDataFormatter
         $include = [
             'Accessibility Feature', 'Accessibility Hazard',
             'Access Restrictions', 'Access Restrictions Extended',
-            'Additional Information',
+            'Additional Information Extended',
             'Age Limit', 'Appraisal', 'Archive', 'Archive Films',
             'Archive Origination', 'Archive Relations',
             'Archive Series', 'Archive File', 'Aspect Ratio', 'Audience',

--- a/module/Finna/src/Finna/View/Helper/Root/RecordDataFormatterFactory.php
+++ b/module/Finna/src/Finna/View/Helper/Root/RecordDataFormatterFactory.php
@@ -585,6 +585,18 @@ class RecordDataFormatterFactory
                 'context' => ['class' => 'recordTitleStatement']
             ]
         );
+
+        $setTemplateLine(
+            'Additional Information Extended', 'getTitleStatementsExtended',
+            'data-addInfoExtended.phtml',
+            [
+                'context' => [
+                    'class' => 'recordTitleStatement',
+                    'title' => 'Additional Information'
+                ]
+            ]
+        );
+
         $setTemplateLine(
             'child_records', 'getChildRecordCount', 'data-childRecords.phtml',
             [

--- a/themes/finna2/templates/RecordDriver/DefaultRecord/data-addInfo.phtml
+++ b/themes/finna2/templates/RecordDriver/DefaultRecord/data-addInfo.phtml
@@ -1,4 +1,14 @@
 <?php //Don't add START and END comments ?>
-<?php if (!empty($data)): ?>
+<?php $extendedData = $this->driver->tryMethod('getTitleStatementsExtended'); if (!empty($extendedData)): ?>
+  <div class="additional-information">
+    <?php foreach ($extendedData as $i => $item): ?>
+      <?= $i > 0 ? '<br/>' : '' ?>
+      <?= $this->escapeHtml($item['text']) ?>
+      <?php $url = $item['url'] ?? ''; if (!empty($url)): ?>
+        (<a target="_blank" href="<?=$this->escapeHtmlAttr($this->proxyUrl($url))?>"><?=$this->escapeHtml($this->truncateUrl($url))?></a>)
+      <?php endif; ?>
+    <?php endforeach; ?>
+  </div>
+<?php elseif (!empty($data)): ?>
   <div class="additional-information"><?=$this->escapeHtml($data) ?></div>
 <?php endif; ?>

--- a/themes/finna2/templates/RecordDriver/DefaultRecord/data-addInfo.phtml
+++ b/themes/finna2/templates/RecordDriver/DefaultRecord/data-addInfo.phtml
@@ -1,14 +1,4 @@
 <?php //Don't add START and END comments ?>
-<?php $extendedData = $this->driver->tryMethod('getTitleStatementsExtended'); if (!empty($extendedData)): ?>
-  <div class="additional-information">
-    <?php foreach ($extendedData as $i => $item): ?>
-      <?= $i > 0 ? '<br/>' : '' ?>
-      <?= $this->escapeHtml($item['text']) ?>
-      <?php $url = $item['url'] ?? ''; if (!empty($url)): ?>
-        (<a target="_blank" href="<?=$this->escapeHtmlAttr($this->proxyUrl($url))?>"><?=$this->escapeHtml($this->truncateUrl($url))?></a>)
-      <?php endif; ?>
-    <?php endforeach; ?>
-  </div>
-<?php elseif (!empty($data)): ?>
+<?php if (!empty($data)): ?>
   <div class="additional-information"><?=$this->escapeHtml($data) ?></div>
 <?php endif; ?>


### PR DESCRIPTION
Näytetään kaikki lisätieto-elementit ja näihin liittyvät linkit:

<img src="https://user-images.githubusercontent.com/3889/125584520-147d1ebd-8d93-43ad-a283-0df0c909ae59.png" width="500" />

Esim: http://finna-dev-fe.csc.fi/edge2/Record/ahaa-ng.851133713_851133881

Mukana myös getTitleStatementin korjaus, joka palauttaa ensimmäisen lisätiedon kun kielikäännöstä ei ole saatavissa.