### PR TITLE
[ALLI-7369] EAD3 Image adjustments

### DIFF
--- a/local/config/finna/config.ini.sample
+++ b/local/config/finna/config.ini.sample
@@ -699,8 +699,8 @@ lastname = SHIB_sn
 ;coverimages     = Syndetics:MySyndeticsId,Amazon:MyAccessKeyId,Booksite,LibraryThing:MyLibraryThingId,Google,OpenLibrary,Summon:MySerialsSolutionsClientKey,Contentcafe:MyContentCafeID,NatLibFi,BookyFi,BTJ:customerId
 coverimages     = NatLibFi,OpenLibrary
 
-; List of blocked formats prevented from showing in LIDO records image section
-; lidoFileFormatBlockList = 'tif,tiff,3d-pdf,3d model,glb,obj,gltf'
+; List of undisplayable file formats
+; undisplayable_file_formats = 'tif:tiff:3d-pdf:3d model:glb:obj:gltf'
 
 ; This setting controls the image to display when no book cover is available.
 ; The path is relative to the base of your theme directory.

--- a/module/Finna/src/Finna/RecordDriver/Feature/SolrFinnaTrait.php
+++ b/module/Finna/src/Finna/RecordDriver/Feature/SolrFinnaTrait.php
@@ -771,7 +771,7 @@ trait SolrFinnaTrait
     }
 
     /**
-     * Can the format be properly displayed?
+     * Can the format not be properly displayed?
      *
      * @param string $format Format to check.
      *

--- a/module/Finna/src/Finna/RecordDriver/Feature/SolrFinnaTrait.php
+++ b/module/Finna/src/Finna/RecordDriver/Feature/SolrFinnaTrait.php
@@ -60,6 +60,15 @@ trait SolrFinnaTrait
      */
     protected $cache = [];
 
+
+    /**
+     * An array of non-displayable formats
+     *
+     * @var array
+     */
+    protected $undisplayableFormats;
+
+
     /**
      * Return an array of image URLs associated with this record with keys:
      * - urls        Image URLs
@@ -761,6 +770,25 @@ trait SolrFinnaTrait
     public function isAuthorityRecord()
     {
         return false;
+    }
+
+    /**
+     * Can the format be properly displayed?
+     * 
+     * @param string $format Format to check.
+     * 
+     * @return bool
+     */
+    public function isUndisplayableFormat(string $format): bool
+    {
+        if (!isset($this->undisplayableFormats)) {
+            $this->undisplayableFormats = explode(
+                ':',
+                $this->mainConfig->Record->undisplayable_file_formats
+                ?? 'tif:tiff:3d-pdf:3d model:glb:obj:gltf'
+            );
+        }
+        return in_array($format, $this->undisplayableFormats);
     }
 
     /**

--- a/module/Finna/src/Finna/RecordDriver/Feature/SolrFinnaTrait.php
+++ b/module/Finna/src/Finna/RecordDriver/Feature/SolrFinnaTrait.php
@@ -60,14 +60,12 @@ trait SolrFinnaTrait
      */
     protected $cache = [];
 
-
     /**
      * An array of non-displayable formats
      *
      * @var array
      */
     protected $undisplayableFormats;
-
 
     /**
      * Return an array of image URLs associated with this record with keys:
@@ -774,9 +772,9 @@ trait SolrFinnaTrait
 
     /**
      * Can the format be properly displayed?
-     * 
+     *
      * @param string $format Format to check.
-     * 
+     *
      * @return bool
      */
     public function isUndisplayableFormat(string $format): bool

--- a/module/Finna/src/Finna/RecordDriver/SolrEad3.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrEad3.php
@@ -821,11 +821,11 @@ class SolrEad3 extends SolrEad
                                 'highResolution' => []
                             ];
                         }
-                        $exploded = explode('/', $role);
+                        [$fileType, $format] = strpos($role, '/') > 0
+                            ? explode('/', $role, 2)
+                            : ['image', 'jpg'];
                         // Image might be original, can not be displayed in browser.
