### PR TITLE
[FINNA-559] Fix typo in translation

### DIFF
--- a/local/languages/finna/fi.ini
+++ b/local/languages/finna/fi.ini
@@ -1141,7 +1141,7 @@ street_search_introduction_results_html = "Teit <span class="highlight">Finna St
 street_search_refresh = "Päivitä sijaintisi"
 street_search_timeout = "Paikannus keskeytettiin, koska se kesti liian kauan. Haku toimii parhaiten ulkotiloissa."
 Studios = "Studiot"
-Study Program Information Notes = "Huomatus opinto-ohjelmasta"
+Study Program Information Notes = "Huomautus opinto-ohjelmasta"
 Subject Actor = "Aiheen toimija"
 Subject Date = "Aiheen aika"
 Subject Detail = "Aiheen tarkenne"


### PR DESCRIPTION
Edelliseen mergeen jäi suom. käännökseen ikävä kirjoitusvirhe ja ehdin poistaa branchin, niin tässä typon korjaava PR. 