### PR TITLE
[ALLI-7639] Clean the processing of images from driver to paginator

### DIFF
--- a/module/Finna/src/Finna/View/Helper/Root/RecordImage.php
+++ b/module/Finna/src/Finna/View/Helper/Root/RecordImage.php
@@ -343,7 +343,10 @@ class RecordImage extends \Laminas\View\Helper\AbstractHelper
             true,
             $this->record->getDriver()->getSourceIdentifier()
         );
-        if ($this->record->getDriver()->tryMethod('getModels')) {
+        // Get plausible model data
+        if (!in_array($type, ['list', 'list grid'])
+            && $this->record->getDriver()->tryMethod('getModels')
+        ) {
             $images = $this->mergeModelDataToImages($images);
         }
         if ($images && $view->layout()->templateDir === 'combined') {

--- a/module/Finna/src/Finna/View/Helper/Root/RecordImage.php
+++ b/module/Finna/src/Finna/View/Helper/Root/RecordImage.php
@@ -343,11 +343,12 @@ class RecordImage extends \Laminas\View\Helper\AbstractHelper
             true,
             $this->record->getDriver()->getSourceIdentifier()
         );
-        if ($images && $view->layout()->templateDir === 'combined') {
-            // Limit combined results to a single image
-            $images = [$images[0]];
+        if ($this->record->getDriver()->tryMethod('getModels')) {
+            $images = $this->mergeModelDataToImages($images);
         }
-
+        if ($images && $view->layout()->templateDir === 'combined') {
+            $images = reset($images);
+        }
         $context = [
             'type' => $type,
             'images' => $images,
@@ -359,5 +360,79 @@ class RecordImage extends \Laminas\View\Helper\AbstractHelper
         ];
 
         return $this->record->renderTemplate('record-image.phtml', $context);
+    }
+
+    /**
+     * Return all models in a presentative format.
+     *
+     * @return array
+     */
+    protected function getAllModelsAsRepresentations(): array
+    {
+        $models = $this->record->getDriver()->tryMethod('getModels', [], []);
+        if (!$models) {
+            return [];
+        }
+
+        $result = [];
+        $uniqueID = $this->record->getDriver()->getUniqueID();
+        $source = $this->record->getDriver()->getSourceIdentifier();
+        $bgImage
+            = $this->view->plugin('imageSrc')->getSourceAddress('3d-bg.jpg', true);
+        foreach ($models as $index => $model) {
+            foreach ($model as $format => $data) {
+                $modelData = [
+                    'urls' => [
+                        'small' => null,
+                        'medium' => null,
+                        'large' => $bgImage,
+                        'master' => null
+                    ],
+                    'type' => 'model',
+                    'format' => $format,
+                    'scripts' => '/themes/finna2/js/vendor/',
+                    'texture' => '/themes/finna2/images/',
+                    'params' => http_build_query(
+                        [
+                            'method' => 'getModel',
+                            'id' => $uniqueID,
+                            'index' => $index,
+                            'format' => $format,
+                            'source' => $source
+                        ]
+                    )
+                ];
+                $result[$index] = $modelData;
+            }
+        }
+        return $result;
+    }
+
+    /**
+     * Function to combine model data with image data.
+     *
+     * @param array $images Images from getAllImagesAsCoverLinks
+     *
+     * @return array
+     */
+    protected function mergeModelDataToImages(array $images): array
+    {
+        $models = $this->getAllModelsAsRepresentations();
+        $modelSettings
+            = $this->record->getDriver()->tryMethod('getModelSettings', [], []);
+        foreach ($models as $ind => $model) {
+            if (!isset($images[$ind])) {
+                $images[$ind] = [
+                    'rights' => []
+                ];
+            }
+            if ($modelSettings['previewImages'] ?? false) {
+                $images[$ind] = array_merge($model, $images[$ind]);
+            } else {
+                $images[$ind] = array_merge($images[$ind], $model);
+            }
+            $images[$ind]['type'] = 'model';
+        }
+        return $images;
     }
 }

