### PR TITLE
[ALLI-7073] Feedtabs improvement

### DIFF
--- a/themes/finna2/js/finna-feed-tabs.js
+++ b/themes/finna2/js/finna-feed-tabs.js
@@ -1,110 +1,134 @@
 /*global finna */
 finna.feedTabs = (function finnaFeedTab() {
-  function getTabContainer(tabs) {
-    return tabs.find('.tab-content');
+  function FeedTab(container) {
+    var _ = this;
+    container.classList.add('inited');
+    _.tabs = container.querySelectorAll('.feed-tab-anchor');
+    _.accordions = container.querySelectorAll('.feed-accordion-anchor');
+    _.tabContent = container.querySelector('.tab-content');
+    _.setEvents();
+    _.firstLoad();
+
+    _.isLoading = false;
   }
 
-  function loadFeed(tabs, tabId) {
-    var tabContainer = getTabContainer(tabs);
-    var feedContainer = tabContainer.find('.feed-container');
-    feedContainer.data('init', null);
-    feedContainer.data('feed', tabId);
-    finna.feed.loadFeed(feedContainer);
-  }
-
-  function keyHandler(e/*, cb*/) {
-    if (e.which === 13 || e.which === 32) {
-      $(e.target).click();
-      e.preventDefault();
-      return false;
-    }
-    return true;
-  }
-
-  function toggleAccordion(container, accordion) {
-    var tabContent = container.find('.tab-content').detach();
-    var tabId = accordion.data('tab');
-    var loadContent = false;
-    var accordions = container.find('.feed-accordions');
-    if (!accordion.hasClass('active') || accordion.hasClass('initial-active')) {
-      accordions.find('.accordion.active')
-        .removeClass('active')
-        .attr('aria-selected', false);
-
-      container.find('.feed-tab.active')
-        .removeClass('active')
-        .attr('aria-selected', false);
-
-      accordions.toggleClass('all-closed', false);
-
-      accordion
-        .addClass('active')
-        .attr('aria-selected', true);
-
-      container.find('.feed-tab[data-tab="' + tabId + '"]')
-        .addClass('active')
-        .attr('aria-selected', true);
-
-      loadContent = true;
-    }
-    tabContent.insertAfter(accordion);
-    accordion.removeClass('initial-active');
-
-    return loadContent;
-  }
-
-  function loadFeedTabs(container) {
-    if (container.hasClass('inited')) {
-      return;
-    }
-    container.addClass('inited');
-    container.tab('show');
-
-    // Init feed tabs
-    container.find('li.nav-item').on('click', function feedTabClick() {
-      var tabId = $(this).data('tab');
-      var li = $(this).closest('li');
-      if (li.hasClass('active') && !li.hasClass('initial-active')) {
-        return false;
-      }
-      li.removeClass('initial-active');
-
-      getTabContainer(container).removeClass('active');
-
-      var accordion = container.find('.feed-accordions .accordion[data-tab="' + tabId + '"]');
-      if (toggleAccordion(container, accordion)) {
-        loadFeed(container, tabId);
-      }
-
-      return false;
-    }).keyup(function onKeyUp(e) {
-      return keyHandler(e);
+  /**
+   * Set proper events to listen for
+   */
+  FeedTab.prototype.setEvents = function setEvents() {
+    var _ = this;
+    _.tabs.forEach(function addClickListener(element) {
+      element.parentNode.addEventListener('click', function onFeedTabClick(e) {
+        e.preventDefault();
+        _.displayTab(element);
+      });
+    });
+    _.accordions.forEach(function addClickListener(element) {
+      element.parentNode.addEventListener('click', function onFeedTabClick(e) {
+        e.preventDefault();
+        _.displayTab(element);
+      });
     });
 
-    // Init accordions (mobile)
-    container.find('.feed-accordions .accordion').on('click', function accordionClicked(/*e*/) {
-      var accordion = $(this);
-      var tabId = accordion.data('tab');
-
-      var tabs = accordion.closest('.feed-tabs');
-      getTabContainer(tabs).removeClass('active');
-
-      if (toggleAccordion(container, accordion)) {
-        loadFeed(container, tabId);
+    window.addEventListener('hashchange', function checkForHashChange() {
+      if (_.isLoading) {
+        return;
       }
-      return false;
-    }).keyup(function onKeyUp(e) {
-      return keyHandler(e);
+      var hash = window.location.hash;
+      if (hash) {
+        _.tabs.forEach(function checkIfThis(element) {
+          if (element.getAttribute('href') === hash) {
+            element.click();
+          }
+        });
+      }
     });
+  };
 
-    container.find('.feed-accordions .accordion.active').click();
-  }
+  /**
+   * Display the proper feedtab and accordion tab
+   * 
+   * @param {HTMLElement} element
+   */
+  FeedTab.prototype.displayTab = function displayTab(element) {
+    var _ = this;
 
+    _.isLoading = true;
+    var tab = element.dataset.tab;
+    var href = element.getAttribute('href');
+    if (window.location.hash !== href) {
+      window.location.hash = href;
+    }
+
+    _.accordions.forEach(function removeActive(el) {
+      el.parentNode.classList.remove('active');
+      el.parentNode.setAttribute('aria-selected', false);
+      if (el.dataset.tab === tab) {
+        el.parentNode.classList.add('active');
+        el.parentNode.setAttribute('aria-selected', true);
+        el.parentNode.insertAdjacentElement('afterend', _.tabContent);
+      }
+    });
+    _.tabs.forEach(function removeActive(el) {
+      el.parentNode.classList.remove('active');
+      el.parentNode.setAttribute('aria-selected', false);
+      if (el.dataset.tab === tab) {
+        el.parentNode.classList.add('active');
+        el.parentNode.setAttribute('aria-selected', true);
+      }
+    });
+    _.tabContent.innerHTML = '';
+    delete _.tabContent.dataset.init;
+    _.tabContent.dataset.feed = tab;
+    finna.feed.loadFeed(_.tabContent, function onLoad() {
+      _.isLoading = false;
+    });
+  };
+
+  /**
+   * Load first tab page when initialization is completed
+   */
+  FeedTab.prototype.firstLoad = function firstLoad() {
+    var _ = this;
+    var hash = window.location.hash;
+
+    _.tabs.forEach(function checkFirst(element) {
+      if (!hash && !_.isLoading && element.parentNode.classList.contains('active')) {
+        element.parentNode.click();
+      }
+      if (hash === element.getAttribute('href')) {
+        element.parentNode.click();
+      }
+    });
+    if (_.tabs[0] && !_.isLoading) {
+      _.tabs[0].parentNode.click();
+    }
+  };
+  
+  /**
+   * Init feedtabs
+   * 
+   * @param {String} id 
+   */
   function init(id) {
-    var container = $('.feed-tabs#' + id);
-    $(container).one('inview', function doInit() {
-      loadFeedTabs(container);
-    });
+    var containers = document.querySelectorAll('.feed-tabs#' + id + ':not(.inited)');
+
+    // TODO: remove jquery version of the init
+    if (window.IntersectionObserver) {
+      var observer = new IntersectionObserver(function observe(entries, obs) {
+        entries.forEach(function checkEntry(entry) {
+          new FeedTab(entry.target);
+          obs.unobserve(entry.target);
+        }); 
+      }, {rootMargin: "0px 0px -200px 0px"});
+      containers.forEach(function observeFeedTab(container) {
+        observer.observe(container);
+      });
+    } else {
+      $(containers).one('inview', function onInview() {
+        new FeedTab(this);
+      });
+    }
   }
 
   var my = {

--- a/themes/finna2/js/finna-feed-tabs.js
+++ b/themes/finna2/js/finna-feed-tabs.js
@@ -1,5 +1,15 @@
 /*global finna */
 finna.feedTabs = (function finnaFeedTab() {
+
+  /**
+   * Return the location hash without hashtag
+   * 
+   * @return {String} hash without hashtag
+   */
+  function getHashWithoutHashTag() {
+    var hash = window.location.hash;
+    return hash ? hash.substring(1) : '';
+  }
   function FeedTab(container) {
     var _ = this;
     container.classList.add('inited');
@@ -101,11 +111,6 @@ finna.feedTabs = (function finnaFeedTab() {
       _.anchors[0].parentNode.click();
     }
   };
-  
-  function getHashWithoutHashTag() {
-    var hash = window.location.hash;
-    return hash ? hash.substring(1) : '';
-  }
 
   /**
    * Init feedtabs

--- a/themes/finna2/js/finna-feed-tabs.js
+++ b/themes/finna2/js/finna-feed-tabs.js
@@ -7,7 +7,7 @@ finna.feedTabs = (function finnaFeedTab() {
     _.tabContent = container.querySelector('.tab-content');
     _.setEvents();
     _.firstLoad();
-
+    _.allowHashchange = false;
     _.isLoading = false;
   }
 
@@ -24,16 +24,17 @@ finna.feedTabs = (function finnaFeedTab() {
     });
 
     window.addEventListener('hashchange', function checkForHashChange() {
-      if (_.isLoading) {
+      if (_.isLoading || !_.allowHashchange) {
         return;
       }
-      var hash = window.location.hash;
+      var hash = getHashWithoutHashTag();
       if (hash) {
         _.anchors.forEach(function checkIfThis(element) {
           if (element.classList.contains('feed-tab-anchor') &&
-            element.getAttribute('href') === hash
+            element.dataset.tab === hash
           ) {
             element.click();
+            element.focus();
           }
         });
       }
@@ -50,9 +51,8 @@ finna.feedTabs = (function finnaFeedTab() {
 
     _.isLoading = true;
     var tab = element.dataset.tab;
-    var href = element.getAttribute('href');
-    if (window.location.hash !== href) {
-      window.location.hash = href;
+    if (window.location.hash !== tab) {
+      window.location.hash = tab;
     }
 
     _.anchors.forEach(function removeActive(el) {
@@ -73,6 +73,9 @@ finna.feedTabs = (function finnaFeedTab() {
     _.tabContent.dataset.feed = tab;
     finna.feed.loadFeed(_.tabContent, function onLoad() {
       _.isLoading = false;
+      if (!_.allowHashchange) {
+        _.allowHashchange = true;
+      }
     });
   };
 
@@ -81,7 +84,7 @@ finna.feedTabs = (function finnaFeedTab() {
    */
   FeedTab.prototype.firstLoad = function firstLoad() {
     var _ = this;
-    var hash = window.location.hash;
+    var hash = getHashWithoutHashTag();
 
     _.anchors.forEach(function checkFirst(element) {
       if (!element.classList.contains('feed-tab-anchor')) {
@@ -89,7 +92,7 @@ finna.feedTabs = (function finnaFeedTab() {
       }
       var parent = element.parentNode;
       if ((!hash && !_.isLoading && parent.classList.contains('active')) ||
-        hash === element.getAttribute('href')
+        hash === element.dataset.tab
       ) {
         parent.click();
       }
@@ -99,6 +102,11 @@ finna.feedTabs = (function finnaFeedTab() {
     }
   };
   
+  function getHashWithoutHashTag() {
+    var hash = window.location.hash;
+    return hash ? hash.substring(1) : '';
+  }
+
   /**
    * Init feedtabs
    * 

--- a/themes/finna2/js/finna-feed-tabs.js
+++ b/themes/finna2/js/finna-feed-tabs.js
@@ -6,18 +6,18 @@ finna.feedTabs = (function finnaFeedTab() {
    * 
    * @return {String} hash without hashtag
    */
-  function getHashWithoutHashTag() {
+  function getTabFromLocationHash() {
     var hash = window.location.hash;
     return hash ? hash.substring(1) : '';
   }
   function FeedTab(container) {
     var _ = this;
-    container.classList.add('inited');
+    container.classList.add('init-done');
     _.anchors = container.querySelectorAll('.feed-tab-anchor, .feed-accordion-anchor');
     _.tabContent = container.querySelector('.tab-content');
     _.setEvents();
     _.firstLoad();
-    _.allowHashchange = false;
+    _.allowHashChange = false;
     _.isLoading = false;
   }
 
@@ -34,10 +34,10 @@ finna.feedTabs = (function finnaFeedTab() {
     });
 
     window.addEventListener('hashchange', function checkForHashChange() {
-      if (_.isLoading || !_.allowHashchange) {
+      if (_.isLoading || !_.allowHashChange) {
         return;
       }
-      var hash = getHashWithoutHashTag();
+      var hash = getTabFromLocationHash();
       if (hash) {
         _.anchors.forEach(function checkIfThis(element) {
           if (element.classList.contains('feed-tab-anchor') &&
@@ -83,8 +83,8 @@ finna.feedTabs = (function finnaFeedTab() {
     _.tabContent.dataset.feed = tab;
     finna.feed.loadFeed(_.tabContent, function onLoad() {
       _.isLoading = false;
-      if (!_.allowHashchange) {
-        _.allowHashchange = true;
+      if (!_.allowHashChange) {
+        _.allowHashChange = true;
       }
     });
   };
@@ -94,7 +94,7 @@ finna.feedTabs = (function finnaFeedTab() {
    */
   FeedTab.prototype.firstLoad = function firstLoad() {
     var _ = this;
-    var hash = getHashWithoutHashTag();
+    var hash = getTabFromLocationHash();
 
     _.anchors.forEach(function checkFirst(element) {
       if (!element.classList.contains('feed-tab-anchor')) {
@@ -118,8 +118,7 @@ finna.feedTabs = (function finnaFeedTab() {
    * @param {String} id 
    */
   function init(id) {
-    var containers = document.querySelectorAll('.feed-tabs#' + id + ':not(.inited)');
-    // TODO: remove jquery version of the init
+    var containers = document.querySelectorAll('.feed-tabs#' + id + ':not(.init-done)');
     if (window.IntersectionObserver) {
       var observer = new IntersectionObserver(function observe(entries, obs) {
         entries.forEach(function checkEntry(entry) {
@@ -131,6 +130,8 @@ finna.feedTabs = (function finnaFeedTab() {
         observer.observe(container);
       });
     } else {
+      // TODO: remove jquery version of the init
+      // Support for older browsers
       $(containers).one('inview', function onInview() {
         new FeedTab(this);
       });

--- a/themes/finna2/js/finna-feed-tabs.js
+++ b/themes/finna2/js/finna-feed-tabs.js
@@ -61,20 +61,22 @@ finna.feedTabs = (function finnaFeedTab() {
     }
 
     _.accordions.forEach(function removeActive(el) {
-      el.parentNode.classList.remove('active');
-      el.parentNode.setAttribute('aria-selected', false);
+      var accParent = el.parentNode;
+      accParent.classList.remove('active');
+      accParent.setAttribute('aria-selected', false);
       if (el.dataset.tab === tab) {
-        el.parentNode.classList.add('active');
-        el.parentNode.setAttribute('aria-selected', true);
-        el.parentNode.insertAdjacentElement('afterend', _.tabContent);
+        accParent.classList.add('active');
+        accParent.setAttribute('aria-selected', true);
+        accParent.insertAdjacentElement('afterend', _.tabContent);
       }
     });
     _.tabs.forEach(function removeActive(el) {
-      el.parentNode.classList.remove('active');
-      el.parentNode.setAttribute('aria-selected', false);
+      var tabParent = el.parentNode;
+      tabParent.classList.remove('active');
+      tabParent.setAttribute('aria-selected', false);
       if (el.dataset.tab === tab) {
-        el.parentNode.classList.add('active');
-        el.parentNode.setAttribute('aria-selected', true);
+        tabParent.classList.add('active');
+        tabParent.setAttribute('aria-selected', true);
       }
     });
     _.tabContent.innerHTML = '';
@@ -93,11 +95,12 @@ finna.feedTabs = (function finnaFeedTab() {
     var hash = window.location.hash;
 
     _.tabs.forEach(function checkFirst(element) {
-      if (!hash && !_.isLoading && element.parentNode.classList.contains('active')) {
-        element.parentNode.click();
+      var parent = element.parentNode;
+      if (!hash && !_.isLoading && parent.classList.contains('active')) {
+        parent.click();
       }
       if (hash === element.getAttribute('href')) {
-        element.parentNode.click();
+        parent.click();
       }
     });
     if (_.tabs[0] && !_.isLoading) {

--- a/themes/finna2/js/finna-feed-tabs.js
+++ b/themes/finna2/js/finna-feed-tabs.js
@@ -3,8 +3,7 @@ finna.feedTabs = (function finnaFeedTab() {
   function FeedTab(container) {
     var _ = this;
     container.classList.add('inited');
-    _.tabs = container.querySelectorAll('.feed-tab-anchor');
-    _.accordions = container.querySelectorAll('.feed-accordion-anchor');
+    _.anchors = container.querySelectorAll('.feed-tab-anchor, .feed-accordion-anchor');
     _.tabContent = container.querySelector('.tab-content');
     _.setEvents();
     _.firstLoad();
@@ -17,13 +16,7 @@ finna.feedTabs = (function finnaFeedTab() {
    */
   FeedTab.prototype.setEvents = function setEvents() {
     var _ = this;
-    _.tabs.forEach(function addClickListener(element) {
-      element.parentNode.addEventListener('click', function onFeedTabClick(e) {
-        e.preventDefault();
-        _.displayTab(element);
-      });
-    });
-    _.accordions.forEach(function addClickListener(element) {
+    _.anchors.forEach(function addClickListener(element) {
       element.parentNode.addEventListener('click', function onFeedTabClick(e) {
         e.preventDefault();
         _.displayTab(element);
@@ -36,8 +29,10 @@ finna.feedTabs = (function finnaFeedTab() {
       }
       var hash = window.location.hash;
       if (hash) {
-        _.tabs.forEach(function checkIfThis(element) {
-          if (element.getAttribute('href') === hash) {
+        _.anchors.forEach(function checkIfThis(element) {
+          if (element.classList.contains('feed-tab-anchor') &&
+            element.getAttribute('href') === hash
+          ) {
             element.click();
           }
         });
@@ -60,23 +55,17 @@ finna.feedTabs = (function finnaFeedTab() {
       window.location.hash = href;
     }
 
-    _.accordions.forEach(function removeActive(el) {
-      var accParent = el.parentNode;
-      accParent.classList.remove('active');
-      accParent.setAttribute('aria-selected', false);
+    _.anchors.forEach(function removeActive(el) {
+      var parent = el.parentNode;
       if (el.dataset.tab === tab) {
-        accParent.classList.add('active');
-        accParent.setAttribute('aria-selected', true);
-        accParent.insertAdjacentElement('afterend', _.tabContent);
-      }
-    });
-    _.tabs.forEach(function removeActive(el) {
-      var tabParent = el.parentNode;
-      tabParent.classList.remove('active');
-      tabParent.setAttribute('aria-selected', false);
-      if (el.dataset.tab === tab) {
-        tabParent.classList.add('active');
-        tabParent.setAttribute('aria-selected', true);
+        parent.classList.add('active');
+        parent.setAttribute('aria-selected', true);
+        if (el.classList.contains('feed-accordion-anchor')) {
+          parent.insertAdjacentElement('afterend', _.tabContent);
+        }
+      } else {
+        parent.classList.remove('active');
+        parent.setAttribute('aria-selected', false);
       }
     });
     _.tabContent.innerHTML = '';
@@ -94,17 +83,19 @@ finna.feedTabs = (function finnaFeedTab() {
     var _ = this;
     var hash = window.location.hash;
 
-    _.tabs.forEach(function checkFirst(element) {
-      var parent = element.parentNode;
-      if (!hash && !_.isLoading && parent.classList.contains('active')) {
-        parent.click();
+    _.anchors.forEach(function checkFirst(element) {
+      if (!element.classList.contains('feed-tab-anchor')) {
+        return;
       }
-      if (hash === element.getAttribute('href')) {
+      var parent = element.parentNode;
+      if ((!hash && !_.isLoading && parent.classList.contains('active')) ||
+        hash === element.getAttribute('href')
+      ) {
         parent.click();
       }
     });
-    if (_.tabs[0] && !_.isLoading) {
-      _.tabs[0].parentNode.click();
+    if (_.anchors[0] && !_.isLoading) {
+      _.anchors[0].parentNode.click();
     }
   };
   
@@ -115,7 +106,6 @@ finna.feedTabs = (function finnaFeedTab() {
    */
   function init(id) {
     var containers = document.querySelectorAll('.feed-tabs#' + id + ':not(.inited)');
-
     // TODO: remove jquery version of the init
     if (window.IntersectionObserver) {
       var observer = new IntersectionObserver(function observe(entries, obs) {

--- a/themes/finna2/js/finna-feed.js
+++ b/themes/finna2/js/finna-feed.js
@@ -279,6 +279,8 @@ finna.feed = (function finnaFeed() {
 
   function loadFeed(holder, callback) {
     var container = holder instanceof jQuery ? holder : $(holder);
+    // Clear the internal jQuery memory of data feed so proper data being taken
+    container.removeData('feed');
     var id = container.data('feed');
     if (typeof id == 'undefined') {
       return;

--- a/themes/finna2/js/finna-feed.js
+++ b/themes/finna2/js/finna-feed.js
@@ -121,7 +121,7 @@ finna.feed = (function finnaFeed() {
     };
   }
 
-  function processLoadFeed(holder, params, callback) {
+  function processLoadFeed(holder, params, onFeedLoaded) {
     params['touch-device'] = (finna.layout.isTouchDevice() ? 1 : 0);
 
     var url = VuFind.path + '/AJAX/JSON?' + $.param(params);
@@ -262,8 +262,8 @@ finna.feed = (function finnaFeed() {
         } else if (feedGrid.width() <= 800) {
           feedGrid.find('.grid-item').css('flex-basis', '50%');
         }
-        if (callback) {
-          callback();
+        if (onFeedLoaded) {
+          onFeedLoaded();
         }
         feedGrid.find('img').unveil();
       })
@@ -277,7 +277,7 @@ finna.feed = (function finnaFeed() {
       });
   }
 
-  function loadFeed(holder, callback) {
+  function loadFeed(holder, onFeedLoaded) {
     var container = holder instanceof jQuery ? holder : $(holder);
     // Clear the internal jQuery memory of data feed so proper data being taken
     container.removeData('feed');
@@ -285,7 +285,7 @@ finna.feed = (function finnaFeed() {
     if (typeof id == 'undefined') {
       return;
     }
-    processLoadFeed(container, {method: 'getFeed', id: id}, callback);
+    processLoadFeed(container, {method: 'getFeed', id: id}, onFeedLoaded);
   }
 
   function loadFeedFromUrl(holder) {

--- a/themes/finna2/js/finna-feed.js
+++ b/themes/finna2/js/finna-feed.js
@@ -121,7 +121,7 @@ finna.feed = (function finnaFeed() {
     };
   }
 
-  function processLoadFeed(holder, params) {
+  function processLoadFeed(holder, params, callback) {
     params['touch-device'] = (finna.layout.isTouchDevice() ? 1 : 0);
 
     var url = VuFind.path + '/AJAX/JSON?' + $.param(params);
@@ -262,6 +262,10 @@ finna.feed = (function finnaFeed() {
         } else if (feedGrid.width() <= 800) {
           feedGrid.find('.grid-item').css('flex-basis', '50%');
         }
+        if (callback) {
+          callback();
+        }
+        feedGrid.find('img').unveil();
       })
       .fail(function loadFeedFail(response/*, textStatus, err*/) {
         var err = '<!-- Feed could not be loaded';
@@ -273,12 +277,13 @@ finna.feed = (function finnaFeed() {
       });
   }
 
-  function loadFeed(holder) {
-    var id = holder.data('feed');
+  function loadFeed(holder, callback) {
+    var container = holder instanceof jQuery ? holder : $(holder);
+    var id = container.data('feed');
     if (typeof id == 'undefined') {
       return;
     }
-    processLoadFeed(holder, {method: 'getFeed', id: id});
+    processLoadFeed(container, {method: 'getFeed', id: id}, callback);
   }
 
   function loadFeedFromUrl(holder) {

--- a/themes/finna2/js/finna-record.js
+++ b/themes/finna2/js/finna-record.js
@@ -295,7 +295,7 @@ finna.record = (function finnaRecord() {
       ? window.location.hash.toLowerCase() : '';
 
     // Open tab in url hash
-    var $tab = $("a[data-tab='" + newTab.substr(1) + "']");
+    var $tab = $("a:not(.feed-tab-anchor,.feed-accordion-anchor)[data-tab='" + newTab.substr(1) + "']");
     var accordion = (newTab.length <= 1 || newTab === '#tabnav' || $tab.length === 0)
       ? $('.record-accordions .accordion.initiallyActive')
       : $tab.closest('.accordion');

--- a/themes/finna2/less/finna/content.less
+++ b/themes/finna2/less/finna/content.less
@@ -54,7 +54,7 @@
         color: @link-color;
         margin-bottom: 25px;
     }
-    & ul:not(.nav-tabs.help-tabs):not(.finna-nav) li {
+    & ul:not(.nav-tabs.help-tabs):not(.finna-nav) li:not(.feed-tab) {
         margin-bottom: 3px;
     }
     .organisation-list-item {

--- a/themes/finna2/less/finna/feed.less
+++ b/themes/finna2/less/finna/feed.less
@@ -461,6 +461,7 @@
     margin-top: 20px;
     margin-bottom: 12px;
     border-bottom: 1px solid #919191;
+    align-items: center;
     .feed-tabs-title {
         margin-left: 0;
         margin-bottom: 5px;

--- a/themes/finna2/less/finna/tabs.less
+++ b/themes/finna2/less/finna/tabs.less
@@ -131,9 +131,23 @@
   }
 }
 
+.feed-tabs .feed-accordions {
+  .accordion {
+    padding: 0;
+    >.feed-accordion-anchor {
+      display: inline-block;
+      width: 100%;
+      height: 100%;
+      margin: 15px 10px;
+      color: @nav-tabs-text-color;
+    }
+  }
+}
+
 // RSS-feed tabs
 .feed-tabs .nav-tabs {
   border-bottom: 1px solid @nav-tabs-border-color;
+  margin-left: 6px;
   > li {
     // Make the list-items overlay the bottom border
     margin-bottom: -1px;
@@ -141,12 +155,9 @@
     font-weight: 500;
     background-color: transparent;
     color: @nav-tabs-text-color;
-    margin-right: 3px;
-    padding: .6em .5em;
-    border: 1px solid transparent;
-    border-radius: 0;
-    transition: none;
-    border-top: 4px solid transparent;
+    border-bottom: 1px solid transparent;
+    margin: 0;
+    padding: .6em 0 0 0;
     cursor: pointer;
     @media (min-width: @screen-sm-min) and (max-width: @screen-sm-max) {
       i {
@@ -161,7 +172,6 @@
       color: @nav-tabs-link-hover-color;
       border-color: transparent;
     }
-
     // Active state, and its :hover to override normal :hover
     &.active {
       cursor: initial;
@@ -169,12 +179,15 @@
       &:hover,
       &:focus {
         background-color: @body-bg;
-        border: 1px solid @nav-tabs-border-color;
-        border-top: 4px solid @nav-tabs-active-color;
-        border-bottom-color: transparent;
-        transition: border 0.05s linear;
         color: @text-color;
+        margin-bottom: -1px;
+        border-bottom: none;
+        transition: 0s;
       }
+    }
+    a {
+      margin-right: 0px;
+      height: 100%;
     }
   }
 }

--- a/themes/finna2/templates/Helpers/feedtabs.phtml
+++ b/themes/finna2/templates/Helpers/feedtabs.phtml
@@ -49,7 +49,7 @@
     <?php endforeach; ?>
   </div>
 
-  <div class="tab-content" id="tab-content-<?=$this->escapeHtmlAttr($this->id)?>">
+  <div class="tab-content">
     <div class="feed-container" data-init="0"></div>
   </div>
 </div>

--- a/themes/finna2/templates/Helpers/feedtabs.phtml
+++ b/themes/finna2/templates/Helpers/feedtabs.phtml
@@ -1,38 +1,32 @@
 <!-- START of: finna - Helpers/feedtabs.phtml -->
 <div class="feed-tabs" id="feed-tabs-<?=$this->escapeHtmlAttr($this->id)?>">
   <?php if (count($this->feedIds) > 3): ?>
-  <div class="tabs-responsive">
+    <div class="tabs-responsive">
   <?php endif; ?>
-    <div class="visible-md visible-lg">
-      <div class="feed-tabs-container">
-        <h2 class="feed-tabs-title"><?= $this->transEsc($this->title);?></h2>
-        <ul class="nav nav-tabs" role="tablist">
-        <?php $tabNames = []; ?>
-        <?php foreach ($this->feedIds as $desc => $feed): ?>
-          <?php
-           $tabName = preg_replace("/\W/", "-", strtolower($feed));
-           $tabNames[] = $tabName;
-           $tabClasses = [ 'nav-item', 'feed-tab', $tabName ];
-           $isActive = 0 === strcasecmp($this->active, $feed);
-           if ($isActive) {
-              $tabClasses[] = 'active initial-active';
-           }
-           $tabId = $this->id . '-' . $feed;
-          ?>
-          <li class="<?=$this->escapeHtmlAttr(implode(' ', $tabClasses))?>" data-tab="<?=$this->escapeHtmlAttr($tabName)?>"
-             aria-label="<?=$this->escapeHtmlAttr($this->transEsc($desc))?>"
-             id="<?=$this->escapeHtmlAttr($tabId)?>-tab"
-             role="tab"
-             tabindex="0"
-             data-tab="<?=$this->escapeHtmlAttr($feed)?>"
-             aria-selected="<?= $isActive ? 'true' : 'false' ?>"><?= $this->transEsc($desc)?>
-          </li>
-          <?php endforeach; ?>
-        </ul>
-      </div>
+  <div class="visible-md visible-lg">
+    <div class="feed-tabs-container">
+      <h2 class="feed-tabs-title"><?= $this->transEsc($this->title);?></h2>
+      <ul class="nav nav-tabs" role="tablist">
+      <?php $tabNames = []; ?>
+      <?php $id = 0; ?>
+      <?php foreach ($this->feedIds as $desc => $feed): ?>
+        <?php
+          $tabName = preg_replace("/\W/", "-", strtolower($feed));
+          $tabNames[] = $tabName;
+          $isActive = 0 === strcasecmp($this->active, $feed);
+          $tabId = $this->id . '-' . $feed;
+        ?>
+        <li class="feed-tab <?=$isActive ? 'active' : ''?>" data-tab="<?=$this->escapeHtmlAttr($tabName)?>" role="tab" aria-selected="<?= $isActive ? 'true' : 'false' ?>">
+            <a class="feed-tab-anchor" tabindex="0" href="<?='#' . $this->escapeHtmlAttr($tabId)?>" id="<?=$this->escapeHtmlAttr($tabId) . '-tab'?>" data-tab="<?=$this->escapeHtmlAttr($feed)?>" aria-label="<?=$this->escapeHtmlAttr($this->transEsc($desc))?>" data-lightbox-ignore>
+              <?= $this->transEsc($desc)?>
+            </a>
+        </li>
+        <?php endforeach; ?>
+      </ul>
     </div>
-  <?php if (count($this->feedIds) > 3): ?>
   </div>
+  <?php if (count($this->feedIds) > 3): ?>
+    </div>
   <?php endif; ?>
 
   <div class="feed-accordions" role="tablist">
@@ -46,12 +40,10 @@
         }
         $tabId = $this->id . '-' . $feed;
       ?>
-      <div class="<?=$this->escapeHtmlAttr(implode(' ', $classes))?>"
-           data-tab="<?=$this->escapeHtmlAttr($feed)?>"
-           role="tab"
-           tabindex="0"
-           aria-selected="<?= $isActive ? 'true' : 'false' ?>">
-          <span class="title"><?=$this->transEsc($desc)?></span>
+      <div class="<?=$this->escapeHtmlAttr(implode(' ', $classes))?>" role="tab" aria-selected="<?= $isActive ? 'true' : 'false' ?>">
+           <a class="feed-accordion-anchor" tabindex="0" href="<?='#' . $this->escapeHtmlAttr($tabId)?>" id="<?=$this->escapeHtmlAttr($tabId) . '-accordion'?>" data-tab="<?=$this->escapeHtmlAttr($feed)?>" aria-label="<?=$this->escapeHtmlAttr($this->transEsc($desc))?>" data-lightbox-ignore>
+              <?= $this->transEsc($desc)?>
+            </a>
           <i class="icon"></i>
       </div>
     <?php endforeach; ?>

--- a/themes/finna2/templates/ajax/feed-grid.phtml
+++ b/themes/finna2/templates/ajax/feed-grid.phtml
@@ -21,7 +21,7 @@
         <?php if (isset($item['image']) && isset($item['image']['url'])): ?>
           <span class="grid-image <?= empty($item['image']['url']) ? 'no-image' : ''; ?>">
             <?php if (!empty($item['image']['url'])): ?>
-              <img src="<?= $item['image']['url']; ?>" alt="" />
+              <img data-src="<?= $item['image']['url']; ?>" alt="" />
             <?php else: ?>
               <i class="fa fa-calendar-o image-placeholder"></i>
             <?php endif; ?>


### PR DESCRIPTION
Lazy-load images, save tab to url fragment. Small style tuning, use proper anchors. Switch code from jquery to js.

Test with 2 feedtabs. Rss.ini can be fetched from vaski.

`<!-- START of: Content/tapahtumat.fi.phtml -->

<? $this->headTitle(''); $this->content()->setHeading(''); ?>

<br><br>
<div class="row">
    <div class="col-xs-12">
<p>Voit selata tapahtumia eri aihepiirien mukaan. Oman kirjastosi tapahtumat näet toimipisteen sivulla. </P>
<?=$this->feedTabs(['title' => 'Tapahtumaotsikko_kaikki_tapahtumat', 'ids' => ['Valilehti_1_kaikki' => 'kaikki_tapahtumat_kirjallisuus', 'Valilehti_2_kaikki' => 'kaikki_tapahtumat_esitys', 'Valilehti_3_kaikki' => 'kaikki_tapahtumat_muu_tapahtuma', 'Valilehti_4_kaikki' => 'kaikki_tapahtumat_nayttely']])?>

</div>
</div>

<div class="row">
    <div class="col-xs-12">
<p>Voit selata tapahtumia eri aihepiirien mukaan. Oman kirjastosi tapahtumat näet toimipisteen sivulla. </P>
<?=$this->feedTabs(['title' => 'Juutestivaan', 'ids' => ['Valilehti_1_kaikki' => 'vinkit-nuoret', 'Valilehti_2_kaikki' => 'nuortenvinkkinosto_kirjat', 'Valilehti_3_kaikki' => 'nuortenvinkkinosto_elokuvat', 'Valilehti_4_kaikki' => 'nuortenvinkkinosto_pelit']])?>

</div>
</div>



<!-- END of: Content/tapahtumat.fi.tpl -->`