### PR TITLE
[FINNA-436] QDC: display copyrights as descriptions if suited

### DIFF
--- a/module/Finna/src/Finna/RecordDriver/Feature/SolrCommonFinnaTrait.php
+++ b/module/Finna/src/Finna/RecordDriver/Feature/SolrCommonFinnaTrait.php
@@ -270,4 +270,46 @@ trait SolrCommonFinnaTrait
         [$locale] = explode('-', $this->getTranslatorLocale());
         return $locale;
     }
+
+    /**
+     * Get an array containing languages in a priority order.
+     * First language is the translator locale, then languages from primary array,
+     * then sites fallback_languages and last default non-language code
+     *
+     * @param array  $primary   An array containing languages, which are to be checked after
+     *                          translator locale.
+     * @param bool   $shortCode Should the languages be reduced into 2 character short codes.
+     *                          Default is false.
+     * @param string $default   If a non-language term is required, then use $default to append
+     *                          a non-language code like 'no_locale'
+     *
+     * @return array
+     */
+    protected function getLanguagePriority(
+        array $primary,
+        bool $shortCode = false,
+        string $default = '',
+    ): array {
+        $languages = [
+            $this->getTranslatorLocale(),
+            ...$primary,
+            ...explode(
+                ',',
+                $this->mainConfig->Site['fallback_languages'] ?? 'fi,sv,en-gb'
+            ),
+        ];
+        if ($shortCode) {
+            $languages = array_map(
+                function ($lang) {
+                    [$code] = explode('-', $lang, 2);
+                    return $code;
+                },
+                $languages
+            );
+        }
+        if ($default) {
+            $languages[] = $default;
+        }
+        return array_unique($languages);
+    }
 }

--- a/module/Finna/src/Finna/RecordDriver/Feature/SolrCommonFinnaTrait.php
+++ b/module/Finna/src/Finna/RecordDriver/Feature/SolrCommonFinnaTrait.php
@@ -286,7 +286,7 @@ trait SolrCommonFinnaTrait
      * @return array
      */
     protected function getLanguagePriority(
-        array $primary,
+        array $primary = [],
         bool $shortCode = false,
         string $default = '',
     ): array {

--- a/module/Finna/src/Finna/RecordDriver/Feature/SolrCommonFinnaTrait.php
+++ b/module/Finna/src/Finna/RecordDriver/Feature/SolrCommonFinnaTrait.php
@@ -309,15 +309,18 @@ trait SolrCommonFinnaTrait
         string $default = '',
     ): array {
         $languages = [
-            $this->getLocale(),
+            $this->getTranslatorLocale(),
             ...$primary,
             ...$this->localeSettings->getFallbackLocales(),
         ];
         $final = [];
         foreach ($languages as $lang) {
             $final[] = $lang;
-            if (str_contains($lang, '-')) {
-                [$code] = explode('-', $lang, 2);
+            if (!str_contains($lang, '-')) {
+                continue;
+            }
+            [$code] = explode('-', $lang, 2);
+            if ($code) {
                 $final[] = $code;
             }
         }

--- a/module/Finna/src/Finna/RecordDriver/SolrDefaultFactory.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrDefaultFactory.php
@@ -78,7 +78,7 @@ class SolrDefaultFactory extends \VuFind\RecordDriver\SolrDefaultWithoutSearchSe
             $container->get(\VuFind\Config\PluginManager::class)->get('datasources')
         );
         $driver->attachVideoHandler($container->get(\Finna\Video\Video::class));
-
+        $driver->attachLocaleSettings($container->get(\VuFind\I18n\Locale\LocaleSettings::class));
         return $driver;
     }
 }

--- a/module/Finna/src/Finna/RecordDriver/SolrQdc.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrQdc.php
@@ -361,7 +361,7 @@ class SolrQdc extends \VuFind\RecordDriver\SolrDefault implements \Laminas\Log\L
         }
         // Check that there is proper values to use for displaying the rights.
         $localizedRights = [];
