### PR TITLE
[FINNA-1003] QDC: Adjust rights to return non-localized rights properly

### DIFF
--- a/module/Finna/src/Finna/RecordDriver/SolrQdc.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrQdc.php
@@ -90,6 +90,13 @@ class SolrQdc extends \VuFind\RecordDriver\SolrDefault implements \Laminas\Log\L
     ];
 
     /**
+     * Default value for no_locale definition used for no language
+     *
+     * @var string
+     */
+    protected const NO_LOCALE = 'no_locale';
+
+    /**
      * Constructor
      *
      * @param \Laminas\Config\Config $mainConfig     VuFind main configuration (omit
@@ -343,12 +350,18 @@ class SolrQdc extends \VuFind\RecordDriver\SolrDefault implements \Laminas\Log\L
             'link' => '',
             'description' => [],
         ];
+        $firstElementPriority = null;
         $cache = [];
         // Get all the copyrights and save them in an array identified by language.
         foreach ($xml->rights as $right) {
             $strRight = trim((string)$right);
             $type = trim((string)$right->attributes()->type);
-            $rightLanguage = trim((string)$right->attributes()->lang) ?: 'no_locale';
+            $rightLanguage = trim((string)$right->attributes()->lang) ?: self::NO_LOCALE;
+            // If no type and language is set and it is the first rights element,
+            // then we can assume it is the main copyright to display
+            if (null === $firstElementPriority) {
+                $firstElementPriority = !$type && self::NO_LOCALE === $rightLanguage;
+            }
             $cache[$rightLanguage][] = [
                 'txt' => $strRight,
                 'type' => $type,
@@ -359,11 +372,15 @@ class SolrQdc extends \VuFind\RecordDriver\SolrDefault implements \Laminas\Log\L
         }
         // Check that there is proper values to use for displaying the rights.
         $localizedRights = [];
-        foreach ($this->getPrioritizedLanguages([$language], 'no_locale') as $lang) {
-            if (!empty($cache[$lang])) {
-                $localizedRights = $cache[$lang];
-                break;
+        foreach ($this->getPrioritizedLanguages([$language], self::NO_LOCALE) as $lang) {
+            if (empty($cache[$lang])) {
+                continue;
             }
+            // If there is an element which should be prepended as it has priority, do so here.
+            $localizedRights = (self::NO_LOCALE !== $lang && $firstElementPriority)
+                ? array_merge($cache[self::NO_LOCALE], $cache[$lang])
+                : $localizedRights = $cache[$lang];
+            break;
         }
         if (empty($localizedRights)) {
             return $result;
@@ -383,7 +400,6 @@ class SolrQdc extends \VuFind\RecordDriver\SolrDefault implements \Laminas\Log\L
                 $result['description'][] = $right['txt'];
             }
         }
-
         return $result;
     }
 

--- a/module/Finna/src/Finna/RecordDriver/SolrQdc.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrQdc.php
@@ -379,7 +379,7 @@ class SolrQdc extends \VuFind\RecordDriver\SolrDefault implements \Laminas\Log\L
             // Check if there is an rights element with priority.
             $localizedRights = (self::NO_LOCALE !== $lang && $firstElementPriority)
                 ? array_merge($cache[self::NO_LOCALE], $cache[$lang])
-                : $localizedRights = $cache[$lang];
+                : $cache[$lang];
             break;
         }
         if (empty($localizedRights)) {

--- a/module/Finna/src/Finna/RecordDriver/SolrQdc.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrQdc.php
@@ -376,7 +376,7 @@ class SolrQdc extends \VuFind\RecordDriver\SolrDefault implements \Laminas\Log\L
             if (empty($cache[$lang])) {
                 continue;
             }
-            // If there is an element which should be prepended as it has priority, do so here.
+            // Check if there is an rights element with priority.
             $localizedRights = (self::NO_LOCALE !== $lang && $firstElementPriority)
                 ? array_merge($cache[self::NO_LOCALE], $cache[$lang])
                 : $localizedRights = $cache[$lang];

--- a/module/Finna/tests/fixtures/qdc/qdc_museum_test.xml
+++ b/module/Finna/tests/fixtures/qdc/qdc_museum_test.xml
@@ -19,6 +19,7 @@
   <file bundle="square">https://www.savanni.art.collection.org/square/ducksinharmony.jpg</file>
   <file bundle="original" sha256="2232ad129bf4d7bdc243a05a407f3cdda4cd45bee4c36538a8d87c20e8df1269" mimetype="image/jpeg">https://www.savanni.art.collection.org/original/ducksinharmony.jpg</file>
   <file bundle="ORIGINAL" href="https://poriartmuseumcollections.pori.fi/files/original/000d586c8b9d30681001a554e1eaf3c5401e4714.jpg"/>
+  <rights>In CopyRight</rights>
   <rights type="accesslevel" lang="en">openAccess</rights>
   <rights type="copyright" lang="en">2023 Finna qa</rights>
   <rights type="copyright" lang="fi">2023 Finna qa which should not show</rights>

--- a/module/Finna/tests/unit-tests/src/FinnaTest/RecordDriver/SolrQdcMuseumTest.php
+++ b/module/Finna/tests/unit-tests/src/FinnaTest/RecordDriver/SolrQdcMuseumTest.php
@@ -66,7 +66,7 @@ class SolrQdcMuseumTest extends \PHPUnit\Framework\TestCase
                         ],
                         'description' => '',
                         'rights' => [
-                            'copyright' => 'openAccess',
+                            'copyright' => 'In CopyRight',
                             'link' => false,
                             'description' => [
                                 '2023 Finna qa',


### PR DESCRIPTION
If the first rights element has no type and language, it should be displayed as the main rights element.