### PR TITLE
[ALLI-7804] Extend classification of database stats entries

### DIFF
--- a/local/config/finna/config.ini.sample
+++ b/local/config/finna/config.ini.sample
@@ -431,6 +431,10 @@ choice_order = Database,Shibboleth,MultiILS
 ; Currently only supported statistics driver is Database. Uncomment to enable
 ; recording of statistics:
 ;driver = Database
+; IP addresses or address ranges of monitoring systems
+;monitoring_ips[] = "127.0.0.1"
+; IP addresses or address ranges of systems excluded from statistics
+;exclude_ips[] = "192.168.1.1-192.168.255.255"
 
 ; This section requires no changes for most installations
 [Index]

--- a/module/Finna/sql/mysql.sql
+++ b/module/Finna/sql/mysql.sql
@@ -171,6 +171,8 @@ CREATE TABLE `finna_feedback` (
 CREATE TABLE `finna_page_view_stats` (
   `institution` varchar(255) NOT NULL,
   `view` varchar(255) NOT NULL,
+  -- Note: `crawler` is actually a bitmap for request type, but the name remains for
+  -- historical reasons.
   `crawler` tinyint(1) NOT NULL,
   `controller` varchar(128) NOT NULL,
   `action` varchar(128) NOT NULL,
@@ -185,6 +187,8 @@ CREATE TABLE `finna_page_view_stats` (
 CREATE TABLE `finna_session_stats` (
   `institution` varchar(255) NOT NULL,
   `view` varchar(255) NOT NULL,
+  -- Note: `crawler` is actually a bitmap for request type, but the name remains for
+  -- historical reasons.
   `crawler` tinyint(1) NOT NULL,
   `date` DATE NOT NULL,
   `count` int(11) NOT NULL DEFAULT 1,
@@ -197,6 +201,8 @@ CREATE TABLE `finna_session_stats` (
 CREATE TABLE `finna_record_stats` (
   `institution` varchar(255) NOT NULL,
   `view` varchar(255) NOT NULL,
+  -- Note: `crawler` is actually a bitmap for request type, but the name remains for
+  -- historical reasons.
   `crawler` tinyint(1) NOT NULL,
   `date` DATE NOT NULL,
   `backend` varchar(128) NOT NULL,
@@ -213,6 +219,8 @@ CREATE TABLE `finna_record_stats` (
 CREATE TABLE `finna_record_stats_log` (
   `institution` varchar(255) NOT NULL,
   `view` varchar(255) NOT NULL,
+  -- Note: `crawler` is actually a bitmap for request type, but the name remains for
+  -- historical reasons.
   `crawler` tinyint(1) NOT NULL,
   `date` DATE NOT NULL,
   `backend` varchar(128) NOT NULL,

--- a/module/Finna/src/Finna/Statistics/Driver/Database.php
+++ b/module/Finna/src/Finna/Statistics/Driver/Database.php
@@ -101,7 +101,7 @@ class Database implements DriverInterface, LoggerAwareInterface
      *
      * @param string $institution Institution code
      * @param string $view        View subpath (empty string for default view)
-     * @param bool   $crawler     Whether the request comes from bot or crawler
+     * @param int    $type        Request type bitmap
      * @param array  $session     Session data
      *
      * @return void
@@ -109,11 +109,11 @@ class Database implements DriverInterface, LoggerAwareInterface
     public function addNewSession(
         string $institution,
         string $view,
-        bool $crawler,
+        int $type,
         array $session
     ): void {
         $date = date('Y-m-d');
-        $crawler = $crawler ? 1 : 0;
+        $crawler = $type;
         $params = compact('institution', 'view', 'crawler', 'date');
         $this->processAdd($this->sessionTable, $params);
     }
@@ -123,7 +123,7 @@ class Database implements DriverInterface, LoggerAwareInterface
      *
      * @param string $institution Institution code
      * @param string $view        View subpath (empty string for default view)
-     * @param bool   $crawler     Whether the request comes from bot or crawler
+     * @param int    $type        Request type bitmap
      * @param string $controller  Controller
      * @param string $action      Action
      *
@@ -132,12 +132,12 @@ class Database implements DriverInterface, LoggerAwareInterface
     public function addPageView(
         string $institution,
         string $view,
-        bool $crawler,
+        int $type,
         string $controller,
         string $action
     ): void {
         $date = date('Y-m-d');
-        $crawler = $crawler ? 1 : 0;
+        $crawler = $type;
         $params = compact(
             'institution',
             'view',
@@ -154,7 +154,7 @@ class Database implements DriverInterface, LoggerAwareInterface
      *
      * @param string $institution Institution code
      * @param string $view        View subpath (empty string for default view)
-     * @param bool   $crawler     Whether the request comes from bot or crawler
+     * @param int    $type        Request type bitmap
      * @param string $backend     Backend ID
      * @param string $source      Record source
      * @param string $recordId    Record ID
@@ -168,7 +168,7 @@ class Database implements DriverInterface, LoggerAwareInterface
     public function addRecordView(
         string $institution,
         string $view,
-        bool $crawler,
+        int $type,
         string $backend,
         string $source,
         string $recordId,
@@ -179,7 +179,7 @@ class Database implements DriverInterface, LoggerAwareInterface
         $date = date('Y-m-d');
 
         // Summary log:
-        $crawler = $crawler ? 1 : 0;
+        $crawler = $type;
         $params = compact(
             'institution',
             'view',

--- a/module/Finna/src/Finna/Statistics/Driver/DriverInterface.php
+++ b/module/Finna/src/Finna/Statistics/Driver/DriverInterface.php
@@ -43,7 +43,7 @@ interface DriverInterface
      *
      * @param string $institution Institution code
      * @param string $view        View subpath (empty string for default view)
-     * @param bool   $crawler     Whether the request comes from bot or crawler
+     * @param int    $type        Request type bitmap
      * @param array  $session     Session data
      *
      * @return void
@@ -51,7 +51,7 @@ interface DriverInterface
     public function addNewSession(
         string $institution,
         string $view,
-        bool $crawler,
+        int $type,
         array $session
     ): void;
 
@@ -60,7 +60,7 @@ interface DriverInterface
      *
      * @param string $institution Institution code
      * @param string $view        View subpath (empty string for default view)
-     * @param bool   $crawler     Whether the request comes from bot or crawler
+     * @param int    $type        Request type bitmap
      * @param string $backend     Backend ID
      * @param string $source      Record source
      * @param string $recordId    Record ID
@@ -74,7 +74,7 @@ interface DriverInterface
     public function addRecordView(
         string $institution,
         string $view,
-        bool $crawler,
+        int $type,
         string $backend,
         string $source,
         string $recordId,
@@ -88,7 +88,7 @@ interface DriverInterface
      *
      * @param string $institution Institution code
      * @param string $view        View subpath (empty string for default view)
-     * @param bool   $crawler     Whether the request comes from bot or crawler
+     * @param int    $type        Request type bitmap
      * @param string $controller  Controller
      * @param string $action      Action
      *
@@ -97,7 +97,7 @@ interface DriverInterface
     public function addPageView(
         string $institution,
         string $view,
-        bool $crawler,
+        int $type,
         string $controller,
         string $action
     ): void;


### PR DESCRIPTION
Makes the crawler bit a bitmap that allows distinguishing of API and monitoring requests.

Note that AdminInterface doesn't need immediate changes as it ignores any non-zero value at the moment.