### PR TITLE
[ALLI-7587] Fix model viewer layout and exit with escape button

### DIFF
--- a/module/Finna/src/Finna/View/Helper/Root/Record.php
+++ b/module/Finna/src/Finna/View/Helper/Root/Record.php
@@ -1219,6 +1219,9 @@ class Record extends \VuFind\View\Helper\Root\Record
      */
     public function hasLargeImageLayout(): bool
     {
+        if ($this->driver->tryMethod('getModels')) {
+            return true;
+        }
         $language = $this->getView()->layout()->userLang;
 
         $imageTypes = ['small', 'medium', 'large', 'master'];

--- a/themes/finna2/js/finna-model-viewer.js
+++ b/themes/finna2/js/finna-model-viewer.js
@@ -837,12 +837,17 @@ class ModelViewerClass extends HTMLElement {
       'webkitRequestFullscreen',
       'webkitEneterFullscreen'
     ];
+    const fullscreenChangeEvents = [
+      'fullscreenchange',
+      'mozfullscreenchange',
+      'MSFullscreenChange',
+      'webkitfullscreenchange'
+    ];
 
     this.fullscreenBtn.addEventListener('click', () => {
       if (this.classList.contains('fullscreen')) {
         exitFullscreens.some((func) => {
           if (document[func]) {
-            this.classList.remove('fullscreen');
             document[func]();
             return true;
           }
@@ -856,6 +861,18 @@ class ModelViewerClass extends HTMLElement {
           }
         });
       }
+    });
+    fullscreenChangeEvents.forEach(event => {
+      document.addEventListener(event, () => {
+        if (!document.fullscreenElement &&
+          !document.mozFullScreenElement &&
+          !document.webkitFullscreenElement
+        ) {
+          this.classList.remove('fullscreen');
+          this.getSize();
+          this.updateScale();
+        }
+      });
     });
   }
 


### PR DESCRIPTION
Forces all the records which has models to use large image layout. 