### PR TITLE
[ALLI-7041] Add copyright info to record email

### DIFF
--- a/module/Finna/src/Finna/View/Helper/Root/Record.php
+++ b/module/Finna/src/Finna/View/Helper/Root/Record.php
@@ -999,4 +999,27 @@ class Record extends \VuFind\View\Helper\Root\Record
             );
         }
     }
+
+    /**
+     * Returns a translated copyright text.
+     *
+     * @param string $copyright Copyright
+     *
+     * @return string
+     */
+    public function translateCopyright(string $copyright) : string
+    {
+        $transEsc = $this->getView()->plugin('transEsc');
+
+        $label = $transEsc($copyright);
+        if ($copyright === 'Luvanvarainen käyttö / ei tiedossa') {
+            $label = $transEsc('usage_F');
+        } else {
+            $translationEmpty = $this->getView()->plugin('translationEmpty');
+            if (!$translationEmpty("rightsstatement_$copyright")) {
+                $label = $transEsc("rightsstatement_$copyright");
+            }
+        }
+        return $label;
+    }
 }

--- a/themes/finna2/templates/RecordDriver/DefaultRecord/image-rights.phtml
+++ b/themes/finna2/templates/RecordDriver/DefaultRecord/image-rights.phtml
@@ -11,12 +11,7 @@
         <?php if (!empty($rights['copyright'])): ?>
           <?php
             $copyright = $rights['copyright'];
-            $label = $this->transEsc($copyright);
-            if ($copyright === 'Luvanvarainen käyttö / ei tiedossa') {
-              $label = $this->transEsc('usage_F');
-            } elseif (!$this->translationEmpty("rightsstatement_$copyright")) {
-              $label = $this->transEsc("rightsstatement_$copyright");
-            }
+            $label = $this->record($this->driver)->translateCopyright($copyright);
           ?>
           <?=$this->partial('Helpers/copyright-icons.phtml', ['copyright' => $copyright]);?><?php if ($hasLink): ?><a target="_blank" aria-label="<?=$this->transEscAttr('external_online_link')?>" href="<?=$this->escapeHtmlAttr($rights['link']) ?>"><?php endif; ?><?= $label ?><?php if ($hasLink): ?></a><?php endif; ?>
         <?php else: ?>

--- a/themes/finna2/templates/RecordDriver/DefaultRecord/result-email-copyright.phtml
+++ b/themes/finna2/templates/RecordDriver/DefaultRecord/result-email-copyright.phtml
@@ -1,0 +1,40 @@
+<?php $termsOfUse = $this->driver->tryMethod('getTermsOfUse'); if (!empty($termsOfUse)): ?>
+  <?php
+    $terms = array_map(
+      function ($term) {
+        $text = $term['terms'] ?? '';
+        if ($copyright = $term['source'] ?? null) {
+          if (!empty($text)) {
+            if (substr($text, -1, 1) !== '.') {
+              $text .= '.';
+            }
+            $text .= ' ';
+          }
+          $text .= $this->record($this->driver)->translateCopyright($copyright);
+        }
+        if ($link = $term['url'] ?? null) {
+          if (!empty($text)) {
+            $text .= '. ';
+          }
+          $text .= $link;
+        }
+        return $text;
+      },
+      $termsOfUse
+    );
+   ?>
+   <?= PHP_EOL . $this->translate('Image Rights') . ': ' . implode(', ', $terms); ?>
+<?php else: ?>
+  <?php
+    $copyrightInfo = $copyright = $copyrightLink = null;
+    if (!$copyrightInfo = $this->driver->getAccessRestrictionsType($this->layout()->userLang)) {
+      $copyrightInfo = $this->recordImage($this->record($this->driver))->getImageRights(0) ?? null;
+    }
+    if ($copyright = $copyrightInfo['copyright'] ?? null) {
+      $copyright = $this->record($this->driver)->translateCopyright($copyright, $this->transEsc, $this->translationEmpty);
+      $copyrightLink = $copyrightInfo['link'] ?? null;
+    }
+    if ($copyright): ?>
+    <?= PHP_EOL . $this->translate('Image Rights') . ': ' . $copyright . ($copyrightLink ? " $copyrightLink" : '') ?>
+  <?php endif; ?>
+<?php endif; ?>

--- a/themes/finna2/templates/RecordDriver/DefaultRecord/result-email.phtml
+++ b/themes/finna2/templates/RecordDriver/DefaultRecord/result-email.phtml
@@ -47,5 +47,6 @@
 <?php if (!empty($format)): ?>
 <?= PHP_EOL . $this->translate($format) ?>
 <?php endif; ?>
+<?= $this->record($this->driver)->renderTemplate('result-email-copyright.phtml') ?>
 
 <?= $this->translate('View Full Record') . ": $url"; ?>

--- a/themes/finna2/templates/RecordDriver/SolrEad/result-email.phtml
+++ b/themes/finna2/templates/RecordDriver/SolrEad/result-email.phtml
@@ -51,5 +51,6 @@
 <?php if ($unit = ($this->driver->tryMethod('getFilingUnit'))): ?>
   <?= PHP_EOL . $this->translate('Filing Unit') . ': ' . $unit ?>
 <?php endif; ?>
+<?= $this->record($this->driver)->renderTemplate('result-email-copyright.phtml') ?>
 
 <?= $this->translate('View Full Record') . ": $url"; ?>

--- a/themes/finna2/templates/RecordDriver/SolrLido/result-email.phtml
+++ b/themes/finna2/templates/RecordDriver/SolrLido/result-email.phtml
@@ -36,5 +36,6 @@ foreach ($parentTitles as $i => $parentTitle) {
   }
 }
 ?>
+<?= $this->record($this->driver)->renderTemplate('result-email-copyright.phtml') ?>
 
 <?= $this->translate('View Full Record') . ": $url"; ?>


### PR DESCRIPTION
Testattu taskin esimerkeillä.

Sähköpostiviesti näyttää tällaiselta:

<img src="https://user-images.githubusercontent.com/3889/125751734-76141008-3242-4a30-ba1b-2cd9bd3564c1.png" width="500" />


