### PR TITLE
[ALLI-7087] LIDO: Add generic event type translations.

### DIFF
--- a/local/languages/finna/en-gb.ini
+++ b/local/languages/finna/en-gb.ini
@@ -1443,54 +1443,20 @@ opacmsg_helmet_v = "14 days loan, no holds"
 3/*/9/ = "Young adults"
 
 ; LIDO Event Types
+; Default translations used when no material-specific translation is available:
+lido_event_type_kuvaus = "Description"
+lido_event_type_käyttö = Used
+lido_event_type_löytyminen = Discovery
+lido_event_type_muotoilu = Design
+lido_event_type_näyttely = Exhibitions
+lido_event_type_painatus = "Printing"
+lido_event_type_suunnittelu = Design
+lido_event_type_tuotanto = Production
+lido_event_type_valmistus = Created
+; Material-specific translations:
 lido_event_type_ArchiveMaterial_valmistus = "Archival time"
 lido_event_type_Book_valmistus = Publication
-lido_event_type_CultureHistoricalObject_valmistus = Created
-lido_event_type_Document_näyttely = Exhibitions
-lido_event_type_Document_painatus = "Printing"
-lido_event_type_Document_suunnittelu = Design
-lido_event_type_Document_valmistus = Created
-lido_event_type_Document_käyttö = Used
-lido_event_type_Image_kuvaus = "Description"
-lido_event_type_Image_käyttö = Used
-lido_event_type_Image_muotoilu = "Design"
-lido_event_type_Image_näyttely = Exhibitions
-lido_event_type_Image_suunnittelu = "Design"
-lido_event_type_Image_tuotanto = "Production"
 lido_event_type_Image_valmistus = "Photo info"
-lido_event_type_Item_valmistus = Created
-lido_event_type_Map_näyttely = Exhibitions
-lido_event_type_Map_sunnittelu = Design
-lido_event_type_Map_valmistus = Created
-lido_event_type_MusicalScore_valmistus = Created
-lido_event_type_Other_käyttö = Used
-lido_event_type_Other_näyttely = Exhibitions
-lido_event_type_Other_painatus = Printing
-lido_event_type_Other_valmistus = Created
-lido_event_type_OtherText_käyttö = Used
-lido_event_type_OtherText_valmistus = Created
-lido_event_type_PhysicalObject_kuvaus = Description
-lido_event_type_PhysicalObject_käyttö = Used
-lido_event_type_PhysicalObject_löytyminen = Discovery
-lido_event_type_PhysicalObject_muotoilu = Design
-lido_event_type_PhysicalObject_näyttely = Exhibitions
-lido_event_type_PhysicalObject_suunnittelu = Design
-lido_event_type_PhysicalObject_tuotanto = Production
-lido_event_type_PhysicalObject_valmistus = Created
-lido_event_type_Place_käyttö = Used
-lido_event_type_Place_suunnittelu = Design
-lido_event_type_Place_valmistus = Created
-lido_event_type_Sound_käyttö = Used
-lido_event_type_Sound_valmistus = Created
-lido_event_type_Video_valmistus = Created
-lido_event_type_Video_käyttö = Used
-lido_event_type_WorkOfArt_kuvaus = Description
-lido_event_type_WorkOfArt_käyttö = Used
-lido_event_type_WorkOfArt_näyttely = Exhibitions
-lido_event_type_WorkOfArt_suunnittelu = Design
-lido_event_type_WorkOfArt_valmistus = Created
-lido_event_type_äänite_käyttö = Used
-lido_event_type_äänite_valmistus = Created
 
 ; MetaLib genre translations
 databases_ = databases

--- a/local/languages/finna/fi.ini
+++ b/local/languages/finna/fi.ini
@@ -1429,54 +1429,22 @@ opacmsg_helmet_v = "14 vrk laina, ei varata"
 3/*/9/ = "Nuoret aikuiset"
 
 ; LIDO Event Types
+; Default translations used when no material-specific translation is available:
+lido_event_type_kuvaus = Kuvaus
+lido_event_type_käyttö = Käyttö
+lido_event_type_löytyminen = Löytyminen
+lido_event_type_muotoilu = Muotoilu
+lido_event_type_näyttely = Näyttelyt
+lido_event_type_painatus = Painatus
+lido_event_type_suunnittelu = Suunnittelu
+lido_event_type_tuotanto = Tuotanto
+lido_event_type_valmistus = Valmistus
+; Material-specific translations:
 lido_event_type_ArchiveMaterial_valmistus = Arkistointiaika
 lido_event_type_Book_valmistus = Julkaisu
