### PR TITLE
Revert "Add skipGroup option to grouped record fields"

### DIFF
--- a/module/Finna/src/Finna/View/Helper/Root/RecordDataFormatter.php
+++ b/module/Finna/src/Finna/View/Helper/Root/RecordDataFormatter.php
@@ -556,41 +556,33 @@ class RecordDataFormatter extends \VuFind\View\Helper\Root\RecordDataFormatter
     }
 
     /**
-     * Helper method for getting a spec of field groups from FieldGroupBuilder.
+     * Helper method for getting a spec of field groups.
      *
-     * @param array  $groups        Array specifying the groups. See
-     *                              FieldGroupBuilder::addGroup() for details.
-     * @param array  $lines         All lines used in the groups. If this contains
-     *                              lines not specified in $groups, all unused lines
-     *                              will be appended as their own group.
-     * @param string $template      Default group template to use if not specified
-     *                              for a group (optional, set to null to use the
-     *                              default value).
-     * @param array  $options       Additional options to use if not specified for a
-     *                              group (optional, set to null to use the default
-     *                              value). See FieldGroupBuilder::addGroup() for
-     *                              details.
-     * @param array  $unusedOptions Additional options for the unused lines group
-     *                              (optional, set to null to use the default value).
-     *                              See FieldGroupBuilder::addGroup()
-     *                              for details.
+     * @param array  $groups        Array specifying the groups.
+     * @param array  $lines         All lines used in the groups.
+     * @param string $template      Default group template to use if not
+     *                              specified (optional).
+     * @param array  $options       Additional options to use if not specified
+     *                              for a group (optional).
+     * @param array  $unusedOptions Additional options for unused lines
+     *                              (optional).
      *
      * @return array
      */
     public function getGroupedFields(
         $groups,
         $lines,
-        $template = null,
-        $options = null,
-        $unusedOptions = null
+        $template = 'core-field-group-fields.phtml',
+        $options = [],
+        $unusedOptions = []
     ) {
         $fieldGroups = new FieldGroupBuilder();
         $fieldGroups->setGroups(
             $groups,
             $lines,
-            $template ?? 'core-field-group-fields.phtml',
-            $options ?? [],
-            $unusedOptions ?? []
+            $template,
+            $options,
+            $unusedOptions
         );
         return $fieldGroups->getArray();
     }
@@ -611,9 +603,6 @@ class RecordDataFormatter extends \VuFind\View\Helper\Root\RecordDataFormatter
         // Apply the group spec.
         $result = [];
         foreach ($groups as $group) {
-            if (!empty($group['skipGroup'])) {
-                continue;
-            }
             $lines = $group['lines'];
             $data = $this->getData($driver, $lines);
             if (empty($data)) {

--- a/module/Finna/src/Finna/View/Helper/Root/RecordDataFormatter/FieldGroupBuilder.php
+++ b/module/Finna/src/Finna/View/Helper/Root/RecordDataFormatter/FieldGroupBuilder.php
@@ -61,13 +61,7 @@ class FieldGroupBuilder
      * @param string $label    Label for this group or false for no label.
      * @param array  $lines    Lines belonging to the group.
      * @param string $template Template used to render the lines in the group.
-     * @param array  $options  Additional group options (optional):
-     *                         - context
-     *                         Context array containing data made available to
-     *                         templates.
-     *                         - skipGroup
-     *                         Set to true to skip rendering of the group. This
-     *                         can e.g. be used to skip rendering unused lines.
+     * @param array  $options  Additional options (optional).
      *
      * @return void
      */
@@ -85,19 +79,14 @@ class FieldGroupBuilder
     /**
      * Helper method for setting multiple groups at once.
      *
-     * @param array  $groups        Array specifying the groups. See
-     *                              FieldGroupBuilder::addGroup() for details.
-     * @param array  $lines         All lines used in the groups. If this contains
-     *                              lines not specified in $groups, all unused lines
-     *                              will be appended as their own group.
+     * @param array  $groups        Array specifying the groups.
+     * @param array  $lines         All lines used in the groups.
      * @param string $template      Default group template to use if not
      *                              specified for a group.
      * @param array  $options       Additional options to use if not specified
-     *                              for a group (optional). See
-     *                              FieldGroupBuilder::addGroup() for details.
-     * @param array  $unusedOptions Additional options for the unused lines group
-     *                              (optional). See FieldGroupBuilder::addGroup()
-     *                              for details.
+     *                              for a group (optional).
+     * @param array  $unusedOptions Additional options for unused lines
+     *                              (optional).
      *
      * @return void
      */

--- a/themes/finna2/templates/RecordDriver/SolrLrmi/core.phtml
+++ b/themes/finna2/templates/RecordDriver/SolrLrmi/core.phtml
@@ -106,7 +106,7 @@
               'Subjects',
               'Language',
             ]]
-        ], $filteredFields, null, null, ['skipGroup' => true]));
+        ], $filteredFields));
       ?>
       <?php if ($rights || !empty($coreFields)): ?>
         <table class="table table-finna-record record-details record-field-groups" role="presentation">


### PR DESCRIPTION
Reverts NatLibFi/NDL-VuFind2#2413

@aleksip I think we talked that it would be ok to revert these changes? 

These changes hid unknown amount of fields from LRMI core. That is why #2425 was implemented.