### PR TITLE
[ALLI-7327] Fix adding DOI to OpenURL

### DIFF
--- a/module/Finna/src/Finna/RecordDriver/Feature/FinnaRecordTrait.php
+++ b/module/Finna/src/Finna/RecordDriver/Feature/FinnaRecordTrait.php
@@ -138,7 +138,13 @@ trait FinnaRecordTrait
     {
         $params = parent::getArticleOpenUrlParams();
         if ($doi = $this->tryMethod('getCleanDOI')) {
-            $params['rft.doi'] = $doi;
+            $doi = 'info:doi/' . $doi;
+            // rft_id can have multiple values (pmid and doi)
+            if (!empty($params['rft_id'])) {
+                $params['rft_id'] = [$params['rft_id'], $doi];
+            } else {
+                $params['rft_id'] = $doi;
+            }
         }
         if ($mmsId = $this->tryMethod('getAlmaMmsId')) {
             $params['rft.mms_id'] = $mmsId;

--- a/module/Finna/src/Finna/RecordDriver/Feature/FinnaRecordTrait.php
+++ b/module/Finna/src/Finna/RecordDriver/Feature/FinnaRecordTrait.php
@@ -137,14 +137,12 @@ trait FinnaRecordTrait
     protected function getArticleOpenUrlParams()
     {
         $params = parent::getArticleOpenUrlParams();
-        if ($doi = $this->tryMethod('getCleanDOI')) {
+        if ($doiFull = $this->tryMethod('getCleanDOI')) {
+            $doi = preg_replace('/^doi:|^info:doi\//', '', $doiFull);
             $doi = 'info:doi/' . $doi;
-            // rft_id can have multiple values (pmid and doi)
-            if (!empty($params['rft_id'])) {
-                $params['rft_id'] = [$params['rft_id'], $doi];
-            } else {
-                $params['rft_id'] = $doi;
-            }
+
+            $params['rft_id'] = (array)($params['rft_id'] ?? []);
+            $params['rft_id'][] = $doi;
         }
         if ($mmsId = $this->tryMethod('getAlmaMmsId')) {
             $params['rft.mms_id'] = $mmsId;

--- a/module/Finna/src/Finna/RecordDriver/Primo.php
+++ b/module/Finna/src/Finna/RecordDriver/Primo.php
@@ -556,4 +556,22 @@ class Primo extends \VuFind\RecordDriver\Primo
         }
         return $params;
     }
+
+    /**
+     * Get the OpenURL parameters to represent this record (useful for the
+     * title attribute of a COinS span tag).
+     *
+     * @param bool $overrideSupportsOpenUrl Flag to override checking
+     * supportsOpenUrl() (default is false)
+     *
+     * @return string OpenURL parameters.
+     */
+    public function getOpenUrl($overrideSupportsOpenUrl = false)
+    {
+        $url = parent::getOpenUrl($overrideSupportsOpenUrl);
+
+        // Remove array syntax from url parameters
+        $url = preg_replace('/%5B([0-9]?)%5D=/', '=', $url);
+        return $url;
+    }
 }

--- a/module/Finna/src/Finna/RecordDriver/Primo.php
+++ b/module/Finna/src/Finna/RecordDriver/Primo.php
@@ -556,22 +556,4 @@ class Primo extends \VuFind\RecordDriver\Primo
         }
         return $params;
     }
-
-    /**
-     * Get the OpenURL parameters to represent this record (useful for the
-     * title attribute of a COinS span tag).
-     *
-     * @param bool $overrideSupportsOpenUrl Flag to override checking
-     * supportsOpenUrl() (default is false)
-     *
-     * @return string OpenURL parameters.
-     */
-    public function getOpenUrl($overrideSupportsOpenUrl = false)
-    {
-        $url = parent::getOpenUrl($overrideSupportsOpenUrl);
-
-        // Remove array syntax from url parameters
-        $url = preg_replace('/%5B([0-9]?)%5D=/', '=', $url);
-        return $url;
-    }
 }


### PR DESCRIPTION
Lisätään DOI oikeassa formaatissa eli `rft_id=info:doi/xxx`.
Tietueessa saattaa olla jo rft_id:n arvona pmid, jota ei haluta yliajaa.
SFX:ssä muotoa ` rft_id[0]=x&rft_id[1]=y ` ei tueta, joten url muutetaan muotoon ` rft_id=x&rft_id=y `