-lido_event_type_CultureHistoricalObject_valmistus = Valmistus
-lido_event_type_Document_näyttely = Näyttelyt
-lido_event_type_Document_painatus = Painatus
-lido_event_type_Document_suunnittelu = Suunnittelu
 lido_event_type_Document_valmistus = Luontiaika
-lido_event_type_Document_käyttö = Käyttö
-lido_event_type_Image_kuvaus = Kuvaus
-lido_event_type_Image_käyttö = Käyttö
 lido_event_type_Image_muotoilu = Suunnittelu
-lido_event_type_Image_näyttely = Näyttelyt
-lido_event_type_Image_suunnittelu = Suunnittelu
-lido_event_type_Image_tuotanto = Tuotanto
 lido_event_type_Image_valmistus = Kuvaustiedot
-lido_event_type_Item_valmistus = Valmistus
-lido_event_type_Map_näyttely = Näyttelyt
-lido_event_type_Map_sunnittelu = Suunnittelu
-lido_event_type_Map_valmistus = Valmistus
-lido_event_type_MusicalScore_valmistus = Valmistus
-lido_event_type_Other_käyttö = Käyttö
-lido_event_type_Other_näyttely = Näyttelyt
-lido_event_type_Other_painatus = Painatus
-lido_event_type_Other_valmistus = Valmistus
-lido_event_type_OtherText_käyttö = Käyttö
-lido_event_type_OtherText_valmistus = Valmistus
-lido_event_type_PhysicalObject_kuvaus = Kuvaus
-lido_event_type_PhysicalObject_käyttö = Käyttö
-lido_event_type_PhysicalObject_löytyminen = Löytyminen
-lido_event_type_PhysicalObject_muotoilu = Muotoilu
-lido_event_type_PhysicalObject_näyttely = Näyttelyt
-lido_event_type_PhysicalObject_suunnittelu = Suunnittelu
-lido_event_type_PhysicalObject_tuotanto = Tuotanto
-lido_event_type_PhysicalObject_valmistus = Valmistus
-lido_event_type_Place_käyttö = Käyttö
-lido_event_type_Place_suunnittelu = Suunnittelu
-lido_event_type_Place_valmistus = Valmistus
-lido_event_type_Sound_käyttö = Käyttö
-lido_event_type_Sound_valmistus = Valmistus
-lido_event_type_Video_valmistus = Valmistus
-lido_event_type_Video_käyttö = Käyttö
-lido_event_type_WorkOfArt_kuvaus = Kuvaus
-lido_event_type_WorkOfArt_käyttö = Käyttö
-lido_event_type_WorkOfArt_näyttely = Näyttelyt
-lido_event_type_WorkOfArt_suunnittelu = Suunnittelu
-lido_event_type_WorkOfArt_valmistus = Valmistus
-lido_event_type_äänite_käyttö = Käyttö
-lido_event_type_äänite_valmistus = Valmistus
 
 ; MetaLib genre translations
 databases_ = tietokannat

