### PR TITLE
Don't pass an array to explode.

### DIFF
--- a/module/Finna/src/Finna/RecordDriver/Feature/FinnaRecordTrait.php
+++ b/module/Finna/src/Finna/RecordDriver/Feature/FinnaRecordTrait.php
@@ -283,12 +283,12 @@ trait FinnaRecordTrait
                 return false;
             }
         }
-        if (!empty($image['pdf'])) {
-            $formats = $this->mainConfig->Content->pdfCoverImageDownload ?? [];
-            $formats = explode(',', $formats);
+        if (!empty($image['pdf'])
+            && !empty($this->mainConfig->Content->pdfCoverImageDownload)
+        ) {
             return !empty(
                 array_intersect(
-                    $formats,
+                    explode(',', $this->mainConfig->Content->pdfCoverImageDownload),
                     $this->getFormats()
                 )
             );


### PR DESCRIPTION
When pdfCoverImageDownload setting was not defined, an empty array was passed to explode function.