### PR TITLE
Add a QA script to local composer

### DIFF
--- a/composer.local.json
+++ b/composer.local.json
@@ -12,6 +12,6 @@
         "create-translation-files": "touch local/languages/finna/fi-datasources.ini; touch local/languages/finna/sv-datasources.ini; touch local/languages/finna/en-gb-datasources.ini",
         "post-install-cmd": ["@phing-install-dependencies", "@create-translation-files"],
         "post-update-cmd": ["@phing-install-dependencies", "@create-translation-files"],
-        "qa": "phing eslint eslint-finna phpunitfast phpcs-console php-cs-fixer-dryrun"
+        "qa": "phing eslint-finna qa-console"
     }
 }

--- a/composer.local.json
+++ b/composer.local.json
@@ -11,6 +11,13 @@
     "scripts": {
         "create-translation-files": "touch local/languages/finna/fi-datasources.ini; touch local/languages/finna/sv-datasources.ini; touch local/languages/finna/en-gb-datasources.ini",
         "post-install-cmd": ["@phing-install-dependencies", "@create-translation-files"],
-        "post-update-cmd": ["@phing-install-dependencies", "@create-translation-files"]
+        "post-update-cmd": ["@phing-install-dependencies", "@create-translation-files"],
+        "qa": [
+            "phing eslint",
+            "phing eslint-finna",
+            "phing phpunitfast",
+            "phing phpcs-console",
+            "phing php-cs-fixer-dryrun"
+        ]
     }
 }

--- a/composer.local.json
+++ b/composer.local.json
@@ -12,12 +12,6 @@
         "create-translation-files": "touch local/languages/finna/fi-datasources.ini; touch local/languages/finna/sv-datasources.ini; touch local/languages/finna/en-gb-datasources.ini",
         "post-install-cmd": ["@phing-install-dependencies", "@create-translation-files"],
         "post-update-cmd": ["@phing-install-dependencies", "@create-translation-files"],
-        "qa": [
-            "phing eslint",
-            "phing eslint-finna",
-            "phing phpunitfast",
-            "phing phpcs-console",
-            "phing php-cs-fixer-dryrun"
-        ]
+        "qa": "phing eslint eslint-finna phpunitfast phpcs-console php-cs-fixer-dryrun"
     }
 }


### PR DESCRIPTION
Requires a small push to VuFind.
Edit:
https://github.com/vufind-org/vufind/commit/d6e7b884b3b076e8a34c5c36e51f9aa4616ab542 has been commited.