### PR TITLE
[ALLI-7301] Refactor large image layout handling.

### DIFF
--- a/local/config/finna/config.ini.sample
+++ b/local/config/finna/config.ini.sample
@@ -1408,6 +1408,17 @@ repository_library_request_in_holdings = true
 ; Whether to display repository library request in organisation info box:
 repository_library_request_in_organisation_info = true
 
+; Record formats (metadata schemas) that always use the large image layout
+; regardless of material type when images are available (default is "lido",
+; "forward" and "forwardAuthority"):
+;large_image_record_formats[] = "lido"
+;large_image_record_formats[] = "qdc"
+
+; Formats (material types) that use the large image layout when images are available
+; (default is "0/Image/", "0/PhysicalObject/", "0/WorkOfArt/" and "0/Video/"):
+;large_image_formats[] = "0/Image/"
+;large_image_formats[] = "0/Map/"
+
 ; The following two sections control the Alphabetic Browse module.
 [AlphaBrowse]
 ; This setting controls how many headings are displayed on each page of results:

--- a/module/Finna/src/Finna/View/Helper/Root/Record.php
+++ b/module/Finna/src/Finna/View/Helper/Root/Record.php
@@ -1137,7 +1137,8 @@ class Record extends \VuFind\View\Helper\Root\Record
         $largeImageFormats = [
             '0/Image/',
             '0/PhysicalObject/',
-            '0/WorkOfArt/'
+            '0/WorkOfArt/',
+            '0/Video/',
         ];
         if (array_intersect($formats, $largeImageFormats)) {
             return true;

--- a/module/Finna/src/Finna/View/Helper/Root/Record.php
+++ b/module/Finna/src/Finna/View/Helper/Root/Record.php
@@ -1113,11 +1113,7 @@ class Record extends \VuFind\View\Helper\Root\Record
         $images = $this->getAllImages($language, false, false, false);
         $hasValidImages = false;
         foreach ($images as $image) {
-            $validTypes = array_intersect(
-                array_keys($image['urls'] ?? []),
-                $imageTypes
-            );
-            if ($validTypes) {
+            if (array_intersect(array_keys($image['urls'] ?? []), $imageTypes)) {
                 $hasValidImages = true;
                 break;
             }
@@ -1126,20 +1122,27 @@ class Record extends \VuFind\View\Helper\Root\Record
             return false;
         }
 
-        // Always large image for LIDO, FORWARD and FORWARD authority:
+        // Check for record formats that always use large image layout:
+        $largeImageRecordFormats
+            = isset($this->config->Record->large_image_record_formats)
+            ? $this->config->Record->large_image_record_formats->toArray()
+            : ['lido', 'forward', 'forwardAuthority'];
         $recordFormat = $this->driver->tryMethod('getRecordFormat');
-        if (in_array($recordFormat, ['lido', 'forward', 'forwardAuthority'])) {
+        if (in_array($recordFormat, $largeImageRecordFormats)) {
             return true;
         }
 
+        // Check for formats that use large image layout:
+        $largeImageFormats
+            = isset($this->config->Record->large_image_formats)
+            ? $this->config->Record->large_image_formats->toArray()
+            : [
+                '0/Image/',
+                '0/PhysicalObject/',
+                '0/WorkOfArt/',
+                '0/Video/',
+            ];
         $formats = $this->driver->tryMethod('getFormats');
-        // Use for certain formats:
-        $largeImageFormats = [
-            '0/Image/',
-            '0/PhysicalObject/',
-            '0/WorkOfArt/',
-            '0/Video/',
-        ];
         if (array_intersect($formats, $largeImageFormats)) {
             return true;
         }

--- a/themes/finna2/js/finna-image-paginator.js
+++ b/themes/finna2/js/finna-image-paginator.js
@@ -125,9 +125,6 @@ FinnaPaginator.prototype.init = function init() {
     _.setEvents();
     _.loadPage(0, _.openImageIndex);
     _.setTrigger(_.track.find('a[index=' + _.openImageIndex + ']'));
-    _.addDocumentLoadCallback(function showLeftsidebar() {
-      $('.large-image-sidebar').removeClass('hidden');
-    });
   } else {
     _.setEvents();
     _.setListTrigger(_.getImageFromArray(0));
@@ -563,27 +560,19 @@ FinnaPaginator.prototype.changeTriggerImage = function changeTriggerImage(imageP
       }
       if (!_.settings.isList && _.images.length <= 1) {
         _.root.closest('.media-left').not('.audio').addClass('hidden-xs');
-        _.root.closest('.media-left').find('.organisation-menu').hide();
         _.root.css('display', 'none');
-        _.root.siblings('.image-details-container:not(:has(.image-rights))').hide();
-        $('.record.large-image-layout').addClass('no-image-layout').removeClass('large-image-layout');
-        $('.large-image-sidebar').addClass('visible-xs visible-sm');
-        $('.record-main').addClass('mainbody left');
-        _.addDocumentLoadCallback(function hideSidebar() {
-          $('.large-image-sidebar').addClass('visible-xs visible-sm');
-        });
+        _.root.siblings('.image-details-container:not(:has(.image-rights))').addClass('hidden');
       }
     } else if (_.trigger.hasClass('no-image')) {
       _.trigger.removeClass('no-image');
     }
   }
 
-  if (!_.settings.isList) {
-    _.showImageDetails(imagePopup);
-  }
   _.imageDetail.html(imagePopup.data('description'));
   img.off('load').on('load', function handleImage() {
-
+    if (!_.settings.isList) {
+      _.showImageDetails(imagePopup);
+    }
     setImageProperties(this);
   });
   img.unveil(100);

--- a/themes/finna2/less/finna/record.less
+++ b/themes/finna2/less/finna/record.less
@@ -908,6 +908,9 @@ a.authority {
 }
 
 .record-main .recordProvidedBy {
+  border: @sidebar-border;
+  padding: 0 15px 10px 15px;
+  margin-bottom: 10px;
   h2 {
     font-size: 20px;
   }

--- a/themes/finna2/less/finna/record.less
+++ b/themes/finna2/less/finna/record.less
@@ -908,8 +908,9 @@ a.authority {
 }
 
 .record-main .recordProvidedBy {
-  &:extend(.sidebar .recordProvidedBy all);
-  h2:extend(.sidebar > h2) {};
+  h2 {
+    font-size: 20px;
+  }
   @media (min-width: @screen-sm-min) {
     max-width: 300px;
   }

--- a/themes/finna2/templates/RecordDriver/DefaultRecord/core.phtml
+++ b/themes/finna2/templates/RecordDriver/DefaultRecord/core.phtml
@@ -53,6 +53,12 @@
       <?=$this->record($this->driver)->renderTemplate('record-audio-player.phtml', ['audioUrls' => $audioUrls]);?>
     <?php endif; ?>
 
+    <?php if ($this->record($this->driver)->getOrganisationMenuPosition() === 'inline'): ?>
+      <div class="organisation-menu">
+        <?=$this->render('record/record-organisation-menu.phtml') ?>
+      </div>
+    <?php endif; ?>
+
     <?=$this->record($this->driver)->renderTemplate('record-post-thumbnail.phtml');?>
   </div>
   <?php $thumbnail = ob_get_contents(); ?>

--- a/themes/finna2/templates/RecordDriver/DefaultRecord/record-image-popup-information.phtml
+++ b/themes/finna2/templates/RecordDriver/DefaultRecord/record-image-popup-information.phtml
@@ -178,9 +178,7 @@ if ($otherTitles):?>
   <?php if ($this->driver->getSourceIdentifier() !== 'SolrAuth'): ?>
     <?= $this->context($this)->renderInContext('RecordDriver/DefaultRecord/image-rights.phtml', ['rights' => $rights, 'truncateLicense' => true]); ?>
   <?php endif ?>
-  <?php if ($this->resolver('record/record-organisation-menu.phtml')): ?>
-    <?=$this->render('record/record-organisation-menu.phtml') ?>
-  <?php endif; ?>
+  <?=$this->render('record/record-organisation-menu.phtml') ?>
   <div style="clear: both;"></div>
 </div>
 <?=

--- a/themes/finna2/templates/RecordDriver/DefaultRecord/record-image.phtml
+++ b/themes/finna2/templates/RecordDriver/DefaultRecord/record-image.phtml
@@ -24,7 +24,7 @@
     <?php $modelPreviewImages = $this->driver->tryMethod('allowModelPreviewImages'); ?>
     <?php foreach ($images as $image): ?>
       <?php $rights = $image['rights']; ?>
-      <div class="image-details-container<?=$ind > 0 ? ' hidden' : '' ?> text-left" data-img-index="<?=$ind?>">
+      <div class="image-details-container text-left hidden" data-img-index="<?=$ind?>">
         <?php if (empty($models[$ind]) || (!empty($models[$ind]) && !empty($modelPreviewImages))): ?>
           <?=$this->record($this->driver)->renderTemplate('image-download.phtml', ['index' => $ind, 'rights' => $rights, 'image' => $image, 'hiRes' => $image['highResolution'] ?? false, 'models' => $models ?? []])?>
           <?=$this->record($this->driver)->renderTemplate('image-information.phtml', ['index' => $ind, 'image' => $image]);?>

--- a/themes/finna2/templates/RecordDriver/SolrAuthDefault/core.phtml
+++ b/themes/finna2/templates/RecordDriver/SolrAuthDefault/core.phtml
@@ -13,11 +13,13 @@
         'img' => $img, 'imageClick' => 'none', 'imageRightsLabel' => 'Image Rights Authority',
         'numOfImages' => ['mobile' => 4, 'normal' => 4]
       ]);?>
-      <?php if ($this->resolver('record/record-organisation-menu.phtml')): ?>
-      <div class="organisation-menu">
-        <?=$this->render('record/record-organisation-menu.phtml') ?>
-      </div>
+
+      <?php if ($this->record($this->driver)->getOrganisationMenuPosition() === 'inline'): ?>
+        <div class="organisation-menu">
+          <?=$this->render('record/record-organisation-menu.phtml') ?>
+        </div>
       <?php endif; ?>
+
       <?=$this->record($this->driver)->renderTemplate('record-post-thumbnail.phtml');?>
     </div>
     <?php $thumbnail = ob_get_contents(); ?>

--- a/themes/finna2/templates/RecordDriver/SolrEad/core.phtml
+++ b/themes/finna2/templates/RecordDriver/SolrEad/core.phtml
@@ -34,9 +34,9 @@
       <?=$this->record($this->driver)->renderTemplate('record-audio-player.phtml', ['audioUrls' => $audioUrls]);?>
     <?php endif; ?>
 
-    <?php if ($this->resolver('record/record-organisation-menu.phtml') && in_array($this->driver->getSourceIdentifier(), ['Solr', 'R2'])): ?>
+    <?php if ($this->record($this->driver)->getOrganisationMenuPosition() === 'inline'): ?>
       <div class="organisation-menu">
-          <?=$this->render('record/record-organisation-menu.phtml') ?>
+        <?=$this->render('record/record-organisation-menu.phtml') ?>
       </div>
     <?php endif; ?>
 

--- a/themes/finna2/templates/RecordDriver/SolrForward/core.phtml
+++ b/themes/finna2/templates/RecordDriver/SolrForward/core.phtml
@@ -38,7 +38,7 @@
 
     <?=$this->record($this->driver)->renderTemplate('record-image-information.phtml', ['img' => $img, 'sizes' => ['small' => ['w' => 100, 'h' => 100], 'medium' => ['w' => 1200, 'h' => 1200]]]);?>
 
-    <?php if ($this->resolver('record/record-organisation-menu.phtml') && $this->driver->getSourceIdentifier() == 'Solr'): ?>
+    <?php if ($this->record($this->driver)->getOrganisationMenuPosition() === 'inline'): ?>
       <div class="organisation-menu">
         <?=$this->render('record/record-organisation-menu.phtml') ?>
       </div>

--- a/themes/finna2/templates/RecordDriver/SolrLido/core.phtml
+++ b/themes/finna2/templates/RecordDriver/SolrLido/core.phtml
@@ -35,7 +35,7 @@
       <?=$this->record($this->driver)->renderTemplate('record-audio-player.phtml', ['audioUrls' => $audioUrls]);?>
     <?php endif; ?>
 
-    <?php if ($this->resolver('record/record-organisation-menu.phtml') && $this->driver->getSourceIdentifier() == 'Solr'): ?>
+    <?php if ($this->record($this->driver)->getOrganisationMenuPosition() === 'inline'): ?>
       <div class="organisation-menu">
         <?=$this->render('record/record-organisation-menu.phtml') ?>
       </div>

--- a/themes/finna2/templates/RecordDriver/SolrLrmi/core.phtml
+++ b/themes/finna2/templates/RecordDriver/SolrLrmi/core.phtml
@@ -13,6 +13,13 @@
   ob_start(); ?>
   <div class="media-<?=$thumbnailAlignment?>">
     <?=$this->record($this->driver)->renderTemplate('record-image-information.phtml', ['img' => $img, 'displayIcon' => true, 'source' => 'L1', 'imageClick' => 'none']);?>
+
+    <?php if ($this->record($this->driver)->getOrganisationMenuPosition() === 'inline'): ?>
+      <div class="organisation-menu">
+        <?=$this->render('record/record-organisation-menu.phtml') ?>
+      </div>
+    <?php endif; ?>
+
     <?=$this->record($this->driver)->renderTemplate('record-post-thumbnail.phtml');?>
   </div>
   <?php $thumbnail = ob_get_contents(); ?>

--- a/themes/finna2/templates/RecordDriver/SolrQdc/core.phtml
+++ b/themes/finna2/templates/RecordDriver/SolrQdc/core.phtml
@@ -62,7 +62,7 @@
       <?=$this->record($this->driver)->renderTemplate('record-audio-player.phtml', ['audioUrls' => $audioUrls]);?>
     <?php endif; ?>
 
-    <?php if ($this->resolver('record/record-organisation-menu.phtml') && $this->driver->getSourceIdentifier() == 'Solr'): ?>
+    <?php if ($this->record($this->driver)->getOrganisationMenuPosition() === 'inline'): ?>
       <div class="organisation-menu">
         <?=$this->render('record/record-organisation-menu.phtml') ?>
       </div>

--- a/themes/finna2/templates/collection/view.phtml
+++ b/themes/finna2/templates/collection/view.phtml
@@ -105,7 +105,7 @@
     <?/* End Main Details */?>
   </div>
   <?php ob_start(); ?>
-    <?php if ($this->resolver('record/record-organisation-menu.phtml') && in_array($this->driver->getSourceIdentifier(), ['Solr', 'R2'])): ?>
+    <?php if ($this->record($this->driver)->getOrganisationMenuPosition() === 'sidebar'): ?>
       <div class="organisation-menu">
           <?=$this->render('record/record-organisation-menu.phtml') ?>
       </div>

--- a/themes/finna2/templates/record/record-organisation-menu.phtml
+++ b/themes/finna2/templates/record/record-organisation-menu.phtml
@@ -1,9 +1,10 @@
 <!-- START of: finna - record/record-organisation-menu.phtml -->
-<?php $currentSource = $this->driver->tryMethod('getDataSource');
-   $currentSourceTranslated = $this->transEsc("source_$currentSource", null, $currentSource);
-   $mergedData = $this->driver->tryMethod('getMergedRecordData');
-   $recordType = $this->driver->tryMethod('getRecordFormat');
-   $sector = $this->driver->tryMethod('getSector');
+<?php
+  $currentSource = $this->driver->tryMethod('getDataSource');
+  $currentSourceTranslated = $this->transEsc("source_$currentSource", null, $currentSource);
+  $mergedData = $this->driver->tryMethod('getMergedRecordData');
+  $recordType = $this->driver->tryMethod('getRecordFormat');
+  $sector = $this->driver->tryMethod('getSector');
 ?>
 <div class="recordProvidedBy">
   <h2 class="record-organisation-header">

--- a/themes/finna2/templates/record/view.phtml
+++ b/themes/finna2/templates/record/view.phtml
@@ -76,8 +76,7 @@
       $this->layout()->userLang,
       $params
   );
-  $noImage = empty($images[0]['urls']['medium']) && empty($images[0]['urls']['large']);
-  $largeImageLayout = !$noImage && in_array($this->driver->tryMethod('getRecordFormat'), ['lido', 'forward', 'ead', 'ead3', 'forwardAuthority', 'qdc']);
+  $largeImageLayout = $this->record($this->driver)->hasLargeImageLayout();
 
   if ($oldRecordId = $this->driver->getExtraDetail('redirectedFromId')) {
       echo $this->inlineScript(
@@ -105,7 +104,7 @@
   </div>
 
   <?php ob_start(); ?>
-    <?php if ($this->resolver('record/record-organisation-menu.phtml') && in_array($this->driver->getSourceIdentifier(), ['Solr', 'SolrAuth', 'L1', 'R2'])): ?>
+    <?php if ($this->record($this->driver)->getOrganisationMenuPosition() === 'sidebar'): ?>
       <div class="organisation-menu">
           <?=$this->render('record/record-organisation-menu.phtml') ?>
       </div>
@@ -121,11 +120,12 @@
   <?php $sidebar = ob_get_contents(); ?>
   <?php ob_end_clean(); ?>
 
-  <div class="sidebar right smaller-image-sidebar hidden-xs hidden-sm">
-    <?php if ($sidebar):?>
-        <?=$sidebar ?>
-    <?php endif; ?>
-  </div>
+  <?php if ($sidebar && !$largeImageLayout):?>
+    <?php // This sidebar is used for larger screens when not in large image layout ?>
+    <div class="sidebar right smaller-image-sidebar hidden-xs hidden-sm">
+      <?=$sidebar ?>
+    </div>
+  <?php endif; ?>
 
   <div class="clearfix hidden-lg hidden-md"></div>
 
@@ -208,11 +208,12 @@
     <div class="clearfix hidden-lg hidden-md"></div>
   </div>
 
-  <div class="sidebar left large-image-sidebar hidden <?= $largeImageLayout ? '' : 'visible-xs visible-sm'?>">
-    <?php if ($sidebar):?>
-        <?=$sidebar ?>
-    <?php endif; ?>
-  </div>
+  <?php if ($sidebar):?>
+    <?php // This sidebar is used for smaller screens and always in large image layout ?>
+    <div class="sidebar left large-image-sidebar<?=$largeImageLayout ? '' : ' visible-xs visible-sm'?>">
+      <?=$sidebar ?>
+    </div>
+  <?php endif; ?>
 
   </div>
 </div>


### PR DESCRIPTION
- Moves layout determination to the Record view helper.
- Updates the rules on when to use large image layout.
- Makes the determined layout stay even if an image could not be loaded (decouples image paginator from the layout).
- Handles image-details-container with setImageProperties so that it doesn't flicker if an image can't be loaded.
- Makes inline "Record provided by" less boxy.