### PR TITLE
[ALLI-6707] Open Markdown processed links in new tab/window

### DIFF
--- a/local/config/finna/markdown.ini.sample
+++ b/local/config/finna/markdown.ini.sample
@@ -80,7 +80,8 @@ disallowed_tags[] = "plaintext"
 [ExternalLink]
 ; This should be always set, if you want to use this extension. You can use regular
 ; expressions to match group of hosts
-internal_hosts[] = www.finna.fi
+internal_hosts[] = "(^|\.)finna\.fi$"
+internal_hosts[] = "(^|\.)finna-pre\.fi$"
 open_in_new_window = true
 ;html_class = external-link
 nofollow = external

--- a/local/config/finna/markdown.ini.sample
+++ b/local/config/finna/markdown.ini.sample
@@ -80,8 +80,8 @@ disallowed_tags[] = "plaintext"
 [ExternalLink]
 ; This should be always set, if you want to use this extension. You can use regular
 ; expressions to match group of hosts
-internal_hosts[] = "(^|\.)finna\.fi$"
-internal_hosts[] = "(^|\.)finna-pre\.fi$"
+internal_hosts[] = "/(^|\.)finna\.fi$/"
+internal_hosts[] = "/(^|\.)finna-pre\.fi$/"
 open_in_new_window = true
 ;html_class = external-link
 nofollow = external

--- a/local/config/finna/markdown.ini.sample
+++ b/local/config/finna/markdown.ini.sample
@@ -39,7 +39,7 @@ renderer[soft_break] = "<br>"
 ; with 'config_key' with value of configuration key, in which your extension expects
 ; its configuration. More about custom extension configuration:
 ; https://commonmark.thephpleague.com/2.3/customization/configuration/
-extensions = Autolink
+extensions = Autolink,ExternalLink
 
 ; CommonMarkCore extension is always enabled by default
 [CommonMarkCore]
@@ -80,12 +80,12 @@ disallowed_tags[] = "plaintext"
 [ExternalLink]
 ; This should be always set, if you want to use this extension. You can use regular
 ; expressions to match group of hosts
-internal_hosts[] = www.example.com
-;open_in_new_window = true
+internal_hosts[] = www.finna.fi
+open_in_new_window = true
 ;html_class = external-link
-;nofollow =
-;noopener = external
-;noreferrer = external
+nofollow = external
+noopener = external
+noreferrer = external
 
 ; See https://commonmark.thephpleague.com/2.3/extensions/footnotes/
 [Footnote]

--- a/module/Finna/src/Finna/View/Helper/Root/Markdown.php
+++ b/module/Finna/src/Finna/View/Helper/Root/Markdown.php
@@ -64,7 +64,7 @@ class Markdown extends \VuFind\View\Helper\Root\Markdown
         // Clean HTML while in Markdown format, since HTML from server-side rendered
         // custom tags should not be cleaned.
         $cleanHtml = $this->getView()->plugin('cleanHtml');
-        $text = $this->converter->convert($cleanHtml($markdown));
+        $text = $this->converter->convert($cleanHtml($markdown, true));
 
         // Adjust heading level by +1.
         $text = $this->getView()->plugin('adjustHeadingLevel')($text, 1);


### PR DESCRIPTION
Tämän lisäksi pitää vielä muuttaa `markdown.ini`:stä seuraavat kohdat

```ini
[Markdown]
...
extensions = Autolink,ExternalLink

[ExternalLink]
; This should be always set, if you want to use this extension. You can use regular
; expressions to match group of hosts
internal_hosts[] = "/(^|\.)finna\.fi$/"
internal_hosts[] = "/(^|\.)finna-pre\.fi$/"
open_in_new_window = true
;html_class = external-link
nofollow = external
noopener = external
noreferrer = external
```