### PR TITLE
[ALLI-7173] AWS: allow excluding of pick up location depending on the hold type

### DIFF
--- a/local/config/finna/AxiellWebServices.ini.sample
+++ b/local/config/finna/AxiellWebServices.ini.sample
@@ -55,12 +55,13 @@ extraHoldFields = pickUpLocation
 ; the Location IDs returned by getPickUpLocations()
 defaultPickUpLocation = 1.001
 
-; A colon-separated list used to block pickup locations from desired request group.
-; Values can be either location IDs returned by getPickUpLocations() or
-; id=x where the x is the id of the organisation to block
-; Supports normal / regional
-;pickUpLocationBlockList['regional'] = 'id=1:1.001:7.115:12.160'
-;pickUpLocationBlockList['normal'] = 'id=3:1.001:7.115:12.160'
+; Exclude locations or organisations from hold pick up selection
+; Normal holds:
+;excludeOrganisationsFromNormalHoldPickUp = "1:3"
+;excludeLocationsFromNormalHoldPickUp = "1.001:7.115"
+; Regional holds:
+;excludeOrganisationsFromRegionalHoldPickUp = "1:3"
+;excludeLocationsFromRegionalHoldPickUp = "1.001:7.115"
 
 ; A request group ID used to pre-select the request group drop down list and
 ; provide a default option if others are not available. Must be one of the following:

--- a/local/config/finna/AxiellWebServices.ini.sample
+++ b/local/config/finna/AxiellWebServices.ini.sample
@@ -55,8 +55,12 @@ extraHoldFields = pickUpLocation
 ; the Location IDs returned by getPickUpLocations()
 defaultPickUpLocation = 1.001
 
-; A colon-separated list used to exclude certain pick up locations
-;excludePickUpLocations = "1.001:7.115:12.160"
+; A colon-separated list used to block pickup locations from desired request group.
+; Values can be either location IDs returned by getPickUpLocations() or
+; id=x where the x is the id of the organisation to block
+; Supports normal / regional
+;pickUpLocationBlockList['regional'] = 'id=1:1.001:7.115:12.160'
+;pickUpLocationBlockList['normal'] = 'id=3:1.001:7.115:12.160'
 
 ; A request group ID used to pre-select the request group drop down list and
 ; provide a default option if others are not available. Must be one of the following:

--- a/module/Finna/src/Finna/ILS/Driver/AxiellWebServices.php
+++ b/module/Finna/src/Finna/ILS/Driver/AxiellWebServices.php
@@ -405,7 +405,7 @@ class AxiellWebServices extends \VuFind\ILS\Driver\AbstractBase
             foreach ($excludePickUpLocations as $location) {
                 $this->pickUpLocationBlockList['regional']['unit'][]
                     = $this->pickUpLocationBlockList['normal']['unit'][]
-                    = $location;
+                        = $location;
             }
         }
 


### PR DESCRIPTION
Allows to block individual units or organisations depending on the hold type. Bc for old setting.