### PR TITLE
[ALLI-7877] Menu movement fixes

### DIFF
--- a/themes/finna2/js/finna-menu-movement.js
+++ b/themes/finna2/js/finna-menu-movement.js
@@ -30,7 +30,7 @@ FinnaMovement.prototype.setEvents = function setEvents() {
       }
     }
   });
-  _.mutationObserver.observe(_.menuRootElement[0], {attributes: true, childList: true, subtree: true})
+  _.mutationObserver.observe(_.menuRootElement[0], {attributes: true, childList: true, subtree: true});
   _.menuRootElement.on('keydown', function detectKeyPress(e) {
     _.checkKey(e);
   });

--- a/themes/finna2/js/finna-menu.js
+++ b/themes/finna2/js/finna-menu.js
@@ -51,7 +51,6 @@ finna.menu = (function finnaMenu() {
           data: {'active': null}
         }).done(function onGetMyListsDone(data) {
           $('.mylist-bar').append(data.data);
-          link.closest('.finna-movement').trigger('reindex');
           $('.add-new-list-holder').hide();
         });
       });

--- a/themes/finna2/js/finna-mylist.js
+++ b/themes/finna2/js/finna-mylist.js
@@ -415,7 +415,6 @@ finna.myList = (function finnaMyList() {
       .done(function onGetMyListsDone(data) {
         toggleSpinner(spinner, false);
         $('.mylist-bar').empty().html(data.data);
-        $('.mylist-bar').closest('.finna-movement').trigger('reindex');
         initEditComponents();
       })
       .fail(function onGetMyListsDone() {


### PR DESCRIPTION
Allow usage of tab key. Avoid infinite loop if favorites are open. Use MutationObserver to detect changes in tree instead of triggering reindex.