### PR TITLE
Remove obsolete code which messed authority record page.

### DIFF
--- a/themes/finna2/less/finna/record.less
+++ b/themes/finna2/less/finna/record.less
@@ -1,17 +1,9 @@
 .authoritybox,
 .record {
-  // .media and .media-body code added to fix IE11 display: table-cell issues
-  .media {
-    display: table;
-    table-layout: fixed;
-    width: 100%;
-    @media(max-width: @screen-sm) {
-      display: block;
-    }
-  }
-
   .media-body {
-    width: auto;
+    @media(max-width: @screen-xs-max) {
+      width: 100%;
+    }
   }
 
   .media-left,


### PR DESCRIPTION
Esim. AuthorityRecord/kavi.elonet_henkilo_978795

Nykyisellään auktoriteettitietueissa menee aika rumasti “Tekijänä1 teoksessa”, jos auktoriteettitietueessa ei ole muita tietoja. Nykyinen flexbox-määritys lähti toimimaan kun poistin vanhoja IE11-määrityksiä. Mobiiliin jouduin lisämään width-määrityksen, muuten "Tekijänä"-sisältö valui viewportin ulkopuolelle. 