### PR TITLE
Cookie::getCookieSameSite comment update

### DIFF
--- a/module/Finna/src/Finna/View/Helper/Root/Cookie.php
+++ b/module/Finna/src/Finna/View/Helper/Root/Cookie.php
@@ -90,7 +90,7 @@ class Cookie extends \Laminas\View\Helper\AbstractHelper
     }
 
     /**
-     * Get cookie SameSite attribute (null if unset).
+     * Get cookie SameSite attribute.
      *
      * @return string
      */


### PR DESCRIPTION
Cookiemanager::constructor offers 'lax' as default value. Can update it to show it as a default value, but its different object.