### PR TITLE
[ALLI-7356] Adjust check if popup zoom has been enabled

### DIFF
--- a/local/config/finna/config.ini.sample
+++ b/local/config/finna/config.ini.sample
@@ -804,7 +804,7 @@ recordMap = openlayers
 ; Enables zoom for images in the image popup, only applies to 
 ; record formats specified in zoomFormats key. Disabled by default.
 ;enableImagePopupZoom = true
-; Formats which are allowed to use the zoom property, separated by :
+; A colon-separated list of formats that are enabled for image zoom function
 zoomFormats = qdc:forward:ead3:ead:lido
 
 [QRCode]

--- a/local/config/finna/config.ini.sample
+++ b/local/config/finna/config.ini.sample
@@ -802,8 +802,10 @@ recordMap = openlayers
 ;displayCoords = true
 
 ; Enables zoom for images in the image popup, only applies to 
-; LIDO, FORWARD, EAD, EAD3, QDC records. Disabled by default.
+; record formats specified in zoomFormats key. Disabled by default.
 ;enableImagePopupZoom = true
+; Formats which are allowed to use the zoom property, separated by :
+;zoomFormats = qdc:forward:ead3:ead:lido
 
 [QRCode]
 ; This setting controls the image to display when no qrcode is available.

--- a/local/config/finna/config.ini.sample
+++ b/local/config/finna/config.ini.sample
@@ -801,7 +801,8 @@ recordMap = openlayers
 ;mapLabels = file:geosearch_test_lookup.txt
 ;displayCoords = true
 
-; Enables zoom for images in the image popup. Disabled by default.
+; Enables zoom for images in the image popup, only applies to 
+; LIDO, FORWARD, EAD, EAD3, QDC records. Disabled by default.
 ;enableImagePopupZoom = true
 
 [QRCode]

--- a/local/config/finna/config.ini.sample
+++ b/local/config/finna/config.ini.sample
@@ -805,7 +805,7 @@ recordMap = openlayers
 ; record formats specified in zoomFormats key. Disabled by default.
 ;enableImagePopupZoom = true
 ; Formats which are allowed to use the zoom property, separated by :
-;zoomFormats = qdc:forward:ead3:ead:lido
+zoomFormats = qdc:forward:ead3:ead:lido
 
 [QRCode]
 ; This setting controls the image to display when no qrcode is available.

--- a/local/config/finna/config.ini.sample
+++ b/local/config/finna/config.ini.sample
@@ -801,9 +801,9 @@ recordMap = openlayers
 ;mapLabels = file:geosearch_test_lookup.txt
 ;displayCoords = true
 
-; Enables zoom for images in the image popup, only applies to records using the large image
-; layout. Disabled by default.
-; enableImagePopupZoom = true
+; Enables zoom for images in the image popup, only applies to 
+; 'lido', 'forward', 'ead', 'ead3', 'qdc' records. Disabled by default.
+;enableImagePopupZoom = true
 
 [QRCode]
 ; This setting controls the image to display when no qrcode is available.

--- a/local/config/finna/config.ini.sample
+++ b/local/config/finna/config.ini.sample
@@ -801,8 +801,7 @@ recordMap = openlayers
 ;mapLabels = file:geosearch_test_lookup.txt
 ;displayCoords = true
 
-; Enables zoom for images in the image popup, only applies to 
-; 'lido', 'forward', 'ead', 'ead3', 'qdc' records. Disabled by default.
+; Enables zoom for images in the image popup. Disabled by default.
 ;enableImagePopupZoom = true
 
 [QRCode]

