### PR TITLE
Move CSS rule to more appropriate file

### DIFF
--- a/themes/finna2/less/components/molecules/containers/finna-panel/finna-panel.less
+++ b/themes/finna2/less/components/molecules/containers/finna-panel/finna-panel.less
@@ -74,10 +74,6 @@
   }
 }
 
-.public-list-embed .finna-panel {
-  margin-bottom: 12px;
-}
-
 // Minimal custom element styling for Markdown preview.
 finna-panel {
   display: block;

--- a/themes/finna2/less/finna/public-favorites.less
+++ b/themes/finna2/less/finna/public-favorites.less
@@ -116,4 +116,7 @@
             display: block;
         }
     }
+    .finna-panel {
+        margin-bottom: 12px;
+    }
 }


### PR DESCRIPTION
Siirretään #2122:ssa lisätty sääntö toiseen tiedostoon. Ajatuksena on pitää komponenttikohtaisissa tiedostoissa ainoastaan komponentteja kaikissa yhteyksissä koskevat yleiset säännöt.