### PR TITLE
Add browser message if the browser does not support es6 syntaxes

### DIFF
--- a/themes/finna2/js/finna.js
+++ b/themes/finna2/js/finna.js
@@ -1,9 +1,39 @@
 /*global finnaCustomInit */
 /*exported finna */
 var finna = (function finnaModule() {
-
+  var checkBrowserSupport = function checkBrowserSupport() {
+    /* jshint ignore:start */
+    /* eslint-disable */
+    try {
+      () => {};
+      // Class support
+      class __ES6FeatureDetectionTest { };
+      // Object initializer property and method shorthands
+      let a = true;
+      let b = { 
+        a,
+        c() { return true; },
+        d: [1,2,3],
+       };
+      // Object destructuring
+      let { c, d } = b;
+      // Spread operator
+      let e = [...d, 4];
+      window.isES6 = true;
+    } catch (error) {
+      console.log(error);
+      var oldBrowser = document.findElementById("#old-browser-message");
+      if (oldBrowser) {
+        oldBrowser.classList.remove('hidden');
+      }
+    };
+    /* eslint-enable */
+  };
+  /* jshint ignore:end */
   var my = {
     init: function init() {
+      // Check if the browser is supported
+      checkBrowserSupport();
       // List of modules to be inited
       var modules = [
         'advSearch',

--- a/themes/finna2/js/finna.js
+++ b/themes/finna2/js/finna.js
@@ -28,8 +28,9 @@ var finna = (function finnaModule() {
       }
     };
     /* eslint-enable */
+    /* jshint ignore:end */
   };
-  /* jshint ignore:end */
+
   var my = {
     init: function init() {
       // Check if the browser is supported

--- a/themes/finna2/js/finna.js
+++ b/themes/finna2/js/finna.js
@@ -19,10 +19,9 @@ var finna = (function finnaModule() {
       let { c, d } = b;
       // Spread operator
       let e = [...d, 4];
-      window.isES6 = true;
     } catch (error) {
       console.log(error);
-      var oldBrowser = document.findElementById("#old-browser-message");
+      var oldBrowser = document.findElementById('old-browser-message');
       if (oldBrowser) {
         oldBrowser.classList.remove('hidden');
       }

--- a/themes/finna2/templates/layout/layout.phtml
+++ b/themes/finna2/templates/layout/layout.phtml
@@ -217,11 +217,9 @@ JS;
       <?php if (!$this->cookie()->get('cookieConsent')): ?>
         <?=$this->partial('Helpers/cookie-consent.phtml');?>
       <?php endif; ?>
-      <?php if (!empty($_SERVER['HTTP_USER_AGENT']) && preg_match('/(?i)Trident\/[0-7]/', $_SERVER['HTTP_USER_AGENT'])): ?>
-        <div class="container-fluid system-messages">
-          <?=$this->translate('outdated_browser_message_html');?>
-        </div>
-      <?php endif; ?>
+      <div id="old-browser-message" class="container-fluid system-messages <?php if (!empty($_SERVER['HTTP_USER_AGENT']) && !preg_match('/(?i)Trident\/[0-7]/', $_SERVER['HTTP_USER_AGENT'])): ?>hidden<?php endif; ?>">
+        <?=$this->translate('outdated_browser_message_html');?>
+      </div>
       <?=$this->render('Helpers/pre-production-warning.phtml')?>
       <?php if ($messages = $this->systemMessages()): ?>
         <div class="container-fluid system-messages">


### PR DESCRIPTION
Some caching would be potentially good so it would skip the check after the first time. Maybe save as a cookie?