--- a/module/Finna/src/Finna/View/Helper/Root/Record.php
+++ b/module/Finna/src/Finna/View/Helper/Root/Record.php
@@ -627,8 +627,10 @@ class Record extends \VuFind\View\Helper\Root\Record
      */
     public function getImagePopupZoom()
     {
-        return isset($this->config->Content->enableImagePopupZoom)
-            && $this->config->Content->enableImagePopupZoom === '1';
+        $enabled = '1' === $this->config->Content->enableImagePopupZoom ?? '0';
+        $formats = explode(':', $this->config->Content->zoomFormats ?? '');
+        return $enabled
+            && in_array($this->driver->tryMethod('getRecordFormat'), $formats);
     }
 
     /**

--- a/module/Finna/src/Finna/View/Helper/Root/Record.php
+++ b/module/Finna/src/Finna/View/Helper/Root/Record.php
@@ -627,10 +627,13 @@ class Record extends \VuFind\View\Helper\Root\Record
      */
     public function getImagePopupZoom()
     {
-        $enabled = '1' === $this->config->Content->enableImagePopupZoom ?? '0';
-        $formats = explode(':', $this->config->Content->zoomFormats ?? '');
-        return $enabled
-            && in_array($this->driver->tryMethod('getRecordFormat'), $formats);
+        if (!($this->config->Content->enableImagePopupZoom ?? false)) {
+            return false;
+        }
+        return in_array(
+            $this->driver->tryMethod('getRecordFormat'),
+            explode(':', $this->config->Content->zoomFormats ?? '')
+        );
     }
 
     /**

--- a/themes/finna2/templates/RecordDriver/DefaultRecord/record-image-paginator.phtml
+++ b/themes/finna2/templates/RecordDriver/DefaultRecord/record-image-paginator.phtml
@@ -1,6 +1,7 @@
 <!-- START of: finna - RecordDriver/DefaultRecord/record-image-paginator.phtml -->
 <?php
   $isList = ($type === 'list' || $type === 'list grid');
+  // Enable zoom only for LIDO, FORWARD, EAD, EAD3, QDC records
   $enableImageZoom = !empty($enableImagePopupZoom) && in_array($this->driver->tryMethod('getRecordFormat'), ['lido', 'forward', 'ead', 'ead3', 'qdc']);
 ?>
 <?php if ($type === 'record' || !$this->userAgent()->isBot()): ?>

--- a/themes/finna2/templates/RecordDriver/DefaultRecord/record-image-paginator.phtml
+++ b/themes/finna2/templates/RecordDriver/DefaultRecord/record-image-paginator.phtml
@@ -1,7 +1,7 @@
 <!-- START of: finna - RecordDriver/DefaultRecord/record-image-paginator.phtml -->
 <?php
   $isList = ($type === 'list' || $type === 'list grid');
-  $enableImageZoom = (isset($enableImagePopupZoom) && $enableImagePopupZoom) && in_array($this->driver->tryMethod('getRecordFormat'), ['lido', 'forward', 'ead', 'qdc']);
+  $enableImageZoom = !empty($enableImagePopupZoom) && in_array($this->driver->tryMethod('getRecordFormat'), ['lido', 'forward', 'ead', 'ead3', 'qdc']);
 ?>
 <?php if ($type === 'record' || !$this->userAgent()->isBot()): ?>
   <?php

--- a/themes/finna2/templates/RecordDriver/DefaultRecord/record-image-paginator.phtml
+++ b/themes/finna2/templates/RecordDriver/DefaultRecord/record-image-paginator.phtml
@@ -1,7 +1,6 @@
 <!-- START of: finna - RecordDriver/DefaultRecord/record-image-paginator.phtml -->
 <?php
   $isList = ($type === 'list' || $type === 'list grid');
-  // Enable zoom only for LIDO, FORWARD, EAD, EAD3, QDC records
   $enableImageZoom = !empty($enableImagePopupZoom) && in_array($this->driver->tryMethod('getRecordFormat'), ['lido', 'forward', 'ead', 'ead3', 'qdc']);
 ?>
 <?php if ($type === 'record' || !$this->userAgent()->isBot()): ?>

--- a/themes/finna2/templates/RecordDriver/DefaultRecord/record-image-paginator.phtml
+++ b/themes/finna2/templates/RecordDriver/DefaultRecord/record-image-paginator.phtml
@@ -85,7 +85,7 @@
         'recordId' => $this->driver->getUniqueId(),
         'recordType' => $this->driver->tryMethod('getRecordFormat'),
         'recordSource' => $this->driver->tryMethod('getSourceIdentifier'),
-        'enableImageZoom' => $enableImagePopupZoom,
+        'enableImageZoom' => $this->record($this->driver)->getImagePopupZoom(),
         'maxRows' => 3,
         'iconlabelClass' => "format-" . $this->record($this->driver)->getFormatClass(end($formats)),
         'isList' => $type === 'list' || $type === 'list grid',

--- a/themes/finna2/templates/RecordDriver/DefaultRecord/record-image-paginator.phtml
+++ b/themes/finna2/templates/RecordDriver/DefaultRecord/record-image-paginator.phtml
@@ -1,7 +1,6 @@
 <!-- START of: finna - RecordDriver/DefaultRecord/record-image-paginator.phtml -->
 <?php
   $isList = ($type === 'list' || $type === 'list grid');
-  $enableImageZoom = !empty($enableImagePopupZoom) && in_array($this->driver->tryMethod('getRecordFormat'), ['lido', 'forward', 'ead', 'ead3', 'qdc']);
 ?>
 <?php if ($type === 'record' || !$this->userAgent()->isBot()): ?>
   <?php
@@ -86,7 +85,7 @@
         'recordId' => $this->driver->getUniqueId(),
         'recordType' => $this->driver->tryMethod('getRecordFormat'),
         'recordSource' => $this->driver->tryMethod('getSourceIdentifier'),
-        'enableImageZoom' => $enableImageZoom,
+        'enableImageZoom' => $enableImagePopupZoom,
         'maxRows' => 3,
         'iconlabelClass' => "format-" . $this->record($this->driver)->getFormatClass(end($formats)),
         'isList' => $type === 'list' || $type === 'list grid',

--- a/themes/finna2/templates/RecordDriver/DefaultRecord/record-image.phtml
+++ b/themes/finna2/templates/RecordDriver/DefaultRecord/record-image.phtml
@@ -2,7 +2,6 @@
 <?php
   $isList = $type == 'list' || $type === 'list grid';
   $formats = $this->driver->tryMethod('getFormats');
-  $enableImagePopupZoom = $this->record($this->driver)->getImagePopupZoom();
   if (!$isList) {
     $models = $this->driver->tryMethod('getModels');
   }
@@ -13,8 +12,12 @@
       $this->record($this->driver)->renderTemplate(
           'record-image-paginator.phtml',
           [
-              'images' => $images, 'type' => $type, 'formats' => $formats, 'enableImagePopupZoom' => $enableImagePopupZoom,
-              'numOfImages' => $numOfImages ?? null, 'displayIcon' => $displayIcon ?? false, 'models' => $models ?? []
+              'images' => $images,
+              'type' => $type,
+              'formats' => $formats,
+              'numOfImages' => $numOfImages ?? null,
+              'displayIcon' => $displayIcon ?? false,
+              'models' => $models ?? []
           ]
       )
     ?>


### PR DESCRIPTION
Move record formats to config file so they can be adjusted without hotfixes. Adjust comments. Only check zoom property when it is needed.