-        foreach ($this->getLanguagePriority([$language], true, 'no_locale') as $lang) {
+        foreach ($this->getPrioritizedLanguages([$language], 'no_locale') as $lang) {
             if (!empty($cache[$lang])) {
                 $localizedRights = $cache[$lang];
                 break;
@@ -376,7 +376,8 @@ class SolrQdc extends \VuFind\RecordDriver\SolrDefault implements \Laminas\Log\L
         $result['copyright'] = $mappedRight;
         $result['link'] = $this->getRightsLink($mappedRight, $language);
         foreach ($localizedRights as $right) {
-            // Add all extra copyrights as description
+            // Add rights as descriptions which have the same localization
+            // as the primary right.
             if (
                 'copyright' === $right['type']
                 && $result['copyright'] !== $right['txt']

--- a/module/Finna/tests/fixtures/qdc/qdc_ir_test.xml
+++ b/module/Finna/tests/fixtures/qdc/qdc_ir_test.xml
@@ -14,8 +14,8 @@
   <relation type="issn" lang="-">1234-5678</relation>
   <rights>CC BY 4.0</rights>
   <rights type="copyright">This is a copyright description</rights>
-  <rights type="copyright" lang="fi">This is a copyright which is should not be displayed</rights>
-  <rights type="copyright">This is a copyright which is should also be displayed as description</rights>
+  <rights type="notdisplayable">This is a copyright which should not be displayed</rights>
+  <rights type="copyright">This is a copyright which should also be displayed as description</rights>
   <publisher lang="-">Tielaitos</publisher>
   <file bundle="ORIGINAL" href="https://www.animals.of.earth.fi/duck.pdf" name="duck.pdf" type="application/pdf" length="41070954" sequence="1"/>
   <recordID>10024_138404</recordID>

--- a/module/Finna/tests/fixtures/qdc/qdc_ir_test.xml
+++ b/module/Finna/tests/fixtures/qdc/qdc_ir_test.xml
@@ -13,6 +13,9 @@
   <relation type="numberofseries" lang="-">11/2022</relation>
   <relation type="issn" lang="-">1234-5678</relation>
   <rights>CC BY 4.0</rights>
+  <rights type="copyright">This is a copyright description</rights>
+  <rights type="copyright" lang="fi">This is a copyright which is should not be displayed</rights>
+  <rights type="copyright">This is a copyright which is should also be displayed as description</rights>
   <publisher lang="-">Tielaitos</publisher>
   <file bundle="ORIGINAL" href="https://www.animals.of.earth.fi/duck.pdf" name="duck.pdf" type="application/pdf" length="41070954" sequence="1"/>
   <recordID>10024_138404</recordID>

--- a/module/Finna/tests/fixtures/qdc/qdc_museum_test.xml
+++ b/module/Finna/tests/fixtures/qdc/qdc_museum_test.xml
@@ -19,6 +19,9 @@
   <file bundle="square">https://www.savanni.art.collection.org/square/ducksinharmony.jpg</file>
   <file bundle="original" sha256="2232ad129bf4d7bdc243a05a407f3cdda4cd45bee4c36538a8d87c20e8df1269" mimetype="image/jpeg">https://www.savanni.art.collection.org/original/ducksinharmony.jpg</file>
   <file bundle="ORIGINAL" href="https://poriartmuseumcollections.pori.fi/files/original/000d586c8b9d30681001a554e1eaf3c5401e4714.jpg"/>
+  <rights type="accesslevel" lang="en">openAccess</rights>
+  <rights type="copyright" lang="en">2023 Finna qa</rights>
+  <rights type="copyright" lang="fi">2023 Finna qa which should not show</rights>
   <medium href="http://www.wikidata.org/entity/Q296955" type="wikidata:P186" comment="P12345 (made from material)">Akryyli</medium>
   <medium href="http://www.wikidata.org/entity/Q1397443" type="wikidata:P186" comment="P12345 (made from material)">Kangas</medium>
   <format width="2.1 cm" height="2.3 cm" comment="P2049, P2048">2.1 cm x 2.3 cm</format>

--- a/module/Finna/tests/unit-tests/src/FinnaTest/RecordDriver/SolrQdcInstitutionalRepositoryTest.php
+++ b/module/Finna/tests/unit-tests/src/FinnaTest/RecordDriver/SolrQdcInstitutionalRepositoryTest.php
@@ -206,6 +206,19 @@ class SolrQdcInstitutionalRepositoryTest extends \PHPUnit\Framework\TestCase
             $config,
             new \Laminas\Config\Config($searchConfig)
         );
+        $localeConfig = [
+            'Site' => [
+                'language' => 'en',
+                'fallbackLocales' => 'en',
+            ],
+            'Languages' => [
+                'fi' => 'Finnish',
+                'en' => 'English',
+                'sv' => 'Swedish',
+            ],
+        ];
+        $localeConfig = new \Laminas\Config\Config($localeConfig);
+        $record->attachLocaleSettings(new \VuFind\I18n\Locale\LocaleSettings($localeConfig));
         $record->setRawData(
             [
                 'id' => 'knp-247394',

--- a/module/Finna/tests/unit-tests/src/FinnaTest/RecordDriver/SolrQdcInstitutionalRepositoryTest.php
+++ b/module/Finna/tests/unit-tests/src/FinnaTest/RecordDriver/SolrQdcInstitutionalRepositoryTest.php
@@ -65,6 +65,10 @@ class SolrQdcInstitutionalRepositoryTest extends \PHPUnit\Framework\TestCase
                         'rights' => [
                             'copyright' => 'CC BY 4.0',
                             'link' => 'http://creativecommons.org/licenses/by/4.0/deed.fi',
+                            'description' => [
+                                'This is a copyright description',
+                                'This is a copyright which is should also be displayed as description',
+                            ],
                         ],
                         'pdf' => true,
                         'downloadable' => true,

--- a/module/Finna/tests/unit-tests/src/FinnaTest/RecordDriver/SolrQdcInstitutionalRepositoryTest.php
+++ b/module/Finna/tests/unit-tests/src/FinnaTest/RecordDriver/SolrQdcInstitutionalRepositoryTest.php
@@ -67,7 +67,7 @@ class SolrQdcInstitutionalRepositoryTest extends \PHPUnit\Framework\TestCase
                             'link' => 'http://creativecommons.org/licenses/by/4.0/deed.fi',
                             'description' => [
                                 'This is a copyright description',
-                                'This is a copyright which is should also be displayed as description',
+                                'This is a copyright which should also be displayed as description',
                             ],
                         ],
                         'pdf' => true,

--- a/module/Finna/tests/unit-tests/src/FinnaTest/RecordDriver/SolrQdcInstitutionalRepositoryTest.php
+++ b/module/Finna/tests/unit-tests/src/FinnaTest/RecordDriver/SolrQdcInstitutionalRepositoryTest.php
@@ -208,13 +208,15 @@ class SolrQdcInstitutionalRepositoryTest extends \PHPUnit\Framework\TestCase
         );
         $localeConfig = [
             'Site' => [
-                'language' => 'en',
-                'fallbackLocales' => 'en',
+                'language' => 'fi',
+                'fallback_languages' => 'en-gb,sv',
+                'browserDetectLanguage' => false,
             ],
             'Languages' => [
                 'fi' => 'Finnish',
                 'en' => 'English',
                 'sv' => 'Swedish',
+                'en-gb' => 'British English',
             ],
         ];
         $localeConfig = new \Laminas\Config\Config($localeConfig);

--- a/module/Finna/tests/unit-tests/src/FinnaTest/RecordDriver/SolrQdcMuseumTest.php
+++ b/module/Finna/tests/unit-tests/src/FinnaTest/RecordDriver/SolrQdcMuseumTest.php
@@ -64,8 +64,11 @@ class SolrQdcMuseumTest extends \PHPUnit\Framework\TestCase
                         ],
                         'description' => '',
                         'rights' => [
-                            'copyright' => '',
+                            'copyright' => 'openAccess',
                             'link' => false,
+                            'description' => [
+                                '2023 Finna qa',
+                            ],
                         ],
                         'highResolution' => [
                             'original' => [

--- a/module/Finna/tests/unit-tests/src/FinnaTest/RecordDriver/SolrQdcMuseumTest.php
+++ b/module/Finna/tests/unit-tests/src/FinnaTest/RecordDriver/SolrQdcMuseumTest.php
@@ -374,6 +374,19 @@ class SolrQdcMuseumTest extends \PHPUnit\Framework\TestCase
             $config,
             new \Laminas\Config\Config($searchConfig)
         );
+        $localeConfig = [
+            'Site' => [
+                'language' => 'en',
+                'fallbackLocales' => 'en',
+            ],
+            'Languages' => [
+                'fi' => 'Finnish',
+                'en' => 'English',
+                'sv' => 'Swedish',
+            ],
+        ];
+        $localeConfig = new \Laminas\Config\Config($localeConfig);
+        $record->attachLocaleSettings(new \VuFind\I18n\Locale\LocaleSettings($localeConfig));
         $record->setRawData(['id' => 'knp-247394', 'fullrecord' => $fixture]);
         return $record;
     }

--- a/module/Finna/tests/unit-tests/src/FinnaTest/RecordDriver/SolrQdcMuseumTest.php
+++ b/module/Finna/tests/unit-tests/src/FinnaTest/RecordDriver/SolrQdcMuseumTest.php
@@ -376,13 +376,15 @@ class SolrQdcMuseumTest extends \PHPUnit\Framework\TestCase
         );
         $localeConfig = [
             'Site' => [
-                'language' => 'en',
-                'fallbackLocales' => 'en',
+                'language' => 'fi',
+                'fallback_languages' => 'en-gb,sv',
+                'browserDetectLanguage' => false,
             ],
             'Languages' => [
                 'fi' => 'Finnish',
                 'en' => 'English',
                 'sv' => 'Swedish',
+                'en-gb' => 'British English',
             ],
         ];
         $localeConfig = new \Laminas\Config\Config($localeConfig);


### PR DESCRIPTION
* Try to match the language from the topmost copyright