### PR TITLE
[ALLI-7831] Fix deduplication source selection with only 1 source

### DIFF
--- a/module/Finna/src/Finna/View/Helper/Root/Record.php
+++ b/module/Finna/src/Finna/View/Helper/Root/Record.php
@@ -1333,9 +1333,10 @@ class Record extends \VuFind\View\Helper\Root\Record
             }
         }
         $dedupData = $this->driver->getDedupData();
-        // Return driver's datasource if deduplication data is not set.
+        // Return driver's datasource if deduplication data is not set or
+        // the count of deduplication data is 1.
         // There cannot be any other sources in this case.
-        if (empty($dedupData)) {
+        if (count($dedupData) <= 1) {
             return $this->driver->tryMethod('getDataSource', [], '');
         }
         $preferredSources = $this->userPreferenceService->getPreferredDataSources();


### PR DESCRIPTION
Filters can remove items from the deduplication array. In this case, return the records own datasource.