### PR TITLE
[Alli-7117] EAD3: Fix displaying labels for non-nested accessrestrict elements in Collection view

### DIFF
--- a/module/Finna/src/Finna/RecordDriver/SolrEad3.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrEad3.php
@@ -931,34 +931,6 @@ class SolrEad3 extends SolrEad
     public function getExtendedAccessRestrictions()
     {
         $xml = $this->getXmlRecord();
-        if (isset($xml->accessrestrict)
-            && !isset($xml->accessrestrict->accessrestrict)
-        ) {
-            // Case 1: no nested accessrestrict elements
-            $result = [];
-
-            foreach ([true, false] as $obeyPreferredLanguage) {
-                foreach ($xml->accessrestrict as $accessNode) {
-                    if ($label = $this->getDisplayLabel(
-                        $accessNode,
-                        'p',
-                        $obeyPreferredLanguage
-                    )
-                    ) {
-                        if (empty($label[0])) {
-                            continue;
-                        }
-                        $result[] = $label[0];
-                    }
-                }
-                if (!empty($result)) {
-                    break;
-                }
-            }
-            return $result;
-        }
-
-        // Case 2: nested accessrestrict elements grouped under subheadings
         $restrictions = [];
         foreach (self::ACCESS_RESTRICT_TYPES as $type) {
             $restrictions[$type] = [];
@@ -1000,28 +972,37 @@ class SolrEad3 extends SolrEad
             }
         };
 
-        foreach ($xml->accessrestrict ?? [] as $accessNode) {
-            $processNode($accessNode);
-            foreach ($accessNode->accessrestrict ?? [] as $accessNode) {
+        if (isset($xml->accessrestrict)
+            && !isset($xml->accessrestrict->accessrestrict)
+        ) {
+            // Case 1: no nested accessrestrict elements
+            foreach ($xml->accessrestrict as $accessNode) {
+                $processNode($accessNode);
+            }
+        } else {
+            // Case 2: nested accessrestrict elements grouped under subheadings
+            foreach ($xml->accessrestrict ?? [] as $accessNode) {
                 $processNode($accessNode);
                 foreach ($accessNode->accessrestrict ?? [] as $accessNode) {
                     $processNode($accessNode);
+                    foreach ($accessNode->accessrestrict ?? [] as $accessNode) {
+                        $processNode($accessNode);
+                    }
                 }
             }
+
+            $result = [];
+
+            // Sort
+            $order = array_flip(self::ACCESS_RESTRICT_TYPES);
+            $orderCnt = count($order);
+            $sortFn = function ($a, $b) use ($order, $orderCnt) {
+                $pos1 = $order[$a] ?? $orderCnt;
+                $pos2 = $order[$b] ?? $orderCnt;
+                return $pos1 - $pos2;
+            };
+            uksort($restrictions, $sortFn);
         }
-
-        $result = [];
-
-        // Sort
-        $order = array_flip(self::ACCESS_RESTRICT_TYPES);
-        $orderCnt = count($order);
-        $sortFn = function ($a, $b) use ($order, $orderCnt) {
-            $pos1 = $order[$a] ?? $orderCnt;
-            $pos2 = $order[$b] ?? $orderCnt;
-            return $pos1 - $pos2;
-        };
-        uksort($restrictions, $sortFn);
-
         // Rename keys to match translations and filter duplicates
         $renamedKeys = [];
         foreach ($restrictions as $key => $val) {

--- a/module/Finna/src/Finna/RecordDriver/SolrEad3.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrEad3.php
@@ -972,35 +972,25 @@ class SolrEad3 extends SolrEad
             }
         };
 
-        if (isset($xml->accessrestrict)
-            && !isset($xml->accessrestrict->accessrestrict)
-        ) {
-            // Case 1: no nested accessrestrict elements
-            foreach ($xml->accessrestrict as $accessNode) {
-                $processNode($accessNode);
-            }
-        } else {
-            // Case 2: nested accessrestrict elements grouped under subheadings
-            foreach ($xml->accessrestrict ?? [] as $accessNode) {
+        foreach ($xml->accessrestrict ?? [] as $accessNode) {
+            $processNode($accessNode);
+            foreach ($accessNode->accessrestrict ?? [] as $accessNode) {
                 $processNode($accessNode);
                 foreach ($accessNode->accessrestrict ?? [] as $accessNode) {
                     $processNode($accessNode);
-                    foreach ($accessNode->accessrestrict ?? [] as $accessNode) {
-                        $processNode($accessNode);
-                    }
                 }
             }
-
-            // Sort
-            $order = array_flip(self::ACCESS_RESTRICT_TYPES);
-            $orderCnt = count($order);
-            $sortFn = function ($a, $b) use ($order, $orderCnt) {
-                $pos1 = $order[$a] ?? $orderCnt;
-                $pos2 = $order[$b] ?? $orderCnt;
-                return $pos1 - $pos2;
-            };
-            uksort($restrictions, $sortFn);
         }
+
+        // Sort
+        $order = array_flip(self::ACCESS_RESTRICT_TYPES);
+        $orderCnt = count($order);
+        $sortFn = function ($a, $b) use ($order, $orderCnt) {
+            $pos1 = $order[$a] ?? $orderCnt;
+            $pos2 = $order[$b] ?? $orderCnt;
+            return $pos1 - $pos2;
+        };
+        uksort($restrictions, $sortFn);
         // Rename keys to match translations and filter duplicates
         $renamedKeys = [];
         foreach ($restrictions as $key => $val) {

--- a/module/Finna/src/Finna/RecordDriver/SolrEad3.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrEad3.php
@@ -991,8 +991,6 @@ class SolrEad3 extends SolrEad
                 }
             }
 
-            $result = [];
-
             // Sort
             $order = array_flip(self::ACCESS_RESTRICT_TYPES);
             $orderCnt = count($order);


### PR DESCRIPTION
esimerkkitietue: http://finna-dev-fe.csc.fi/edge2/Collection/sks.106445052
yksittäisen accessrestrict-elementin kohdalla Collection-sivupohjaan ei tule taulukkotietoihin otsikkoa. 
Muutos: käsitellään yksittäiset elementit samoin kuin monikerroksiset. Eli collection-pohjassa taulukon otsikko tulee encodinganalog-attribuutista, ja Recordissa pääotsikko on Pääsyoikeudet, jonka alla alaotsikkona encodinganalog:ista tuleva otsikko