### PR TITLE
Proxy feed item images and improve caching.

### DIFF
--- a/module/Finna/src/Finna/Controller/FeedContentController.php
+++ b/module/Finna/src/Finna/Controller/FeedContentController.php
@@ -122,15 +122,7 @@ class FeedContentController extends ContentController
 
         // Validate image url to ensure we don't proxy anything not belonging to the
         // feed:
-        $valid = false;
-        $proxiedUrl = $feedService->proxifyImageUrl($imageUrl, $id);
-        foreach ($feed['items'] as $item) {
-            if (($item['image']['url'] ?? '') === $proxiedUrl) {
-                $valid = true;
-                break;
-            }
-        }
-        if (!$valid) {
+        if (!in_array($imageUrl, $feed['allowedImages'])) {
             return $this->notFoundAction();
         }
 


### PR DESCRIPTION
Now caches parsed results to avoid repeatedly processing the feed data. Also stores an array of allowed images so that it's easier to check when loading an image.