### PR TITLE
Convert variable to string before trimming

### DIFF
--- a/module/Finna/src/Finna/RecordDriver/SolrLido.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrLido.php
@@ -669,7 +669,7 @@ class SolrLido extends \VuFind\RecordDriver\SolrDefault
                     $language
                 );
             if ($descriptionTrimmed = trim((string)$description)) {
-                $type = trim($description->attributes()->type);
+                $type = trim((string)$description->attributes()->type);
                 if ($type === 'displayLink') {
                     $result['resourceName'] = $descriptionTrimmed;
                 } else {

--- a/module/Finna/src/Finna/RecordDriver/SolrQdc.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrQdc.php
@@ -417,15 +417,16 @@ class SolrQdc extends \VuFind\RecordDriver\SolrDefault
         foreach ([$xml->identifier, $xml->isFormatOf] as $field) {
             foreach ($field as $identifier) {
                 $type = (string)$identifier['type'];
+                $identifierTrimmed = trim((string)$identifier);
                 if (in_array($type, ['issn', 'isbn'])) {
                     continue;
                 }
-                $trimmed = str_replace('-', '', trim($identifier));
+                $trimmed = str_replace('-', '', $identifierTrimmed);
                 // ISBN
                 if (preg_match('{^[0-9]{9,12}[0-9xX]}', $trimmed)) {
                     continue;
                 }
-                $trimmed = trim($identifier);
+                $trimmed = $identifierTrimmed;
                 // ISSN
                 if (preg_match('{(issn:)[\S]{4}\-[\S]{4}}', $trimmed)) {
                     continue;
@@ -434,7 +435,7 @@ class SolrQdc extends \VuFind\RecordDriver\SolrDefault
                 // Leave out some obvious matches like urls or urns
                 if (!preg_match('{(^urn:|^https?)}i', $trimmed)) {
                     $detail = (string)$identifier['type'];
-                    $data = trim((string)$identifier);
+                    $data = $identifierTrimmed;
                     $results[] = compact('data', 'detail');
                 }
             }

--- a/module/Finna/src/Finna/RecordDriver/SolrQdc.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrQdc.php
@@ -434,7 +434,7 @@ class SolrQdc extends \VuFind\RecordDriver\SolrDefault
 
                 // Leave out some obvious matches like urls or urns
                 if (!preg_match('{(^urn:|^https?)}i', $trimmed)) {
-                    $detail = (string)$identifier['type'];
+                    $detail = $type;
                     $data = $identifierTrimmed;
                     $results[] = compact('data', 'detail');
                 }


### PR DESCRIPTION
Causes deprecation warning in php 8.1 if null is passed into trim method