--- a/module/Finna/src/Finna/View/Helper/Root/RecordImage.php
+++ b/module/Finna/src/Finna/View/Helper/Root/RecordImage.php
@@ -347,7 +347,8 @@ class RecordImage extends \Laminas\View\Helper\AbstractHelper
             $images = $this->mergeModelDataToImages($images);
         }
         if ($images && $view->layout()->templateDir === 'combined') {
-            $images = reset($images);
+            // Limit combined results to a single image
+            $images = [reset($images)];
         }
         $context = [
             'type' => $type,

--- a/themes/finna2/js/finna-image-paginator.js
+++ b/themes/finna2/js/finna-image-paginator.js
@@ -626,7 +626,7 @@ FinnaPaginator.prototype.loadPage = function loadPage(direction, openImageIndex,
       cur = $('<div/>');
       _.appendTracks(cur);
     }
-    var image = _.createImagePopup(_.images[currentImage]);
+    var image = _.createImagePopup(_.images[currentImage], currentImage);
     if (typeof image !== 'undefined') {
       cur.append(image);
       column = (column === _.settings.imagesPerRow) ? 1 : column + 1;
@@ -779,15 +779,16 @@ FinnaPaginator.prototype.loadBookDescription = function loadBookDescription() {
  * Function to create small images for popup track consuming the data from image object
  *
  * @param {object} image
+ * @param {number} index
  */
-FinnaPaginator.prototype.createImagePopup = function createImagePopup(image) {
+FinnaPaginator.prototype.createImagePopup = function createImagePopup(image, index) {
   var _ = this;
   var holder = $(_.imagePopup).clone(true);
   if (_.images.length > 1) {
-    if (image.small) {
+    if (image.urls.small) {
       var img = new Image();
-      img.src = image.small;
-      img.alt = image.alt;
+      img.src = image.urls.small;
+      img.alt = image.description;
       img.title = image.title;
       holder.append(img, $('<i class="fa fa-spinner fa-spin"/>'));
       img.onload = function onLoad() {
@@ -801,13 +802,13 @@ FinnaPaginator.prototype.createImagePopup = function createImagePopup(image) {
     }
   }
   holder.attr({
-    'index': image.index,
-    'data-large': image.large,
-    'data-master': image.master,
+    'index': index,
+    'data-large': image.urls.large,
+    'data-master': image.urls.master,
     'data-description': image.description,
     'data-type': image.type,
-    'href': (!_.settings.isList) ? image.large : image.medium,
-    'data-alt': image.alt
+    'href': (!_.settings.isList) ? image.urls.large : image.urls.medium,
+    'data-alt': image.description
   });
 
   if (image.type === 'model') {
@@ -1050,11 +1051,11 @@ FinnaPaginator.prototype.zoomButtonState = function zoomButtonState() {
 FinnaPaginator.prototype.setListTrigger = function setListTrigger(image) {
   var _ = this;
   var tmpImg = $(_.imagePopup).clone(true);
-  tmpImg.find('img').data('src', image.small);
+  tmpImg.find('img').data('src', image.urls.small);
   tmpImg.attr({
-    'index': image.index,
-    'href': image.medium,
-    'data-alt': image.alt
+    'index': _.offSet,
+    'href': image.urls.medium,
+    'data-alt': image.description
   });
   tmpImg.click();
 };

--- a/themes/finna2/templates/RecordDriver/DefaultRecord/image-download.phtml
+++ b/themes/finna2/templates/RecordDriver/DefaultRecord/image-download.phtml
@@ -37,17 +37,19 @@
             </ul>
         </div>
     <?php else: ?>
-        <div class="open-link">
-            <?php
-                $recordImage = $this->recordImage($this->record($this->driver));
-                $originalImage = $recordImage->getMasterImage($index);
-            ?>
-            <a target="_blank" href="<?=$this->escapeHtmlAttr($originalImage) ?>" rel="nofollow" download>
-                <i aria-hidden="true" class="fa fa-download"></i>
-                <span><?=$this->transEsc('Download the image') ?></span>
-            </a>
-            <span class="image-dimensions"></span>
-        </div>
+        <?php
+            $recordImage = $this->recordImage($this->record($this->driver));
+            $originalImage = $recordImage->getMasterImage($index);
+            if ($originalImage):
+        ?>
+            <div class="open-link">
+                <a target="_blank" href="<?=$this->escapeHtmlAttr($originalImage) ?>" rel="nofollow" download>
+                    <i aria-hidden="true" class="fa fa-download"></i>
+                    <span><?=$this->transEsc('Download the image') ?></span>
+                </a>
+                <span class="image-dimensions"></span>
+            </div>
+        <?php endif; ?>
     <?php endif; ?>
 </div>
 <!-- END of Finna - RecordDriver/DefaultRecord/image-download.phtml -->

--- a/themes/finna2/templates/RecordDriver/DefaultRecord/record-image-paginator.phtml
+++ b/themes/finna2/templates/RecordDriver/DefaultRecord/record-image-paginator.phtml
@@ -3,71 +3,7 @@
   $isList = ($type === 'list' || $type === 'list grid');
 ?>
 <?php if ($type === 'record' || !$this->userAgent()->isBot()): ?>
-  <?php
-    $ind = 0;
-    $paginatedLinks = [];
-    $recordImage = $this->recordImage($this->record($this->driver));
-    $modelTranslations = null;
-  ?>
-  <?php foreach ($images as $img): ?>
-    <?php
-      $originalImageData = $recordImage->getMasterImageWithInfo($ind);
-      $originalImage = $originalImageData['url'] ?? false;
-      $obj = [
-        'type' => 'image',
-        'small' => $img['urls']['small'],
-        'medium' => $img['urls']['medium'],
-        'large' => $img['urls']['large'] ?? $img['urls']['medium'],
-        'master' => $originalImage ?: null,
-        'index' => $ind++,
-        'alt' => $img['description'],
-        'description' => $img['description'],
-        'title' => $this->transEsc('Image') . ' ' . $ind
-      ];
-      $paginatedLinks[] = $obj;
-    ?>
-  <?php endforeach; ?>
-  <?php if (!empty($models)) {
-    $modelSettings = $this->driver->getModelSettings();
-    $modelTranslations = $this->partial('Helpers/modeljs-translations.phtml');
-    foreach ($models as $index => $model):
-      foreach ($model as $format => $data):
-        $modelData = [
-          'type' => 'model',
-          'format' => $format,
-          'scripts' => '/themes/finna2/js/vendor/',
-          'texture' => '/themes/finna2/images/',
-          'params' => http_build_query([
-            'method' => 'getModel',
-            'id' => $this->driver->getUniqueId(),
-            'index' => $index,
-            'format' => $format,
-            'source' => $this->driver->getSourceIdentifier()
-          ])
-        ];
-
-        $override = [
-          'small' => null,
-          'medium' => null,
-          'large' => $this->imageSrc()->getSourceAddress('3d-bg.jpg', true),
-          'master' => null,
-          'index' => $index,
-          'title' => $this->transEsc('Image') . ' ' . $ind++,
-        ];
-
-        if (!empty($paginatedLinks[$index])) {
-          if ($modelSettings['previewImages'] ?? false) {
-            $paginatedLinks[$index] = array_merge($paginatedLinks[$index], $modelData);
-          } else {
-            $paginatedLinks[$index] = array_merge($paginatedLinks[$index], $modelData, $override);
-          }
-        } else {
-          $paginatedLinks[] = array_merge($modelData, $override);
-        }
-      endforeach;
-    endforeach;
-  } ?>
-  <?php if (count($paginatedLinks) > 0): ?>
+  <?php if (count($images) > 0): ?>
     <?php
       $settings = [
         'recordId' => $this->driver->getUniqueId(),
@@ -80,16 +16,19 @@
         'recordCovers' => 'recordcovers',
         'displayIcon' => $displayIcon,
         'triggerClick' => $this->imageClick ?? 'modal',
-        'modelTranslations' => $modelTranslations,
-        'viewerDebug' => $modelSettings['debug'] ?? false
       ];
+      if ($this->driver->tryMethod('getModels')) {
+        $modelSettings = $this->driver->tryMethod('getModelSettings', [], []);
+        $settings['modelTranslations'] = $this->partial('Helpers/modeljs-translations.phtml');
+        $settings['viewerDebug'] = $modelSettings['debug'] ?? false;
+      }
     ?>
   <?php endif; ?>
   <?php if (!$this->userAgent()->isBot()): ?>
-    <?php if (!empty($images[0]['urls']['medium']) || !empty($images[0]['urls']['large']) || !empty($models)): ?>
+    <?php if (!empty($images[0]['urls']['medium']) || !empty($images[0]['urls']['large'])): ?>
       <div class="recordcover-container">
         <button class="next-image left" type="button"><i class="fa fa-chevron-left"></i><span class="sr-only"><?= $this->transEsc('previous_image') ?></span></button>
-        <a class="image-popup-trigger init" draggable="false" href="<?=$this->escapeHtmlAttr($this->recordLinker()->getUrl($this->driver)) ?>" data-images="<?=htmlspecialchars(json_encode($paginatedLinks ?? []), ENT_QUOTES, 'UTF-8');?>" data-settings="<?=htmlspecialchars(json_encode($settings ?? []), ENT_QUOTES, 'UTF-8');?>">
+        <a class="image-popup-trigger init" draggable="false" href="<?=$this->escapeHtmlAttr($this->recordLinker()->getUrl($this->driver)) ?>" data-images="<?=htmlspecialchars(json_encode($images ?? []), ENT_QUOTES, 'UTF-8');?>" data-settings="<?=htmlspecialchars(json_encode($settings ?? []), ENT_QUOTES, 'UTF-8');?>">
           <div class="iconlabel format-<?=$this->record($this->driver)->getFormatClass(end($formats))?>"></div>
           <div class="paginator-info"><span class="image-index"></span></div>
           <img src="<?=$this->imageSrc()->getDataPixel()?>" data-src="<?=$this->url('cover-unavailable')?>" class="recordcover<?= ($images[0]['pdf'] ?? false) ? ' pdf-cover' : ''?>" alt="<?=$this->transEsc('No Cover Image')?>"/>
@@ -99,7 +38,7 @@
       </div>
     <?php endif; ?>
   <?php else: ?>
-    <a href="<?=$this->escapeHtmlAttr($img['urls']['large'] ?? $img['urls']['medium']) ?>"><?=($ind + 1)?></a>
+    <a href="<?=$this->escapeHtmlAttr($img['urls']['large'] ?? $img['urls']['medium']) ?>">1</a>
   <?php endif; ?>
   <div class="recordcover-image-detail">
     <p class="image-description">

--- a/themes/finna2/templates/RecordDriver/DefaultRecord/record-image.phtml
+++ b/themes/finna2/templates/RecordDriver/DefaultRecord/record-image.phtml
@@ -24,14 +24,11 @@
   </div>
   <?php if (!$isList): ?>
     <?php $ind = 0; ?>
-    <?php $modelPreviewImages = $this->driver->tryMethod('allowModelPreviewImages'); ?>
     <?php foreach ($images as $image): ?>
       <?php $rights = $image['rights']; ?>
       <div class="image-details-container text-left hidden" data-img-index="<?=$ind?>">
-        <?php if (empty($models[$ind]) || (!empty($models[$ind]) && !empty($modelPreviewImages))): ?>
-          <?=$this->record($this->driver)->renderTemplate('image-download.phtml', ['index' => $ind, 'rights' => $rights, 'image' => $image, 'hiRes' => $image['highResolution'] ?? false, 'models' => $models ?? []])?>
-          <?=$this->record($this->driver)->renderTemplate('image-information.phtml', ['index' => $ind, 'image' => $image]);?>
-        <?php endif; ?>
+        <?=$this->record($this->driver)->renderTemplate('image-download.phtml', ['index' => $ind, 'rights' => $rights, 'image' => $image, 'hiRes' => $image['highResolution'] ?? false, 'models' => $models ?? []])?>
+        <?=$this->record($this->driver)->renderTemplate('image-information.phtml', ['index' => $ind, 'image' => $image]);?>
         <?php if (!empty($models[$ind])): ?>
           <?=$this->record($this->driver)->renderTemplate('model-download.phtml', ['index' => $ind, 'rights' => $rights, 'model' => $models[$ind]]);?>
         <?php endif; ?>

--- a/themes/finna2/templates/record/view.phtml
+++ b/themes/finna2/templates/record/view.phtml
@@ -71,11 +71,6 @@
   }
 
   $params = $this->searchMemory()->getLastSearchParams($this->searchClassId);
-  $recordImage = $this->recordImage($this->record($this->driver));
-  $images = $recordImage->getAllImagesAsCoverLinks(
-      $this->layout()->userLang,
-      $params
-  );
   $largeImageLayout = $this->record($this->driver)->hasLargeImageLayout();
 
   if ($oldRecordId = $this->driver->getExtraDetail('redirectedFromId')) {


### PR DESCRIPTION
Lots of rework done, image-paginator now understands getAllImagesAsCoverLinks without extra parsing. Combine models in RecordImage instead of template and do it littlebit more smoothly.