--- a/local/languages/finna/sv.ini
+++ b/local/languages/finna/sv.ini
@@ -1412,54 +1412,21 @@ opacmsg_helmet_v = "14 dygns lån, reserveras ej"
 3/*/9/ = "Unga vuxna"
 
 ; LIDO Event Types
+; Default translations used when no material-specific translation is available:
+lido_event_type_kuvaus = Beskrivning
+lido_event_type_käyttö = Bruk
+lido_event_type_löytyminen = Upptäckt
+lido_event_type_muotoilu = Design
+lido_event_type_näyttely = Utställningar
+lido_event_type_painatus = "Tryckning"
+lido_event_type_suunnittelu = Design
+lido_event_type_tuotanto = Produktion
+lido_event_type_valmistus = Tillverkning
+; Material-specific translations:
 lido_event_type_ArchiveMaterial_valmistus = Arkiveringstid
 lido_event_type_Book_valmistus = Publicering
-lido_event_type_CultureHistoricalObject_valmistus = Tillverkning
-lido_event_type_Document_käyttö = Bruk
-lido_event_type_Document_näyttely = Utställningar
-lido_event_type_Document_painatus = "Tryckning"
-lido_event_type_Document_suunnittelu = Design
-lido_event_type_Document_valmistus = Tillverkning
-lido_event_type_Image_kuvaus = "Beskrivning"
-lido_event_type_Image_käyttö = Bruk
-lido_event_type_Image_muotoilu = "Design"
-lido_event_type_Image_näyttely = Utställningar
-lido_event_type_Image_suunnittelu = "Design"
-lido_event_type_Image_tuotanto = "Produktion"
+lido_event_type_Document_valmistus = Skapande
 lido_event_type_Image_valmistus = Bildinformation
-lido_event_type_Item_valmistus = Tillverkning
-lido_event_type_Map_näyttely = Utställningar
-lido_event_type_Map_sunnittelu = Design
-lido_event_type_Map_valmistus = Tillverkning
-lido_event_type_MusicalScore_valmistus = Tillverkning
-lido_event_type_Other_käyttö = Bruk
-lido_event_type_Other_näyttely = Utställningar
-lido_event_type_Other_painatus = Tryckning
-lido_event_type_Other_valmistus = Tillverkning
-lido_event_type_OtherText_käyttö = Bruk
-lido_event_type_OtherText_valmistus = Tillverkning
-lido_event_type_PhysicalObject_kuvaus = Beskrivning
-lido_event_type_PhysicalObject_käyttö = Bruk
-lido_event_type_PhysicalObject_löytyminen = Upptäckt
-lido_event_type_PhysicalObject_muotoilu = Design
-lido_event_type_PhysicalObject_näyttely = Utställningar
-lido_event_type_PhysicalObject_suunnittelu = Design
-lido_event_type_PhysicalObject_tuotanto = Produktion
-lido_event_type_PhysicalObject_valmistus = Tillverkning
-lido_event_type_Place_käyttö = Bruk
-lido_event_type_Place_suunnittelu = Design
-lido_event_type_Place_valmistus = Tillverkning
-lido_event_type_Sound_käyttö = Bruk
-lido_event_type_Sound_valmistus = Tillverkning
-lido_event_type_Video_valmistus = Tillverkning
-lido_event_type_Video_käyttö = Bruk
-lido_event_type_WorkOfArt_kuvaus = Beskrivning
-lido_event_type_WorkOfArt_käyttö = Bruk
-lido_event_type_WorkOfArt_näyttely = Utställningar
-lido_event_type_WorkOfArt_suunnittelu = Design
-lido_event_type_WorkOfArt_valmistus = Tillverkning
-lido_event_type_äänite_käyttö = Bruk
-lido_event_type_äänite_valmistus = Tillverkning
 
 ; MetaLib genre translations
 databases_ = databaser

--- a/module/Finna/src/Finna/View/Helper/Root/RecordDataFormatterFactory.php
+++ b/module/Finna/src/Finna/View/Helper/Root/RecordDataFormatterFactory.php
@@ -57,6 +57,13 @@ class RecordDataFormatterFactory
     extends \VuFind\View\Helper\Root\RecordDataFormatterFactory
 {
     /**
+     * Translator
+     *
+     * @var \Laminas\I18n\Translator\TranslatorInterface
+     */
+    protected $translator = null;
+
+    /**
      * Create an object
      *
      * @param ContainerInterface $container     Service manager
@@ -77,6 +84,10 @@ class RecordDataFormatterFactory
         $requestedName,
         array $options = null
     ) {
+        $this->translator = $container->get(
+            \Laminas\I18n\Translator\TranslatorInterface::class
+        );
+
         $helper = parent::__invoke($container, $requestedName, $options);
 
         $helper->setDefaults('authority', [$this, 'getDefaultAuthoritySpecs']);
@@ -546,10 +557,21 @@ class RecordDataFormatterFactory
                         'context' => ['class' => 'recordEvents'],
                         'labelFunction'
                             => function ($data, $driver) use ($eventType) {
+                                if (!$eventType) {
+                                    return '';
+                                }
                                 $mainFormat = $driver->getMainFormat();
-                                return $eventType
-                                    ? "lido_event_type_{$mainFormat}_$eventType"
-                                    : '';
+                                $keys = [
+                                    "lido_event_type_{$mainFormat}_$eventType",
+                                    "lido_event_type_$eventType",
+                                ];
+                                foreach ($keys as $key) {
+                                    $label = $this->translator->translate($key);
+                                    if ($key !== $label) {
+                                        return $key;
+                                    }
+                                }
+                                return '';
                             },
                     ],
                 ];


### PR DESCRIPTION
This ensures any event type that doesn't need a special translation for the material gets properly translated.