### PR TITLE
[ALLI-7695] Re-enable cleanHtml in Markdown helper

### DIFF
--- a/module/Finna/src/Finna/View/Helper/Root/CleanHtml.php
+++ b/module/Finna/src/Finna/View/Helper/Root/CleanHtml.php
@@ -108,6 +108,17 @@ class CleanHtml extends \Laminas\View\Helper\AbstractHelper
                 $config->set('HTML.TargetBlank', 1);
             }
 
+            // Setting the following option makes purifier’s DOMLex pass the
+            // LIBXML_PARSEHUGE option to DOMDocument::loadHtml method. This in turn
+            // ensures that PHP calls htmlCtxtUseOptions (see
+            // github.com/php/php-src/blob/PHP-8.1.14/ext/dom/document.c#L1870),
+            // which ensures that the libxml2 options (namely keepBlanks) are set up
+            // properly, and whitespace nodes are preserved. This should not be an
+            // issue from libxml2 version 2.9.5, but during testing the issue was
+            // still intermittently present. Regardless of that, CentOS 7.x have an
+            // older libxml2 that exhibits the issue.
+            $config->set('Core.AllowParseManyTags', true);
+
             // Add elements and attributes not supported by default
             $def = $config->getHTMLDefinition(true);
             foreach ($this->allowedElements as $elementName => $elementInfo) {

--- a/module/Finna/src/Finna/View/Helper/Root/Markdown.php
+++ b/module/Finna/src/Finna/View/Helper/Root/Markdown.php
@@ -63,12 +63,8 @@ class Markdown extends \VuFind\View\Helper\Root\Markdown
 
         // Clean HTML while in Markdown format, since HTML from server-side rendered
         // custom tags should not be cleaned.
-        /*
-        TODO: Disabled cleanHtml due to it removing whitespace on certain
-        circumstances.
         $cleanHtml = $this->getView()->plugin('cleanHtml');
-        $text = $this->converter->convert($cleanHtml($markdown));*/
-        $text = $this->converter->convert($markdown);
+        $text = $this->converter->convert($cleanHtml($markdown));
 
         // Adjust heading level by +1.
         $text = $this->getView()->plugin('adjustHeadingLevel')($text, 1);


### PR DESCRIPTION
Adds an HTMLPurifier option to fix an issue with libxml2