-                        if (!empty($exploded[1])
-                            && $this->isUndisplayableFormat($exploded[1])
-                        ) {
+                        if ($this->isUndisplayableFormat($format)) {
                             $displayImage['highResolution']['original'][] = [
                                 'data' => [],
                                 'url' => $url,

--- a/module/Finna/src/Finna/RecordDriver/SolrEad3.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrEad3.php
@@ -766,7 +766,7 @@ class SolrEad3 extends SolrEad
             }
             $result['displayImages'][] = $formatted;
         };
-        $hasExcludeTitlePart = function ($title) {
+        $isExcludedFromOCR = function ($title) {
             foreach (self::EXCLUDE_OCR_TITLE_PARTS as $part) {
                 if (false !== strpos($title, $part)) {
                     return true;
@@ -815,7 +815,7 @@ class SolrEad3 extends SolrEad
                     $sort = (string)($attr->label ?? '');
 
                     // Save image to another array if match is found
-                    if (self::IMAGE_OCR === $type && !$hasExcludeTitlePart($title)) {
+                    if (self::IMAGE_OCR === $type && !$isExcludedFromOCR($title)) {
                         $ocrImages['items'][] = [
                             'label' => $title,
                             'url' => $url,

--- a/module/Finna/src/Finna/RecordDriver/SolrEad3.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrEad3.php
@@ -703,19 +703,19 @@ class SolrEad3 extends SolrEad
      */
     public function getExternalData()
     {
-        $fullResImages = $this->getFullResImages();
-        $ocrImages = $this->getOCRImages();
+        $locale = $this->getLocale();
+        $result = $this->getImagesAsAssoc($locale);
         $physicalItems = $this->getPhysicalItems();
         $digitized
             = !empty($fullResImages) || !empty($ocrImages)
             || !empty($this->getAllImages());
 
         $result = [];
-        if (!empty($fullResImages)) {
-            $result['items']['fullResImages'] = $fullResImages;
+        if (!empty($result['fullres'])) {
+            $result['items']['fullResImages'] = $result['fullres'];
         }
-        if (!empty($ocrImages)) {
-            $result['items']['OCRImages'] = $ocrImages;
+        if (!empty($result['ocr'])) {
+            $result['items']['OCRImages'] = $result['ocr'];
         }
         if (!empty($physicalItems)) {
             $result['items']['physicalItems'] = $physicalItems;
@@ -746,7 +746,7 @@ class SolrEad3 extends SolrEad
         $language = 'fi',
         $includePdf = false
     ) {
-        $result = $this->getRepresentations($language, $includePdf);
+        $result = $this->getImagesAsAssoc($language, $includePdf);
         return $result['displayImages'] ?? [];
     }
 
@@ -762,7 +762,7 @@ class SolrEad3 extends SolrEad
      *
      * @return array
      */
-    protected function getRepresentations(
+    protected function getImagesAsAssoc(
         string $language = 'fi',
         bool $includePdf = false
     ) {
@@ -1690,30 +1690,6 @@ class SolrEad3 extends SolrEad
     {
         $xml = $this->getXmlRecord();
         return (string)($xml->did->container ?? '');
-    }
-
-    /**
-     * Get fullresolution images.
-     *
-     * @return array
-     */
-    protected function getFullResImages()
-    {
-        $locale = $this->getLocale();
-        $result = $this->getRepresentations($locale);
-        return $result['fullres'] ?? [];
-    }
-
-    /**
-     * Get OCR images.
-     *
-     * @return array
-     */
-    protected function getOCRImages()
-    {
-        $locale = $this->getLocale();
-        $result = $this->getRepresentations($locale);
-        return $result['ocr'] ?? [];
     }
 
     /**

--- a/module/Finna/src/Finna/RecordDriver/SolrEad3.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrEad3.php
@@ -677,7 +677,7 @@ class SolrEad3 extends SolrEad
         $physicalItems = $this->getPhysicalItems();
         $digitized
             = !empty($fullResImages) || !empty($ocrImages)
-            || !empty($this->getAllImages());
+            || !empty($result['displayImages']);
 
         $result = [];
         if (!empty($result['fullres'])) {
@@ -1195,7 +1195,7 @@ class SolrEad3 extends SolrEad
      */
     public function getImageRights($language, $skipImageCheck = false)
     {
-        if (!$skipImageCheck && !$this->getAllImages()) {
+        if (!$skipImageCheck && !$this->getAllImages($language)) {
             return false;
         }
 

--- a/module/Finna/src/Finna/RecordDriver/SolrEad3.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrEad3.php
@@ -801,7 +801,11 @@ class SolrEad3 extends SolrEad
                         if (!$this->isUrlLoadable($url, $this->getUniqueID())) {
                             continue;
                         }
-                        $type = (string)($attr->localtype ?? self::IMAGE_LARGE);
+                        $type = (string)(
+                            $attr->localtype
+                            ?? $parentType
+                            ?? self::IMAGE_LARGE
+                        );
                         $role = (string)($attr->linkrole ?? '');
                         $sort = (string)($attr->label ?? '');
 
@@ -830,6 +834,9 @@ class SolrEad3 extends SolrEad
                             continue;
                         }
                         if ($size = self::IMAGE_MAP[$type] ?? false || $parentSize) {
+                            if (false === $size) {
+                                $size = $parentSize;
+                            }
                             $rights = $rights
                                 ?? $this->getImageRights($language, true);
                             $size = $size === self::IMAGE_FULLRES

--- a/module/Finna/src/Finna/RecordDriver/SolrEad3.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrEad3.php
@@ -836,11 +836,12 @@ class SolrEad3 extends SolrEad
                         if ($size = self::IMAGE_MAP[$type] ?? false || $parentSize) {
                             if (false === $size) {
                                 $size = $parentSize;
+                            } else {
+                                $size = $size === self::IMAGE_FULLRES
+                                    ? self::IMAGE_LARGE : $size;
                             }
                             $rights = $rights
                                 ?? $this->getImageRights($language, true);
-                            $size = $size === self::IMAGE_FULLRES
-                                ? self::IMAGE_LARGE : $size;
 
                             if (isset($displayImage['urls'][$size])) {
                                 // Add old stash to results.

--- a/module/Finna/src/Finna/RecordDriver/SolrEad3.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrEad3.php
@@ -735,7 +735,8 @@ class SolrEad3 extends SolrEad
         string $language = 'fi',
         bool $includePdf = false
     ) {
-        $cacheKey = __FUNCTION__ . "/$language/" . ($includePdf ? '1' : '0');
+        // Do not include pdf bool to cachekey as it does not change results
+        $cacheKey = __FUNCTION__ . "/$language";
         if (isset($this->cache[$cacheKey])) {
             return $this->cache[$cacheKey];
         }
@@ -804,7 +805,7 @@ class SolrEad3 extends SolrEad
                         $type = (string)(
                             $attr->localtype
                             ?? $parentType
-                            ?? self::IMAGE_LARGE
+                            ?? 'none'
                         );
                         $role = (string)($attr->linkrole ?? '');
                         $sort = (string)($attr->label ?? '');

--- a/module/Finna/src/Finna/RecordDriver/SolrEad3.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrEad3.php
@@ -809,6 +809,22 @@ class SolrEad3 extends SolrEad
                         $role = (string)($attr->linkrole ?? '');
                         $sort = (string)($attr->label ?? '');
 
+                        // Save image to another array if match is found
+                        if (self::IMAGE_OCR === $type
+                            && false === strpos($title, 'Kuva/Aukeama')
+                        ) {
+                            $ocrImages['items'][] = [
+                                'label' => $title,
+                                'url' => $url,
+                                'sort' => $sort
+                            ];
+                        } elseif (self::IMAGE_FULLRES === $type) {
+                            $fullResImages['items'][] = [
+                                'label' => $title,
+                                'url' => $url
+                            ];
+                        }
+
                         if (empty($displayImage)) {
                             $displayImage = [
                                 'urls' => [],
@@ -834,12 +850,11 @@ class SolrEad3 extends SolrEad
                             continue;
                         }
                         if ($size = self::IMAGE_MAP[$type] ?? false || $parentSize) {
-                            if (false === $size) {
-                                $size = $parentSize;
-                            } else {
-                                $size = $size === self::IMAGE_FULLRES
-                                    ? self::IMAGE_LARGE : $size;
-                            }
+                            $size = (false === $size)
+                                ? $parentSize
+                                : (($size === self::IMAGE_FULLRES)
+                                ? self::IMAGE_LARGE : $size);
+
                             $rights = $rights
                                 ?? $this->getImageRights($language, true);
 
@@ -853,20 +868,6 @@ class SolrEad3 extends SolrEad
                             $displayImage['urls'][$size] = $url;
                             $displayImage['pdf'][$size]
                                 = $role === 'application/pdf';
-                        }
-                        if (self::IMAGE_OCR === $type
-                            && false === strpos($title, 'Kuva/Aukeama')
-                        ) {
-                            $ocrImages['items'][] = [
-                                'label' => $title,
-                                'url' => $url,
-                                'sort' => $sort
-                            ];
-                        } elseif (self::IMAGE_FULLRES === $type) {
-                            $fullResImages['items'][] = [
-                                'label' => $title,
-                                'url' => $url
-                            ];
                         }
                     }
                     if (!empty($displayImage)) {

--- a/module/Finna/src/Finna/RecordDriver/SolrEad3.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrEad3.php
@@ -763,7 +763,7 @@ class SolrEad3 extends SolrEad
             $result['displayImages'][] = $formatted;
         };
 
-        if (!empty($xml->did->daoset) || !empty($xml->did->dao)) {
+        if (isset($xml->did->daoset) || isset($xml->did->dao)) {
             // All images have same lazy-fetched rights.
             $rights = null;
             $images = [];

--- a/module/Finna/src/Finna/RecordDriver/SolrEad3.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrEad3.php
@@ -850,8 +850,8 @@ class SolrEad3 extends SolrEad
                             && false === strpos($title, 'Kuva/Aukeama')
                         ) {
                             $ocrImages['items'][] = [
-                                'label' => $desc,
-                                'url' => $href,
+                                'label' => $title,
+                                'url' => $url,
                                 'sort' => $sort
                             ];
                         } elseif (self::IMAGE_FULLRES === $type) {

--- a/module/Finna/src/Finna/RecordDriver/SolrEad3.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrEad3.php
@@ -724,7 +724,7 @@ class SolrEad3 extends SolrEad
      * - displayImages Images to be displayed in the front end.
      * - ocr           Ocr images.
      * - fullres       Fullres images.
-     * 
+     *
      * @param string $language   Language for copyright information
      * @param bool   $includePdf Whether to include first PDF file when no image
      * links are found

--- a/module/Finna/src/Finna/RecordDriver/SolrEad3.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrEad3.php
@@ -675,21 +675,20 @@ class SolrEad3 extends SolrEad
         $locale = $this->getLocale();
         $result = $this->getImagesAsAssoc($locale);
         $physicalItems = $this->getPhysicalItems();
-        $digitized
-            = !empty($fullResImages) || !empty($ocrImages)
-            || !empty($result['displayImages']);
 
         $result = [];
-        if (!empty($result['fullres'])) {
+        if (!empty($result['fullres']['items'])) {
             $result['items']['fullResImages'] = $result['fullres'];
         }
-        if (!empty($result['ocr'])) {
+        if (!empty($result['ocr']['items'])) {
             $result['items']['OCRImages'] = $result['ocr'];
         }
         if (!empty($physicalItems)) {
             $result['items']['physicalItems'] = $physicalItems;
         }
-        $result['digitized'] = $digitized;
+        $result['digitized'] = !empty($result['displayImages'])
+            || !empty($result['fullres']['items'])
+            || !empty($result['ocr']['items']);
         return $result;
     }
 

--- a/module/Finna/src/Finna/RecordDriver/SolrEad3.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrEad3.php
@@ -673,22 +673,22 @@ class SolrEad3 extends SolrEad
     public function getExternalData()
     {
         $locale = $this->getLocale();
-        $result = $this->getImagesAsAssoc($locale);
+        $images = $this->getImagesAsAssoc($locale);
         $physicalItems = $this->getPhysicalItems();
 
         $result = [];
-        if (!empty($result['fullres']['items'])) {
-            $result['items']['fullResImages'] = $result['fullres'];
+        if (!empty($images['fullres']['items'])) {
+            $result['items']['fullResImages'] = $images['fullres'];
         }
-        if (!empty($result['ocr']['items'])) {
-            $result['items']['OCRImages'] = $result['ocr'];
+        if (!empty($images['ocr']['items'])) {
+            $result['items']['OCRImages'] = $images['ocr'];
         }
         if (!empty($physicalItems)) {
             $result['items']['physicalItems'] = $physicalItems;
         }
-        $result['digitized'] = !empty($result['displayImages'])
-            || !empty($result['fullres']['items'])
-            || !empty($result['ocr']['items']);
+        $result['digitized'] = !empty($images['displayImages'])
+            || !empty($images['fullres']['items'])
+            || !empty($images['ocr']['items']);
         return $result;
     }
 

--- a/module/Finna/src/Finna/RecordDriver/SolrEad3.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrEad3.php
@@ -142,37 +142,6 @@ class SolrEad3 extends SolrEad
     ];
 
     /**
-     * An array of non-presentable images
-     *
-     * @var array
-     */
-    protected $originalImageMimetypes;
-
-    /**
-     * Constructor
-     *
-     * @param \Laminas\Config\Config $mainConfig     VuFind main configuration (omit
-     * for built-in defaults)
-     * @param \Laminas\Config\Config $recordConfig   Record-specific configuration
-     * file (omit to use $mainConfig as $recordConfig)
-     * @param \Laminas\Config\Config $searchSettings Search-specific configuration
-     * file
-     */
-    public function __construct(
-        $mainConfig = null,
-        $recordConfig = null,
-        $searchSettings = null
-    ) {
-        parent::__construct($mainConfig, $recordConfig, $searchSettings);
-
-        $this->originalImageMimetypes = explode(
-            ':',
-            $mainConfig->Record->ead_original_image_mimetypes
-            ?? 'image/tiff'
-        );
-    }
-
-    /**
      * Get the institutions holding the record.
      *
      * @return array
@@ -848,9 +817,11 @@ class SolrEad3 extends SolrEad
                                 'highResolution' => []
                             ];
                         }
+                        $exploded = explode('/', $role);
                         // Image might be original, can not be displayed in browser.
-                        if (in_array($role, $this->originalImageMimetypes)) {
-                            [$start, $format] = explode('/', $role);
+                        if (!empty($exploded[1])
+                            && $this->isUndisplayableFormat($exploded[1])
+                        ) {
                             $displayImage['highResolution']['original'][] = [
                                 'data' => [],
                                 'url' => $url,

--- a/module/Finna/src/Finna/RecordDriver/SolrLido.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrLido.php
@@ -62,16 +62,6 @@ class SolrLido extends \VuFind\RecordDriver\SolrDefault
     ];
 
     /**
-     * List of undisplayable file formats
-     *
-     * @var array
-     */
-    protected $undisplayableFileFormats = [
-        'tif', 'tiff', '3d-pdf', '3d model', 'gltf', 'glb',
-        'obj', 'mp3', 'wav', 'mp4'
-    ];
-
-    /**
      * Image types array
      *
      * @var array
@@ -175,33 +165,6 @@ class SolrLido extends \VuFind\RecordDriver\SolrDefault
         'viewerPaddingAngle',
         'debug'
     ];
-
-    /**
-     * Constructor
-     *
-     * @param \Laminas\Config\Config $mainConfig     VuFind main configuration (omit
-     * for built-in defaults)
-     * @param \Laminas\Config\Config $recordConfig   Record-specific configuration
-     * file (omit to use $mainConfig as $recordConfig)
-     * @param \Laminas\Config\Config $searchSettings Search-specific configuration
-     * file
-     */
-    public function __construct(
-        $mainConfig = null,
-        $recordConfig = null,
-        $searchSettings = null
-    ) {
-        parent::__construct($mainConfig, $recordConfig, $searchSettings);
-
-        // Keep old setting name for back-compatibility:
-        $formatBlockList = $mainConfig['Content']['lidoFileFormatBlockList']
-            ?? $mainConfig['Content']['lidoFileFormatBlackList']
-            ?? '';
-
-        if (!empty($formatBlockList)) {
-            $this->undisplayableFileFormats = explode(',', $formatBlockList);
-        }
-    }
 
     /**
      * Return access restriction notes for the record.
@@ -763,10 +726,8 @@ class SolrLido extends \VuFind\RecordDriver\SolrDefault
     ): array {
         // Check if the image is really an image
         // Original images can be any type and are not displayed
-        if ($this->undisplayableFileFormats && $type !== 'image_original') {
-            if (in_array($format, $this->undisplayableFileFormats)) {
-                return [];
-            }
+        if ($this->isUndisplayableFormat($format) && $type !== 'image_original') {
+            return [];
         }
 
         $size = $this->imageTypes[$type];

--- a/module/Finna/src/Finna/RecordDriver/SolrLido.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrLido.php
@@ -726,7 +726,7 @@ class SolrLido extends \VuFind\RecordDriver\SolrDefault
     ): array {
         // Check if the image is really an image
         // Original images can be any type and are not displayed
-        if ($this->isUndisplayableFormat($format) && $type !== 'image_original') {
+        if ('image_original' !== $type && $this->isUndisplayableFormat($format)) {
             return [];
         }
 


### PR DESCRIPTION
Alter the check for undisplayable format. Unify Lido and EAD3 to use the same check.
Checked that lidoFileFormatBl* was not in use in any view with find + grep.
Dao elements can be in did-> or did->daoset so take both into account here.