### PR TITLE
[ALLI-7195] Fix missing pdf links from result-online-urls

### DIFF
--- a/themes/finna2/templates/RecordDriver/DefaultRecord/result-online-urls.phtml
+++ b/themes/finna2/templates/RecordDriver/DefaultRecord/result-online-urls.phtml
@@ -26,7 +26,7 @@
         <?php if (!empty($urls)): ?>
           <?php foreach ($urls as $i => $url): ?>
             <?php
-              if (isset($images[$url['url']]) && !empty($url['codec']) && $url['codec'] !== 'pdf') {
+              if (isset($images[$url['url']]) && ($url['codec'] ?? '') !== 'pdf') {
                 continue;
               }
               $renderedURLs[] = $url['url'];
@@ -63,10 +63,8 @@
         <?php if (!empty($onlineURLs) || !empty($mergedData['urls'])): ?>
           <?php foreach (!empty($mergedData['urls']) ? $mergedData['urls'] : $onlineURLs as $i => $url): ?>
             <?php
-              if (isset($images[$url['url']]) || in_array($url['url'], $renderedURLs)) {
-                if (!empty($url['codec']) && $url['codec'] !== 'pdf') {
-                  continue;
-                }
+              if ((isset($images[$url['url']]) || in_array($url['url'], $renderedURLs)) && ($url['codec'] ?? '') !== 'pdf') {
+                continue;
               }
               $currentUrl = [
                 'href' => $this->proxyUrl($url['url']),

--- a/themes/finna2/templates/RecordDriver/DefaultRecord/result-online-urls.phtml
+++ b/themes/finna2/templates/RecordDriver/DefaultRecord/result-online-urls.phtml
@@ -66,8 +66,8 @@
             <?php
               if ((isset($images[$url['url']])
                 || in_array($url['url'], $renderedURLs))
-                && strcasecmp(pathinfo($url['url'], PATHINFO_EXTENSION), 'pdf') !== 0)
-              {
+                && strcasecmp(pathinfo($url['url'], PATHINFO_EXTENSION), 'pdf') !== 0
+              ) {
                 // PDF links should be displayed as they are not originally images
                 continue;
               }

--- a/themes/finna2/templates/RecordDriver/DefaultRecord/result-online-urls.phtml
+++ b/themes/finna2/templates/RecordDriver/DefaultRecord/result-online-urls.phtml
@@ -5,7 +5,6 @@
 
     $images = $this->record($this->driver)->getAllRecordImageUrls();
     $urls = $this->driver->getURLs();
-
     $onlineURLs = $this->driver->tryMethod('getOnlineURLs');
     $mergedData = $this->driver->tryMethod('getMergedRecordData');
 

--- a/themes/finna2/templates/RecordDriver/DefaultRecord/result-online-urls.phtml
+++ b/themes/finna2/templates/RecordDriver/DefaultRecord/result-online-urls.phtml
@@ -8,9 +8,6 @@
 
     $onlineURLs = $this->driver->tryMethod('getOnlineURLs');
     $mergedData = $this->driver->tryMethod('getMergedRecordData');
-    echo "<pre>";
-    var_dump($urls, $onlineURLs);
-    echo "</pre>";
     $videoScripts = $this->partial('Helpers/videojs-urls.phtml');
 
     $urlBase = [

--- a/themes/finna2/templates/RecordDriver/DefaultRecord/result-online-urls.phtml
+++ b/themes/finna2/templates/RecordDriver/DefaultRecord/result-online-urls.phtml
@@ -5,9 +5,12 @@
 
     $images = $this->record($this->driver)->getAllRecordImageUrls();
     $urls = $this->driver->getURLs();
+
     $onlineURLs = $this->driver->tryMethod('getOnlineURLs');
     $mergedData = $this->driver->tryMethod('getMergedRecordData');
-
+    echo "<pre>";
+    var_dump($urls, $onlineURLs);
+    echo "</pre>";
     $videoScripts = $this->partial('Helpers/videojs-urls.phtml');
 
     $urlBase = [
@@ -66,7 +69,10 @@
             <?php
               if (isset($images[$url['url']]) || in_array($url['url'], $renderedURLs))
               {
-                continue;
+                // PDF links should be displayed still as they are not originally images
+                if (strcasecmp(pathinfo($url['url'], PATHINFO_EXTENSION), 'pdf') !== 0) {
+                  continue;
+                }
               }
               $currentUrl = [
                 'href' => $this->proxyUrl($url['url']),

--- a/themes/finna2/templates/RecordDriver/DefaultRecord/result-online-urls.phtml
+++ b/themes/finna2/templates/RecordDriver/DefaultRecord/result-online-urls.phtml
@@ -64,12 +64,12 @@
         <?php if (!empty($onlineURLs) || !empty($mergedData['urls'])): ?>
           <?php foreach (!empty($mergedData['urls']) ? $mergedData['urls'] : $onlineURLs as $i => $url): ?>
             <?php
-              if (isset($images[$url['url']]) || in_array($url['url'], $renderedURLs))
+              if ((isset($images[$url['url']])
+                || in_array($url['url'], $renderedURLs))
+                && strcasecmp(pathinfo($url['url'], PATHINFO_EXTENSION), 'pdf') !== 0)
               {
-                // PDF links should be displayed still as they are not originally images
-                if (strcasecmp(pathinfo($url['url'], PATHINFO_EXTENSION), 'pdf') !== 0) {
-                  continue;
-                }
+                // PDF links should be displayed as they are not originally images
+                continue;
               }
               $currentUrl = [
                 'href' => $this->proxyUrl($url['url']),

--- a/themes/finna2/templates/RecordDriver/DefaultRecord/result-online-urls.phtml
+++ b/themes/finna2/templates/RecordDriver/DefaultRecord/result-online-urls.phtml
@@ -26,11 +26,10 @@
         <?php if (!empty($urls)): ?>
           <?php foreach ($urls as $i => $url): ?>
             <?php
-              if (isset($images[$url['url']]) && strcasecmp(pathinfo($url['url'], PATHINFO_EXTENSION), 'pdf') !== 0) {
+              if (isset($images[$url['url']]) && !empty($url['codec']) && $url['codec'] !== 'pdf') {
                 continue;
-              } else {
-                $renderedURLs[] = $url['url'];
               }
+              $renderedURLs[] = $url['url'];
             ?>
             <?=$i > 0 ? '<br/>' : '' ?>
             <?php
@@ -64,12 +63,10 @@
         <?php if (!empty($onlineURLs) || !empty($mergedData['urls'])): ?>
           <?php foreach (!empty($mergedData['urls']) ? $mergedData['urls'] : $onlineURLs as $i => $url): ?>
             <?php
-              if ((isset($images[$url['url']])
-                || in_array($url['url'], $renderedURLs))
-                && strcasecmp(pathinfo($url['url'], PATHINFO_EXTENSION), 'pdf') !== 0
-              ) {
-                // PDF links should be displayed as they are not originally images
-                continue;
+              if (isset($images[$url['url']]) || in_array($url['url'], $renderedURLs)) {
+                if (!empty($url['codec']) && $url['codec'] !== 'pdf') {
+                  continue;
+                }
               }
               $currentUrl = [
                 'href' => $this->proxyUrl($url['url']),

--- a/themes/finna2/templates/RecordDriver/DefaultRecord/result-online-urls.phtml
+++ b/themes/finna2/templates/RecordDriver/DefaultRecord/result-online-urls.phtml
@@ -8,6 +8,7 @@
 
     $onlineURLs = $this->driver->tryMethod('getOnlineURLs');
     $mergedData = $this->driver->tryMethod('getMergedRecordData');
+
     $videoScripts = $this->partial('Helpers/videojs-urls.phtml');
 
     $urlBase = [


### PR DESCRIPTION
Shouldn't they be still shown as they are not images but rather converted images.

test:

http://localhost/vufind/Search/Results?lookfor=id%3A%28etk.10024_129049+OR+etk.10024_129412+OR+etk.10024_129423+OR+etk.10024_131469%29&type=AllFields&dfApplied=1&limit=20