### PR TITLE
Adjust medium image size in result-grid.phtml

### DIFF
--- a/themes/finna2/templates/RecordDriver/DefaultRecord/result-grid.phtml
+++ b/themes/finna2/templates/RecordDriver/DefaultRecord/result-grid.phtml
@@ -21,7 +21,7 @@ $urls = $this->record($this->driver)->getLinkDetails($openUrlActive);
         <?=$this->render('list/list-notes.phtml')?>
       <?php endif ?>
       <?php $img = $this->recordImage($this->record($this->driver))?>
-      <?=$img->render('list grid', ['small' => ['w' => 100, 'h' => 100], 'medium' => ['w' => 600, 'h' => 600]]) ?>
+      <?=$img->render('list grid', ['small' => ['w' => 100, 'h' => 100], 'medium' => ['w' => 250, 'h' => 250]]) ?>
     </div>
     <?php if (!$openUrlActive && empty($urls)): ?>
       <?php if ($this->driver->supportsAjaxStatus()): ?>


### PR DESCRIPTION
Bigger images causes overflowing in grid view and safari doesn't like it.