### PR TITLE
[ALLI-7669] Adjust payment response params

### DIFF
--- a/module/Finna/src/Finna/OnlinePayment/Handler/TurkuPaymentAPI.php
+++ b/module/Finna/src/Finna/OnlinePayment/Handler/TurkuPaymentAPI.php
@@ -288,20 +288,34 @@ class TurkuPaymentAPI extends AbstractBase
      */
     public function getPaymentResponseParams($request)
     {
-        $params = $request->getQuery()->toArray();
-
-        $required = [
-            'checkout-amount',
-            'checkout-reference',
-            'checkout-stamp',
-            'checkout-status',
-            'checkout-provider',
-            'checkout-transaction-id',
-            'X-TURKU-SP',
-            'X-TURKU-TS',
-            'Authorization'
-        ];
-
+        $params = [];
+        $required = [];
+        if ($request->isGet()) {
+            $params = $request->getQuery()->toArray();
+            $required = [
+                'checkout-amount',
+                'checkout-reference',
+                'checkout-stamp',
+                'checkout-status',
+                'checkout-provider',
+                'checkout-transaction-id',
+                'X-TURKU-SP',
+                'X-TURKU-TS',
+                'Authorization'
+            ];
+        } elseif ($request->isPost()) {
+            $params = $request->getHeaders()->toArray();
+            $required = [
+                'X-TURKU-SP',
+                'X-TURKU-TS',
+                'Authorization'
+            ];
+        } else {
+            $this->logPaymentError(
+                'The request was not POST or GET'
+            );
+            return false;
+        }
         foreach ($required as $name) {
             if (empty($params[$name])) {
                 $this->logPaymentError(

--- a/module/Finna/src/Finna/OnlinePayment/Handler/TurkuPaymentAPI.php
+++ b/module/Finna/src/Finna/OnlinePayment/Handler/TurkuPaymentAPI.php
@@ -290,6 +290,7 @@ class TurkuPaymentAPI extends AbstractBase
     {
         $params = [];
         $required = [];
+        // Payment response is a get request and notify is a post request
         if ($request->isGet()) {
             $params = $request->getQuery()->toArray();
             $required = [


### PR DESCRIPTION
Notify calls ended in error in the log but had no actual impact on anything else. Post request has the required fields in headers as in get request they are as a query.