### PR TITLE
[ALLI-7686] LIDO: Improve displaying date ranges

### DIFF
--- a/module/Finna/src/Finna/RecordDriver/SolrLido.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrLido.php
@@ -1569,7 +1569,7 @@ class SolrLido extends \VuFind\RecordDriver\SolrDefault
     /**
      * Get an array of dates for results list display
      *
-     * @return array
+     * @return ?array Array of two dates or null if not available
      */
     public function getResultDateRange()
     {
@@ -1848,7 +1848,7 @@ class SolrLido extends \VuFind\RecordDriver\SolrDefault
      *
      * @param string $event Event name
      *
-     * @return null|array Array of two dates or null if not available
+     * @return ?array Array of two dates or null if not available
      */
     protected function getDateRange($event)
     {

--- a/module/Finna/src/Finna/RecordDriver/SolrLido.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrLido.php
@@ -1856,8 +1856,21 @@ class SolrLido extends \VuFind\RecordDriver\SolrDefault
         if (!isset($this->fields[$key])) {
             return null;
         }
-        if (preg_match('/\[(\d{4}).* TO (\d{4})/', $this->fields[$key], $matches)) {
-            return [$matches[1], $matches[2] == '9999' ? null : $matches[2]];
+        $start = null;
+        $end = null;
+        if (preg_match(
+            '/\[(-?\d{4}).* TO (-?\d{4})/',
+            $this->fields[$key],
+            $matches
+        )
+        ) {
+            $start = (string)(intval($matches[1]));
+            $end = (string)(intval($matches[2]));
+        } elseif (preg_match('/^(-?\d{4})-/', $this->fields[$key], $matches)) {
+            $start = (string)intval($matches[1]);
+        }
+        if ($start != null) {
+            return [$start, $end == '9999' ? null : $end];
         }
         return null;
     }

--- a/module/Finna/src/Finna/RecordDriver/SolrLido.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrLido.php
@@ -1856,21 +1856,22 @@ class SolrLido extends \VuFind\RecordDriver\SolrDefault
         if (!isset($this->fields[$key])) {
             return null;
         }
-        $start = null;
-        $end = null;
         if (preg_match(
             '/\[(-?\d{4}).* TO (-?\d{4})/',
             $this->fields[$key],
             $matches
         )
         ) {
-            $start = (string)(intval($matches[1]));
             $end = (string)(intval($matches[2]));
+            return [
+                (string)(intval($matches[1])),
+                $end == '9999' ? null : $end
+            ];
         } elseif (preg_match('/^(-?\d{4})-/', $this->fields[$key], $matches)) {
-            $start = (string)intval($matches[1]);
-        }
-        if ($start != null) {
-            return [$start, $end == '9999' ? null : $end];
+            return [
+                (string)(intval($matches[1])),
+                null
+            ];
         }
         return null;
     }

--- a/module/Finna/tests/unit-tests/src/FinnaTest/RecordDriver/SolrLidoTest.php
+++ b/module/Finna/tests/unit-tests/src/FinnaTest/RecordDriver/SolrLidoTest.php
@@ -370,6 +370,14 @@ class SolrLidoTest extends \PHPUnit\Framework\TestCase
                 ['999', null]
             ],
             [
+                '[-9999-01-01 TO 9998-12-31]',
+                ['-9999', '9998']
+            ],
+            [
+                '[-0055-10-31 TO -0002-02-15]',
+                ['-55', '-2']
+            ],           
+            [
                 '',
                 null
             ]

--- a/module/Finna/tests/unit-tests/src/FinnaTest/RecordDriver/SolrLidoTest.php
+++ b/module/Finna/tests/unit-tests/src/FinnaTest/RecordDriver/SolrLidoTest.php
@@ -376,7 +376,7 @@ class SolrLidoTest extends \PHPUnit\Framework\TestCase
             [
                 '[-0055-10-31 TO -0002-02-15]',
                 ['-55', '-2']
-            ],           
+            ],
             [
                 '',
                 null

--- a/module/Finna/tests/unit-tests/src/FinnaTest/RecordDriver/SolrLidoTest.php
+++ b/module/Finna/tests/unit-tests/src/FinnaTest/RecordDriver/SolrLidoTest.php
@@ -342,6 +342,72 @@ class SolrLidoTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Function to get expected date range data
+     *
+     * @return array
+     */
+    public function getDateRangeData(): array
+    {
+        return [
+            [
+                '[2009-01-01 TO 2009-12-31]',
+                ['2009', '2009']
+            ],
+            [
+                '[-2000-01-01 TO 0900-12-31]',
+                ['-2000', '900']
+            ],
+            [
+                '1937-12-08',
+                ['1937', null]
+            ],
+            [
+                '[0000-01-01 TO 0000-12-31]',
+                ['0', '0']
+            ],
+            [
+                '[0999-06-02 TO 9999-12-31]',
+                ['999', null]
+            ],
+            [
+                '',
+                null
+            ]
+        ];
+    }
+
+    /**
+     * Test getDateRange
+     *
+     * @param string $indexValue Index value to test
+     * @param ?array $expected Result to be expected
+     *
+     * @dataProvider getDateRangeData
+     *
+     * @return void
+     */
+    public function testGetDateRange(
+        string $indexValue,
+        ?array $expected
+    ): void {
+        $record = new SolrLido(
+            [],
+            [],
+            new \Laminas\Config\Config([])
+        );
+        $record->setRawData(
+            [
+                'id' => 'knp-247394',
+                'creation_daterange' => $indexValue
+            ]
+        );
+        $this->assertEquals(
+            $expected,
+            $record->getResultDateRange()
+        );
+    }
+
+    /**
      * Get a record driver with fake data
      *
      * @param string $recordXml    Xml record to use for the test


### PR DESCRIPTION
Fixes displaying dateranges consisting of a single date and dateranges before common era. Removes leading zeros from years before 1000.