### PR TITLE
Custom elements implementation improvements

### DIFF
--- a/composer.local.json
+++ b/composer.local.json
@@ -4,7 +4,7 @@
     ],
     "require": {
         "ezyang/htmlpurifier": "4.12.0",
-        "paquettg/php-html-parser": "3.1.1",
+        "paquettg/php-html-parser": "3.1.0",
         "picqer/php-barcode-generator": "2.0.1",
         "smartbox/besimple-soap": "^1.3.5"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -5982,16 +5982,16 @@
         },
         {
             "name": "paquettg/php-html-parser",
-            "version": "3.1.1",
+            "version": "3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/paquettg/php-html-parser.git",
-                "reference": "4e01a438ad5961cc2d7427eb9798d213c8a12629"
+                "reference": "b200ae9894af3ba309115c120799f3f273d3e2aa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/paquettg/php-html-parser/zipball/4e01a438ad5961cc2d7427eb9798d213c8a12629",
-                "reference": "4e01a438ad5961cc2d7427eb9798d213c8a12629",
+                "url": "https://api.github.com/repos/paquettg/php-html-parser/zipball/b200ae9894af3ba309115c120799f3f273d3e2aa",
+                "reference": "b200ae9894af3ba309115c120799f3f273d3e2aa",
                 "shasum": ""
             },
             "require": {
@@ -6002,7 +6002,7 @@
                 "guzzlehttp/psr7": "^1.6",
                 "myclabs/php-enum": "^1.7",
                 "paquettg/string-encode": "~1.0.0",
-                "php": ">=7.2",
+                "php": ">=7.1",
                 "php-http/httplug": "^2.1"
             },
             "require-dev": {
@@ -6038,7 +6038,7 @@
             ],
             "support": {
                 "issues": "https://github.com/paquettg/php-html-parser/issues",
-                "source": "https://github.com/paquettg/php-html-parser/tree/3.1.1"
+                "source": "https://github.com/paquettg/php-html-parser/tree/3.1.0"
             },
             "funding": [
                 {
@@ -6046,7 +6046,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-11-01T20:34:43+00:00"
+            "time": "2020-09-19T19:27:31+00:00"
         },
         {
             "name": "paquettg/string-encode",
@@ -14209,5 +14209,5 @@
     "platform-overrides": {
         "php": "7.3.0"
     },
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.0.0"
 }

--- a/module/Finna/src/Finna/View/CustomElement/AbstractBase.php
+++ b/module/Finna/src/Finna/View/CustomElement/AbstractBase.php
@@ -250,7 +250,10 @@ abstract class AbstractBase implements CustomElementInterface
      */
     protected static function getOptionToVariableMap(): array
     {
-        return static::getAttributeToVariableMap();
+        return array_merge(
+            ['attributes' => 'attributes'],
+            static::getAttributeToVariableMap()
+        );
     }
 
     /**
@@ -272,6 +275,19 @@ abstract class AbstractBase implements CustomElementInterface
             }
         }
         return $values;
+    }
+
+    /**
+     * Get a view model variable.
+     *
+     * @param string     $name    Name
+     * @param mixed|null $default Default value if the variable is not present
+     *
+     * @return mixed
+     */
+    protected function getVariable(string $name, $default = null)
+    {
+        return $this->getViewModel()->getVariable($name, $default);
     }
 
     /**

--- a/module/Finna/src/Finna/View/CustomElement/AbstractBase.php
+++ b/module/Finna/src/Finna/View/CustomElement/AbstractBase.php
@@ -127,7 +127,9 @@ abstract class AbstractBase implements CustomElementInterface
         if (isset($options['outerHTML'])) {
             $dom = (new Dom())->loadStr(
                 $options['outerHTML'],
-                (new Options())->setCleanupInput(false)
+                (new Options())
+                    ->setCleanupInput(false)
+                    ->setRemoveDoubleSpace(false)
             );
             if ($dom->countChildren() !== 1
                 || $dom->firstChild()->getTag()->name() !== $this->getName()
@@ -183,13 +185,30 @@ abstract class AbstractBase implements CustomElementInterface
     }
 
     /**
-     * Get the names of attributes supported by the element.
+     * Get information about the element.
      *
      * @return array
      */
-    public static function getAttributes(): array
+    public static function getInfo(): array
     {
-        return array_keys(static::getAttributeToVariableMap());
+        return [
+            self::TYPE => 'Block',
+            self::CONTENTS => 'Flow',
+            self::ATTR_COLLECTIONS => 'Common',
+            self::ATTRIBUTES => array_fill_keys(
+                array_keys(static::getAttributeToVariableMap()), 'CDATA'
+            )
+        ];
+    }
+
+    /**
+     * Get information about child elements supported by the element.
+     *
+     * @return array
+     */
+    public static function getChildInfo(): array
+    {
+        return [];
     }
 
     /**
@@ -256,33 +275,58 @@ abstract class AbstractBase implements CustomElementInterface
     }
 
     /**
-     * Remove a slot element from the DOM, with additional cleanup of possible
-     * unneeded elements added by Markdown processing.
+     * Set a view model variable.
      *
-     * @param $slotElement HtmlNode Element with a slot attribute
+     * @param string $name  Name
+     * @param mixed  $value Value
      *
      * @return void
      */
-    protected function removeSlotElement($slotElement): void
+    protected function setVariable(string $name, $value): void
     {
-        // Remove br elements immediately following the slot element.
-        $slotElementParent = $slotElement->getParent();
-        while ($slotElement->hasNextSibling()) {
-            $sibling = $slotElement->nextSibling();
+        $this->getViewModel()->setVariable($name, $value);
+    }
+
+    /**
+     * Set the view model template.
+     *
+     * @param string $template Template
+     *
+     * @return void
+     */
+    protected function setTemplate(string $template): void
+    {
+        $this->getViewModel()->setTemplate($template);
+    }
+
+    /**
+     * Remove an element from the DOM, with additional cleanup of possible unneeded
+     * elements added by Markdown processing.
+     *
+     * @param $element HtmlNode Element
+     *
+     * @return void
+     */
+    protected function removeElement(HtmlNode $element): void
+    {
+        // Remove br elements immediately following the element.
+        $parent = $element->getParent();
+        while ($element->hasNextSibling()) {
+            $sibling = $element->nextSibling();
             if ($sibling->getTag()->name() !== 'br') {
                 break;
             }
-            $slotElementParent->removeChild($sibling->id());
+            $parent->removeChild($sibling->id());
         }
 
-        // Remove the slot element.
-        $slotElementParent->removeChild($slotElement->id());
+        // Remove the element.
+        $parent->removeChild($element->id());
 
         // If the parent is an empty p element, remove the parent also.
-        if (!$slotElementParent->hasChildren()
-            && $slotElementParent->getTag()->name() === 'p'
+        if (!$parent->hasChildren()
+            && $parent->getTag()->name() === 'p'
         ) {
-            $slotElementParent->getParent()->removeChild($slotElementParent->id());
+            $parent->getParent()->removeChild($parent->id());
         }
     }
 }

--- a/module/Finna/src/Finna/View/CustomElement/CustomElementInterface.php
+++ b/module/Finna/src/Finna/View/CustomElement/CustomElementInterface.php
@@ -41,6 +41,38 @@ use Laminas\View\Model\ModelInterface;
 interface CustomElementInterface
 {
     /**
+     * Element information array key for the content set type.
+     * See HTML Purifier documentation for possible values.
+     *
+     * @var string
+     */
+    public const TYPE = 'type';
+
+    /**
+     * Element information array key for allowed children.
+     * See HTML Purifier documentation for possible values.
+     *
+     * @var string
+     */
+    public const CONTENTS = 'contents';
+
+    /**
+     * Element information array key for common attributes collections.
+     * See HTML Purifier documentation for possible values.
+     *
+     * @var string
+     */
+    public const ATTR_COLLECTIONS = 'attrCollections';
+
+    /**
+     * Element information array key for attributes.
+     * See HTML Purifier documentation for possible values.
+     *
+     * @var string
+     */
+    public const ATTRIBUTES = 'attributes';
+
+    /**
      * Get the name of the element.
      *
      * @return string
@@ -48,11 +80,18 @@ interface CustomElementInterface
     public function getName(): string;
 
     /**
-     * Get the names of attributes supported by the element.
+     * Get information about the element.
      *
      * @return array
      */
-    public static function getAttributes(): array;
+    public static function getInfo(): array;
+
+    /**
+     * Get information about child elements supported by the element.
+     *
+     * @return array
+     */
+    public static function getChildInfo(): array;
 
     /**
      * Get the view model for server-side rendering the element.

--- a/module/Finna/src/Finna/View/CustomElement/FinnaList.php
+++ b/module/Finna/src/Finna/View/CustomElement/FinnaList.php
@@ -48,7 +48,7 @@ class FinnaList extends AbstractBase
     {
         parent::__construct($name, $options, true);
 
-        $this->getViewModel()->setTemplate('CustomElement/finna-list');
+        $this->setTemplate('CustomElement/finna-list');
     }
 
     /**

--- a/module/Finna/src/Finna/View/CustomElement/FinnaTruncate.php
+++ b/module/Finna/src/Finna/View/CustomElement/FinnaTruncate.php
@@ -48,35 +48,56 @@ class FinnaTruncate extends AbstractBase
     {
         parent::__construct($name, $options);
 
-        $labelElement = $this->dom->find('*[slot="label"]');
-        if ($labelElement = $labelElement[0] ?? false) {
-            $label = trim(strip_tags($labelElement->innerHtml()));
-            if (!empty($label)) {
-                $this->viewModel->setVariable('label', $label);
-            }
-            $this->removeSlotElement($labelElement);
-        }
-
         // If only one of the 'rows' and 'row-height' attributes is set, unset the
         // default value of the other attribute.
         if (isset($this->attributes['rows'])
             && !isset($this->attributes['row-height'])
         ) {
-            $this->getViewModel()->setVariable('rowHeight', null);
+            $this->setVariable('rowHeight', null);
         }
         if (isset($this->attributes['row-height'])
             && !isset($this->attributes['rows'])
         ) {
-            $this->getViewModel()->setVariable('rows', null);
+            $this->setVariable('rows', null);
         }
 
-        $this->viewModel->setVariable(
-            'content', $this->dom->firstChild()->innerHTML()
-        );
+        if ($this->dom) {
+            $labelElement = $this->dom->find('[slot="label"]');
+            if ($labelElement = $labelElement[0] ?? false) {
+                $label = trim(strip_tags($labelElement->innerHtml()));
+                if (!empty($label)) {
+                    $this->setVariable('label', $label);
+                }
+                $this->removeElement($labelElement);
+            }
 
-        $this->getViewModel()->setTemplate(
+            $this->viewModel->setVariable(
+                'content', $this->dom->firstChild()->innerHTML()
+            );
+        }
+
+        $this->setTemplate(
             'components/molecules/containers/finna-truncate/finna-truncate'
         );
+    }
+
+    /**
+     * Get information about child elements supported by the element.
+     *
+     * @return array Array containing element names as keys and arrays of
+     *     HTMLPurifier_HTMLDefinition::addElement() arguments excluding the name of
+     *     the element as values.
+     */
+    public static function getChildInfo(): array
+    {
+        return [
+            'span' => [
+                self::TYPE => 'Inline',
+                self::CONTENTS => 'Inline',
+                self::ATTR_COLLECTIONS => 'Common',
+                self::ATTRIBUTES => ['slot' => 'CDATA']
+            ]
+        ];
     }
 
     /**

--- a/module/Finna/src/Finna/View/Helper/Root/CleanHtml.php
+++ b/module/Finna/src/Finna/View/Helper/Root/CleanHtml.php
@@ -28,6 +28,8 @@
  */
 namespace Finna\View\Helper\Root;
 
+use Finna\View\CustomElement\CustomElementInterface;
+
 /**
  * HTML Cleaner view helper
  *
@@ -55,11 +57,12 @@ class CleanHtml extends \Laminas\View\Helper\AbstractHelper
     protected $cacheDir;
 
     /**
-     * Allowed custom element names and attributes
+     * Array containing allowed element names as keys and element info arrays as
+     * values
      *
      * @var array
      */
-    protected $customElements;
+    protected $allowedElements;
 
     /**
      * Current target blank setting
@@ -71,14 +74,13 @@ class CleanHtml extends \Laminas\View\Helper\AbstractHelper
     /**
      * Constructor
      *
-     * @param string $cacheDir       Cache directory
-     * @param array  $customElements Array containing allowed custom element names as
-     *                               keys and element attribute name arrays as values
+     * @param string $cacheDir        Cache directory
+     * @param array  $allowedElements Allowed elements
      */
-    public function __construct($cacheDir, $customElements)
+    public function __construct($cacheDir, $allowedElements)
     {
         $this->cacheDir = $cacheDir;
-        $this->customElements = $customElements;
+        $this->allowedElements = $allowedElements;
     }
 
     /**
@@ -108,24 +110,15 @@ class CleanHtml extends \Laminas\View\Helper\AbstractHelper
 
             // Add elements and attributes not supported by default
             $def = $config->getHTMLDefinition(true);
-            foreach ($this->customElements as $elementName => $elementAttributes) {
-                $def->addElement($elementName, 'Block', 'Flow', 'Common');
-                foreach ($elementAttributes as $attributeName) {
-                    $def->addAttribute($elementName, $attributeName, 'CDATA');
-                }
+            foreach ($this->allowedElements as $elementName => $elementInfo) {
+                $def->addElement(
+                    $elementName,
+                    $elementInfo[CustomElementInterface::TYPE],
+                    $elementInfo[CustomElementInterface::CONTENTS],
+                    $elementInfo[CustomElementInterface::ATTR_COLLECTIONS],
+                    $elementInfo[CustomElementInterface::ATTRIBUTES]
+                );
             }
-            $def->addAttribute('span', 'slot', 'CDATA');
-            $def->addElement(
-                'details',
-                'Block',
-                'Flow',
-                'Common',
-                ['open' => new \HTMLPurifier_AttrDef_HTML_Bool(true)]
-            );
-            $def->addElement('summary', 'Block', 'Flow', 'Common');
-            $def->addAttribute('div', 'data-rows', 'Number');
-            $def->addAttribute('div', 'data-row-height', 'Number');
-            $def->addAttribute('div', 'data-label', 'Text');
 
             $this->purifier = new \HTMLPurifier($config);
         }

--- a/module/Finna/src/Finna/View/Helper/Root/CleanHtmlFactory.php
+++ b/module/Finna/src/Finna/View/Helper/Root/CleanHtmlFactory.php
@@ -27,6 +27,7 @@
  */
 namespace Finna\View\Helper\Root;
 
+use Finna\View\CustomElement\CustomElementInterface;
 use Interop\Container\ContainerInterface;
 use Interop\Container\Exception\ContainerException;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
@@ -68,12 +69,21 @@ class CleanHtmlFactory implements FactoryInterface
             ->getCache('object')->getOptions()->getCacheDir();
 
         $config = $container->get('config');
-        $customElements
+        $allowedElements
             = $config['vufind']['plugin_managers']['view_customelement']['aliases'];
-        foreach ($customElements as $elementName => $elementClass) {
-            $customElements[$elementName] = $elementClass::getAttributes();
+        $attrs = CustomElementInterface::ATTRIBUTES;
+        foreach ($allowedElements as $elementName => $elementClass) {
+            $allowedElements[$elementName] = $elementClass::getInfo();
+            foreach ($elementClass::getChildInfo() as $childName => $childInfo) {
+                if (isset($allowedElements[$childName][$attrs])) {
+                    $childInfo[$attrs] = array_merge(
+                        $allowedElements[$childName][$attrs], $childInfo[$attrs]
+                    );
+                }
+                $allowedElements[$childName] = $childInfo;
+            }
         }
 
-        return new $requestedName($cacheDir, $customElements);
+        return new $requestedName($cacheDir, $allowedElements);
     }
 }

--- a/module/Finna/src/Finna/View/Helper/Root/Markdown.php
+++ b/module/Finna/src/Finna/View/Helper/Root/Markdown.php
@@ -105,7 +105,7 @@ class Markdown extends \VuFind\View\Helper\Root\Markdown
         // Replace details > summary elements, which have the markdown attribute.
         $markdown = preg_replace(
             $this->getTagContentRegex('summary', ' markdown="1"'),
-            "  <span slot=\"heading\">$1</span>\n",
+            "  <h3 slot=\"heading\">$1</h3>\n",
             $markdown
         );
 

--- a/themes/finna2/js/components/organisms/widgets/finna-md-editable/finna-md-editable.js
+++ b/themes/finna2/js/components/organisms/widgets/finna-md-editable/finna-md-editable.js
@@ -276,10 +276,10 @@ FinnaMdEditable.prototype._insertElement = function _insertElement(element, curs
 FinnaMdEditable.prototype._insertPanel = function _insertPanel() {
   var headingPlaceholder = VuFind.translate('details_summary_placeholder');
   var panelElement = '\n<finna-panel>\n'
-    + '  <span slot="heading">' + headingPlaceholder + '</span>\n\n'
+    + '  <h3 slot="heading">' + headingPlaceholder + '</h3>\n\n'
     + '  ' + VuFind.translate('details_text_placeholder') + '\n'
     + '</finna-panel>\n';
-  this._insertElement(panelElement, -4, 23 + headingPlaceholder.length);
+  this._insertElement(panelElement, -4, 21 + headingPlaceholder.length);
 };
 
 FinnaMdEditable.prototype._insertTruncate = function _insertTruncate() {

--- a/themes/finna2/less/components/molecules/containers/finna-panel/finna-panel.less
+++ b/themes/finna2/less/components/molecules/containers/finna-panel/finna-panel.less
@@ -75,13 +75,12 @@
 }
 
 // Minimal custom element styling for Markdown preview.
-
 finna-panel {
   display: block;
   outline: 1px solid @gray-lighter;
   margin-bottom: 21px;
   padding: 10px;
-  > span[slot="heading"] {
+  > [slot="heading"] {
     outline: 1px solid @gray-lighter;
     display: block;
     margin: -10px -10px 10px -10px;


### PR DESCRIPTION
- Palautetaan yksityiskohtaisempaa tietoa elementeistä ja niiden tukemista lapsielementeistä HTML Purifierin sääntöjen asetusta varten
- Lisätty elementtien toteutusta helpottavia apumetodeja perusluokkaan
- Säädetty HTML-parseria toimimaan paremmin Markdownista tuotetun HTML:n kanssa
- Huomioitu elementtien toimivuus myös ilman parsittavaa HTML:ää
- Lisätty finna-panel:in tuki h-tagien käyttöön, muutettu oletustagiksi h3 ja oletusotsikkotasoksi 3
- Muutettu metodien ja muuttujien nimiä kuvaavammiksi
- Muutettu paquettg/php-html-parser -versiota uusimmassa versiossa olevan HTML-kommenttikäsittelybugin välttämiseksi (https://github.com/paquettg/php-html-parser/issues/274)
