### PR TITLE
[FINNA-1274] Refactor description loading and add provider for Kirjavälitys.

### DIFF
--- a/local/config/finna/config.ini.sample
+++ b/local/config/finna/config.ini.sample
@@ -739,6 +739,13 @@ lastname = SHIB_sn
 ;        Example: LocalFile:%vufind-local-dir%/path/to/file/%size%/issn/%issn%.%anyimage%
 coverimages     = NatLibFi,OpenLibrary
 
+; Description providers (a comma-separated list in priority order). Available
+; providers are:
+; NatLibFi
+; Record
+; RecordUrl
+descriptions = NatLibFi,RecordUrl,Record
+
 ; List of undisplayable file formats
 ; undisplayable_file_formats = 'tif:tiff:3d-pdf:3d model:glb:obj:gltf'
 

--- a/local/config/finna/datasources.ini.sample
+++ b/local/config/finna/datasources.ini.sample
@@ -33,7 +33,7 @@ institution = Library
 ; RecordUrl
 ; Kirjavalitys:customerId (customerId is part of the URL, e.g. consortium name in lowercase)
 ; shared (a special one to include the common providers from main configuration)
-;coverimages = Kirjavalitys:customerId,shared
+;descriptions = Kirjavalitys:customerId,shared
 ; Link template for linking to the staff UI. Note that staff UI link is available
 ; only for users with the access.finna.StaffUiLink permission.
 staffUiUrl = "https://server-address/cgi-bin/koha/catalogue/detail.pl?biblionumber=%%id%%"

--- a/local/config/finna/datasources.ini.sample
+++ b/local/config/finna/datasources.ini.sample
@@ -25,6 +25,15 @@ institution = Library
 ; Contentcafe and/or Google Books. These settings are used in addition to the ones
 ; defined in config.ini
 ;coverimages = BTJ:customerId
+;coverimages = BTJ:customerId,Kirjavalitys:customerId
+; Description providers (a comma-separated list in priority order). Available
+; providers are:
+; NatLibFi
+; Record
+; RecordUrl
+; Kirjavalitys:customerId (customerId is part of the URL, e.g. consortium name in lowercase)
+; shared (a special one to include the common providers from main configuration)
+;coverimages = Kirjavalitys:customerId,shared
 ; Link template for linking to the staff UI. Note that staff UI link is available
 ; only for users with the access.finna.StaffUiLink permission.
 staffUiUrl = "https://server-address/cgi-bin/koha/catalogue/detail.pl?biblionumber=%%id%%"

--- a/module/Finna/config/module.config.php
+++ b/module/Finna/config/module.config.php
@@ -5,7 +5,7 @@
  *
  * PHP version 8
  *
- * Copyright (C) The National Library of Finland 2014-2021.
+ * Copyright (C) The National Library of Finland 2014-2023.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,
@@ -356,6 +356,7 @@ $config = [
             'Finna\Config\SearchSpecsReader' => 'VuFind\Config\YamlReaderFactory',
             'Finna\Config\YamlReader' => 'VuFind\Config\YamlReaderFactory',
             'Finna\Connection\Finto' => 'Finna\Connection\FintoFactory',
+            'Finna\Content\Description\PluginManager' => 'VuFind\ServiceManager\AbstractPluginManagerFactory',
             'Finna\Cookie\RecommendationMemory' => 'Finna\Cookie\RecommendationMemoryFactory',
             'Finna\Cover\Loader' => 'VuFind\Cover\LoaderFactory',
             'Finna\Export' => 'VuFind\ExportFactory',
@@ -588,6 +589,7 @@ $config = [
                     'r2' => 'Finna\Autocomplete\R2',
                 ],
             ],
+            'content_description' => [],
             'db_row' => [
                 'factories' => [
                     'Finna\Db\Row\CommentsInappropriate' => 'VuFind\Db\Row\RowGatewayFactory',
@@ -894,6 +896,7 @@ $config = [
                 'factories' => [
                     'Finna\Content\Covers\BTJ' => 'Finna\Content\Covers\BTJFactory',
                     'Finna\Content\Covers\CoverArtArchive' => 'Finna\Content\Covers\CoverArtArchiveFactory',
+                    'Finna\Content\Covers\Kirjavalitys' => 'Finna\Content\Covers\KirjavalitysFactory',
                 ],
                 'invokables' => [
                     'bookyfi' => 'Finna\Content\Covers\BookyFi',
@@ -902,6 +905,7 @@ $config = [
                 'aliases' => [
                     'btj' => 'Finna\Content\Covers\BTJ',
                     'coverartarchive' => 'Finna\Content\Covers\CoverArtArchive',
+                    'kirjavalitys' => 'Finna\Content\Covers\Kirjavalitys',
                 ],
             ],
             'recorddriver' => [

--- a/module/Finna/src/Finna/AjaxHandler/GetDescription.php
+++ b/module/Finna/src/Finna/AjaxHandler/GetDescription.php
@@ -5,7 +5,7 @@
  *
  * PHP version 8
  *
- * Copyright (C) The National Library of Finland 2015-2019.
+ * Copyright (C) The National Library of Finland 2015-2023.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,
@@ -30,9 +30,9 @@
 
 namespace Finna\AjaxHandler;
 
+use Finna\Content\Description\PluginManager as DescriptionPluginManager;
 use Laminas\Config\Config;
 use Laminas\Mvc\Controller\Plugin\Params;
-use Laminas\View\Renderer\RendererInterface;
 use VuFind\Cache\Manager as CacheManager;
 use VuFind\I18n\Translator\TranslatorAwareInterface;
 use VuFind\Record\Loader;
@@ -48,11 +48,10 @@ use VuFind\Session\Settings as SessionSettings;
  * @link     https://vufind.org/wiki/development Wiki
  */
 class GetDescription extends \VuFind\AjaxHandler\AbstractBase implements
-    TranslatorAwareInterface,
-    \VuFindHttp\HttpServiceAwareInterface
+    TranslatorAwareInterface
 {
+    use \VuFind\Config\Feature\ExplodeSettingTrait;
     use \VuFind\I18n\Translator\TranslatorAwareTrait;
-    use \VuFindHttp\HttpServiceAwareTrait;
 
     /**
      * Cache manager
@@ -76,33 +75,43 @@ class GetDescription extends \VuFind\AjaxHandler\AbstractBase implements
     protected $recordLoader;
 
     /**
-     * View renderer
+     * Data source configuration
      *
-     * @var RendererInterface
+     * @var Config
      */
-    protected $renderer;
+    protected $dataSourceConfig;
+
+    /**
+     * Description provider plugin manager
+     *
+     * @var DescriptionPluginManager
+     */
+    protected $descriptionPluginManager;
 
     /**
      * Constructor
      *
-     * @param SessionSettings   $ss       Session settings
-     * @param CacheManager      $cm       Cache manager
-     * @param Config            $config   Main configuration
-     * @param Loader            $loader   Record loader
-     * @param RendererInterface $renderer View renderer
+     * @param SessionSettings          $ss       Session settings (for disableSessionWrites)
+     * @param CacheManager             $cm       Cache manager
+     * @param Loader                   $loader   Record loader
+     * @param DescriptionPluginManager $dpm      Description provider plugin manager
+     * @param array                    $config   Main configuration
+     * @param array                    $dsConfig Data source configuration
      */
     public function __construct(
         SessionSettings $ss,
         CacheManager $cm,
-        Config $config,
         Loader $loader,
-        RendererInterface $renderer
+        DescriptionPluginManager $dpm,
+        array $config,
+        array $dsConfig
     ) {
         $this->sessionSettings = $ss;
         $this->cacheManager = $cm;
-        $this->config = $config;
         $this->recordLoader = $loader;
-        $this->renderer = $renderer;
+        $this->descriptionPluginManager = $dpm;
+        $this->config = $config;
+        $this->dataSourceConfig = $dsConfig;
     }
 
     /**
@@ -116,17 +125,13 @@ class GetDescription extends \VuFind\AjaxHandler\AbstractBase implements
     {
         $this->disableSessionWrites();  // avoid session write timing bug
 
-        $id = $params->fromPost('id', $params->fromQuery('id'));
-
-        if (!$id) {
+        if (!($id = $params->fromPost('id') ?? $params->fromQuery('id'))) {
             return $this->formatResponse('', self::STATUS_HTTP_BAD_REQUEST);
         }
+        $source = $params->fromPost('source') ?? $params->fromQuery('source') ?? 'Solr';
 
-        $cacheDir = $this->cacheManager->getCache('description')->getOptions()
-            ->getCacheDir();
-
+        $cacheDir = $this->cacheManager->getCache('description')->getOptions()->getCacheDir();
         $localFile = "$cacheDir/" . urlencode($id) . '.txt';
-
         $maxAge = $this->config->Content->summarycachetime ?? 1440;
 
         if (
@@ -134,71 +139,57 @@ class GetDescription extends \VuFind\AjaxHandler\AbstractBase implements
             && time() - filemtime($localFile) < $maxAge * 60
         ) {
             // Load local cache if available
-            if (($content = file_get_contents($localFile)) !== false) {
-                return $this->formatResponse(['html' => $content]);
+            if (($html = file_get_contents($localFile)) !== false) {
+                return $this->formatResponse(compact('html'));
             } else {
                 return $this->formatResponse('', self::STATUS_HTTP_ERROR);
             }
-        } else {
-            // Get URL
-            $driver = $this->recordLoader->load($id, 'Solr');
-            $url = $driver->getDescriptionURL();
-            // Get, manipulate, save and display content if available
-            if ($url) {
-                $result = $this->httpService->get($url, [], 60);
-                if ($result->isSuccess() && ($content = $result->getBody())) {
-                    if ($contentType = $result->getHeaders()->get('Content-Type')) {
-                        $encoding = strtoupper($contentType->getCharset());
-                    } else {
-                        $encoding = mb_detect_encoding(
-                            $content,
-                            ['UTF-8', 'ISO-8859-1']
-                        );
-                    }
-                    if ('UTF-8' !== $encoding) {
-                        $content = mb_convert_encoding($content, 'UTF-8', $encoding);
-                    }
-                    // Remove head tag, so no titles will be printed.
-                    $content = preg_replace(
-                        '/<head[^>]*>(.*?)<\/head>/si',
-                        '',
-                        $content
-                    );
+        }
 
-                    $content = preg_replace('/.*<.B>(.*)/', '\1', $content);
-                    $content = strip_tags($content, '<br><p>');
-
-                    // Trim leading and trailing whitespace
-                    $content = trim($content);
-
-                    // Replace line breaks with <br>
-                    $content = preg_replace(
-                        '/(\r\n|\n|\r){3,}/',
-                        '<br><br>',
-                        $content
-                    );
-
-                    file_put_contents($localFile, $content);
-
-                    return $this->formatResponse(['html' => $content]);
-                }
-            }
-            // For LIDO records the summary is displayed separately from description in the core template
-            if (!($driver instanceof \Finna\RecordDriver\SolrLido)) {
-                $language = $this->translator->getLocale();
-                if ($summary = $driver->getSummary($language)) {
-                    $summary = implode("\n\n", $summary);
-
-                    // Replace double hash with a <br>
-                    $summary = str_replace('##', "\n\n", $summary);
-
-                    // Process markdown
-                    $summary = $this->renderer->plugin('markdown')->toHtml($summary);
-
-                    return $this->formatResponse(['html' => $summary]);
-                }
+        // Try each description provider:
+        $driver = $this->recordLoader->load($id, $source);
+        $dataSourceId = strtok($id, '.');
+        $html = '';
+        foreach ($this->getProviders($dataSourceId) as $providerConfig) {
+            $provider = $this->descriptionPluginManager->get($providerConfig['id']);
+            if ($html = $provider->get($providerConfig['key'], $driver)) {
+                break;
             }
         }
-        return $this->formatResponse(['html' => '']);
+        file_put_contents($localFile, $html);
+        return $this->formatResponse(compact('html'));
+    }
+
+    /**
+     * Get a list of active description providers
+     *
+     * @param string $sourceId Record source ID
+     *
+     * @return array
+     */
+    protected function getProviders(string $sourceId): array
+    {
+        $providers = $this->explodeSetting($this->dataSourceConfig[$sourceId]['descriptions'] ?? '', true, ',');
+        $sharedProviders = $this->explodeSetting($this->config['Content']['descriptions'] ?? '', true, ',');
+
+        if ($providers) {
+            if (false !== ($offset = array_search('shared', $providers))) {
+                // Splice in the common providers:
+                array_splice($providers, $offset, 1, $sharedProviders);
+            }
+        } else {
+            $providers = $sharedProviders;
+        }
+
+        return array_map(
+            function ($s) {
+                $parts = explode(':', $s, 2);
+                return [
+                    'id' => $parts[0],
+                    'key' => $parts[1] ?? '',
+                ];
+            },
+            array_values(array_unique(array_filter($providers)))
+        );
     }
 }

--- a/module/Finna/src/Finna/Content/Description/AbstractDescriptionProvider.php
+++ b/module/Finna/src/Finna/Content/Description/AbstractDescriptionProvider.php
@@ -1,0 +1,89 @@
+<?php
+
+/**
+ * Abstract base class for description providers.
+ *
+ * PHP version 8
+ *
+ * Copyright (C) The National Library of Finland 2023.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * @category VuFind
+ * @package  Content
+ * @author   Ere Maijala <ere.maijala@helsinki.fi>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development Wiki
+ */
+
+namespace Finna\Content\Description;
+
+use Laminas\Http\Response;
+
+/**
+ * Abstract base class for description providers.
+ *
+ * @category VuFind
+ * @package  Content
+ * @author   Ere Maijala <ere.maijala@helsinki.fi>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development Wiki
+ */
+abstract class AbstractDescriptionProvider implements DescriptionProviderInterface
+{
+    /**
+     * Process a response
+     *
+     * @param Response $response HTTP response
+     *
+     * @return string Ready-to-display HTML or an empty string on error
+     */
+    protected function processResponse(Response $response): string
+    {
+        if (!($content = $response->getBody())) {
+            return '';
+        }
+        $contentType = $response->getHeaders()->get('Content-Type');
+        if ($contentType instanceof \Laminas\Http\Header\ContentType) {
+            $encoding = strtoupper($contentType->getCharset());
+        } else {
+            $encoding = mb_detect_encoding($content, ['UTF-8', 'ISO-8859-1']);
+        }
+        if ('UTF-8' !== $encoding) {
+            $content = mb_convert_encoding($content, 'UTF-8', $encoding);
+        }
+
+        // Remove head tag, so no titles will be printed.
+        $content = preg_replace(
+            '/<head[^>]*>(.*?)<\/head>/si',
+            '',
+            $content
+        );
+
+        $content = preg_replace('/.*<.B>(.*)/', '\1', $content);
+        $content = strip_tags($content, '<br><p>');
+
+        // Trim leading and trailing whitespace
+        $content = trim($content);
+
+        // Replace line breaks with <br>
+        $content = preg_replace(
+            '/(\r\n|\n|\r){3,}/',
+            '<br><br>',
+            $content
+        );
+
+        return trim($content);
+    }
+}

--- a/module/Finna/src/Finna/Content/Description/DescriptionProviderInterface.php
+++ b/module/Finna/src/Finna/Content/Description/DescriptionProviderInterface.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * Interface for description providers.
+ *
+ * PHP version 8
+ *
+ * Copyright (C) The National Library of Finland 2023.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * @category VuFind
+ * @package  Content
+ * @author   Ere Maijala <ere.maijala@helsinki.fi>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development Wiki
+ */
+
+namespace Finna\Content\Description;
+
+use VuFind\RecordDriver\DefaultRecord;
+
+/**
+ * Interface for description providers.
+ *
+ * @category VuFind
+ * @package  Content
+ * @author   Ere Maijala <ere.maijala@helsinki.fi>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development Wiki
+ */
+interface DescriptionProviderInterface
+{
+    /**
+     * Get description for a particular API key and record.
+     *
+     * @param string        $key    API key
+     * @param DefaultRecord $record Record driver
+     *
+     * @return string URL or empty string
+     */
+    public function get(string $key, DefaultRecord $record): string;
+}

--- a/module/Finna/src/Finna/Content/Description/Kirjavalitys.php
+++ b/module/Finna/src/Finna/Content/Description/Kirjavalitys.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * Kirjavälitys description provider.
+ *
+ * PHP version 8
+ *
+ * Copyright (C) The National Library of Finland 2023.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * @category VuFind
+ * @package  Content
+ * @author   Ere Maijala <ere.maijala@helsinki.fi>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development Wiki
+ */
+
+namespace Finna\Content\Description;
+
+use VuFind\RecordDriver\DefaultRecord;
+use VuFindHttp\HttpServiceAwareInterface;
+use VuFindHttp\HttpServiceAwareTrait;
+
+/**
+ * Kirjavälitys description provider.
+ *
+ * @category VuFind
+ * @package  Content
+ * @author   Ere Maijala <ere.maijala@helsinki.fi>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development Wiki
+ */
+class Kirjavalitys extends AbstractDescriptionProvider implements HttpServiceAwareInterface
+{
+    use HttpServiceAwareTrait;
+
+    /**
+     * Get description for a particular API key and record.
+     *
+     * @param string        $key    API key
+     * @param DefaultRecord $record Record driver
+     *
+     * @return string Ready-to-display HTML or an empty string on error
+     */
+    public function get(string $key, DefaultRecord $record): string
+    {
+        if (!($isbn = $record->getCleanISBN())) {
+            return '';
+        }
+        $url = 'https://media.kirjavalitys.fi/library/description/' . rawurlencode($key) . '/' . rawurlencode($isbn)
+            . '?format=html';
+        $response = $this->httpService->get($url, [], 60);
+        if (!$response->isSuccess()) {
+            return '';
+        }
+        return $this->processResponse($response);
+    }
+}

--- a/module/Finna/src/Finna/Content/Description/NatLibFi.php
+++ b/module/Finna/src/Finna/Content/Description/NatLibFi.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * National Library of Finland description provider.
+ *
+ * PHP version 8
+ *
+ * Copyright (C) The National Library of Finland 2023.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * @category VuFind
+ * @package  Content
+ * @author   Ere Maijala <ere.maijala@helsinki.fi>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development Wiki
+ */
+
+namespace Finna\Content\Description;
+
+use VuFind\RecordDriver\DefaultRecord;
+use VuFindHttp\HttpServiceAwareInterface;
+use VuFindHttp\HttpServiceAwareTrait;
+
+/**
+ * National Library of Finland description provider.
+ *
+ * @category VuFind
+ * @package  Content
+ * @author   Ere Maijala <ere.maijala@helsinki.fi>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development Wiki
+ */
+class NatLibFi extends AbstractDescriptionProvider implements HttpServiceAwareInterface
+{
+    use HttpServiceAwareTrait;
+
+    /**
+     * Get description URL for a particular API key and record.
+     *
+     * @param string        $key    API key
+     * @param DefaultRecord $record Record driver
+     *
+     * @return string Ready-to-display HTML or an empty string on error
+     */
+    public function get(string $key, DefaultRecord $record): string
+    {
+        if (!($isbn = $record->getCleanISBN())) {
+            return '';
+        }
+        $url = 'https://media.kirjavalitys.fi/library/description/' . rawurlencode($key) . '/' . urlencode($isbn)
+            . '?format=html';
+        $response = $this->httpService->get($url, [], 60);
+        if (!$response->isSuccess()) {
+            return '';
+        }
+        return $this->processResponse($response);
+    }
+}

--- a/module/Finna/src/Finna/Content/Description/PluginManager.php
+++ b/module/Finna/src/Finna/Content/Description/PluginManager.php
@@ -1,0 +1,79 @@
+<?php
+
+/**
+ * Description provider plugin manager
+ *
+ * PHP version 8
+ *
+ * Copyright (C) The National Library of Finland 2023.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * @category VuFind
+ * @package  Content
+ * @author   Ere Maijala <ere.maijala@helsinki.fi>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development:plugins:hierarchy_components Wiki
+ */
+
+namespace Finna\Content\Description;
+
+use Laminas\ServiceManager\Factory\InvokableFactory;
+
+/**
+ * Copyright (C) The National Library of Finland 2023.
+ *
+ * @category VuFind
+ * @package  Content
+ * @author   Ere Maijala <ere.maijala@helsinki.fi>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development:plugins:hierarchy_components Wiki
+ */
+class PluginManager extends \VuFind\ServiceManager\AbstractPluginManager
+{
+    /**
+     * Default plugin aliases.
+     *
+     * @var array
+     */
+    protected $aliases = [
+        'Kirjavalitys' => Kirjavalitys::class,
+        'NatLibFi' => NatLibFi::class,
+        'Record' => Record::class,
+        'RecordUrl' => RecordUrl::class,
+    ];
+
+    /**
+     * Default plugin factories.
+     *
+     * @var array
+     */
+    protected $factories = [
+        Kirjavalitys::class => InvokableFactory::class,
+        NatLibFi::class => InvokableFactory::class,
+        Record::class => RecordFactory::class,
+        RecordUrl::class => InvokableFactory::class,
+    ];
+
+    /**
+     * Return the name of the base class or interface that plug-ins must conform
+     * to.
+     *
+     * @return string
+     */
+    protected function getExpectedInterface()
+    {
+        return DescriptionProviderInterface::class;
+    }
+}

--- a/module/Finna/src/Finna/Content/Description/PluginManager.php
+++ b/module/Finna/src/Finna/Content/Description/PluginManager.php
@@ -32,7 +32,7 @@ namespace Finna\Content\Description;
 use Laminas\ServiceManager\Factory\InvokableFactory;
 
 /**
- * Copyright (C) The National Library of Finland 2023.
+ * Description provider plugin manager
  *
  * @category VuFind
  * @package  Content

--- a/module/Finna/src/Finna/Content/Description/Record.php
+++ b/module/Finna/src/Finna/Content/Description/Record.php
@@ -1,0 +1,94 @@
+<?php
+
+/**
+ * Record description provider.
+ *
+ * PHP version 8
+ *
+ * Copyright (C) The National Library of Finland 2023.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * @category VuFind
+ * @package  Content
+ * @author   Ere Maijala <ere.maijala@helsinki.fi>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development Wiki
+ */
+
+namespace Finna\Content\Description;
+
+use Laminas\View\Renderer\RendererInterface;
+use VuFind\I18n\Translator\TranslatorAwareInterface;
+use VuFind\RecordDriver\DefaultRecord;
+
+/**
+ * Record description provider.
+ *
+ * @category VuFind
+ * @package  Content
+ * @author   Ere Maijala <ere.maijala@helsinki.fi>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development Wiki
+ */
+class Record extends AbstractDescriptionProvider implements TranslatorAwareInterface
+{
+    use \VuFind\I18n\Translator\TranslatorAwareTrait;
+
+    /**
+     * View renderer
+     *
+     * @var RendererInterface
+     */
+    protected $renderer;
+
+    /**
+     * Constructor
+     *
+     * @param RendererInterface $renderer View renderer
+     */
+    public function __construct(RendererInterface $renderer)
+    {
+        $this->renderer = $renderer;
+    }
+
+    /**
+     * Get description for a particular API key and record.
+     *
+     * @param string        $key    API key
+     * @param DefaultRecord $record Record driver
+     *
+     * @return string Ready-to-display HTML or an empty string on error
+     */
+    public function get(string $key, DefaultRecord $record): string
+    {
+        // For LIDO records the summary is displayed separately from description in the core template
+        if ($record instanceof \Finna\RecordDriver\SolrLido) {
+            return '';
+        }
+        $language = $this->translator->getLocale();
+        if (!($summary = $record->getSummary($language))) {
+            return '';
+        }
+        $summary = implode("\n\n", $summary);
+
+        // Replace double hash with a <br>
+        $summary = str_replace('##', "\n\n", $summary);
+
+        // Process markdown
+        $summary = $this->renderer->plugin('markdown')->toHtml($summary);
+
+        return $summary;
+    }
+}

--- a/module/Finna/src/Finna/Content/Description/RecordFactory.php
+++ b/module/Finna/src/Finna/Content/Description/RecordFactory.php
@@ -1,11 +1,11 @@
 <?php
 
 /**
- * Factory for GetDescription AJAX handler.
+ * Factory for Record description provider.
  *
  * PHP version 8
  *
- * Copyright (C) The National Library of Finland 2018-2019.
+ * Copyright (C) The National Library of Finland 2023.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,
@@ -21,13 +21,13 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  *
  * @category VuFind
- * @package  AJAX
+ * @package  Service
  * @author   Ere Maijala <ere.maijala@helsinki.fi>
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
- * @link     https://vufind.org/wiki/development Wiki
+ * @link     http://vufind.org/wiki/vufind2:developer_manual Wiki
  */
 
-namespace Finna\AjaxHandler;
+namespace Finna\Content\Description;
 
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
@@ -35,15 +35,15 @@ use Psr\Container\ContainerExceptionInterface as ContainerException;
 use Psr\Container\ContainerInterface;
 
 /**
- * Factory for GetDescription AJAX handler.
+ * Factory for Record description provider.
  *
  * @category VuFind
- * @package  AJAX
+ * @package  Service
  * @author   Ere Maijala <ere.maijala@helsinki.fi>
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
- * @link     https://vufind.org/wiki/development Wiki
+ * @link     http://vufind.org/wiki/vufind2:developer_manual Wiki
  */
-class GetDescriptionFactory implements \Laminas\ServiceManager\Factory\FactoryInterface
+class RecordFactory implements \Laminas\ServiceManager\Factory\FactoryInterface
 {
     /**
      * Create an object
@@ -69,15 +69,6 @@ class GetDescriptionFactory implements \Laminas\ServiceManager\Factory\FactoryIn
         if (!empty($options)) {
             throw new \Exception('Unexpected options passed to factory.');
         }
-        $config = $container->get(\VuFind\Config\PluginManager::class);
-        $result = new $requestedName(
-            $container->get(\VuFind\Session\Settings::class),
-            $container->get(\VuFind\Cache\Manager::class),
-            $container->get(\VuFind\Record\Loader::class),
-            $container->get(\Finna\Content\Description\PluginManager::class),
-            $config->get('config')->toArray(),
-            $config->get('datasources')->toArray()
-        );
-        return $result;
+        return new $requestedName($container->get('ViewRenderer'));
     }
 }

--- a/module/Finna/src/Finna/Content/Description/RecordUrl.php
+++ b/module/Finna/src/Finna/Content/Description/RecordUrl.php
@@ -1,0 +1,68 @@
+<?php
+
+/**
+ * Record URL description provider.
+ *
+ * PHP version 8
+ *
+ * Copyright (C) The National Library of Finland 2023.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * @category VuFind
+ * @package  Content
+ * @author   Ere Maijala <ere.maijala@helsinki.fi>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development Wiki
+ */
+
+namespace Finna\Content\Description;
+
+use VuFind\RecordDriver\DefaultRecord;
+use VuFindHttp\HttpServiceAwareInterface;
+use VuFindHttp\HttpServiceAwareTrait;
+
+/**
+ * Record URL description provider.
+ *
+ * @category VuFind
+ * @package  Content
+ * @author   Ere Maijala <ere.maijala@helsinki.fi>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development Wiki
+ */
+class RecordUrl extends AbstractDescriptionProvider implements HttpServiceAwareInterface
+{
+    use HttpServiceAwareTrait;
+
+    /**
+     * Get description URL for a particular API key and record.
+     *
+     * @param string        $key    API key
+     * @param DefaultRecord $record Record driver
+     *
+     * @return string Ready-to-display HTML or an empty string on error
+     */
+    public function get(string $key, DefaultRecord $record): string
+    {
+        if (!($url = $record->tryMethod('getDescriptionURL') ?: '')) {
+            return '';
+        }
+        $response = $this->httpService->get($url, [], 60);
+        if (!$response->isSuccess()) {
+            return '';
+        }
+        return $this->processResponse($response);
+    }
+}

--- a/module/Finna/src/Finna/RecordDriver/SolrLido.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrLido.php
@@ -647,20 +647,6 @@ class SolrLido extends \VuFind\RecordDriver\SolrDefault implements \Laminas\Log\
     }
 
     /**
-     * Return an external URL where a displayable description text
-     * can be retrieved from, if available; false otherwise.
-     *
-     * @return mixed
-     */
-    public function getDescriptionURL()
-    {
-        if ($isbn = $this->getCleanISBN()) {
-            return 'https://kansikuvat.finna.fi/getText.php?query=' . $isbn;
-        }
-        return false;
-    }
-
-    /**
      * Return description as associative array
      * - type Type of the description and text as the value
      *

--- a/module/Finna/src/Finna/RecordDriver/SolrMarc.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrMarc.php
@@ -478,9 +478,6 @@ class SolrMarc extends \VuFind\RecordDriver\SolrMarc implements \Laminas\Log\Log
             }
         }
 
-        if ($isbn = $this->getCleanISBN()) {
-            return 'https://kansikuvat.finna.fi/getText.php?query=' . $isbn;
-        }
         return false;
     }
 

--- a/module/Finna/src/Finna/RecordDriver/SolrQdc.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrQdc.php
@@ -416,20 +416,6 @@ class SolrQdc extends \VuFind\RecordDriver\SolrDefault implements \Laminas\Log\L
     }
 
     /**
-     * Return an external URL where a displayable description text
-     * can be retrieved from, if available; false otherwise.
-     *
-     * @return mixed
-     */
-    public function getDescriptionURL()
-    {
-        if ($isbn = $this->getCleanISBN()) {
-            return 'https://kansikuvat.finna.fi/getText.php?query=' . $isbn;
-        }
-        return false;
-    }
-
-    /**
      * Return education programs
      *
      * @return array

--- a/themes/finna2/js/finna-record.js
+++ b/themes/finna2/js/finna-record.js
@@ -5,8 +5,11 @@ finna.record = (function finnaRecord() {
   function initDescription() {
     var description = $('#description_text');
     if (description.length) {
-      var id = description.data('id');
-      var url = VuFind.path + '/AJAX/JSON?method=getDescription&id=' + id;
+      let params = new URLSearchParams({
+        id: description.data('id'),
+        source: description.data('source')
+      });
+      var url = VuFind.path + '/AJAX/JSON?method=getDescription&' + params;
       $.getJSON(url)
         .done(function onGetDescriptionDone(response) {
           if (response.data.html.length > 0) {

--- a/themes/finna2/templates/RecordDriver/DefaultRecord/core.phtml
+++ b/themes/finna2/templates/RecordDriver/DefaultRecord/core.phtml
@@ -259,7 +259,7 @@
     </div> <?php // record-core-metadata ?>
 
     <div class="description recordSummary">
-      <span id="description_text" data-id="<?=$this->escapeHtmlAttr($this->driver->getUniqueID())?>">
+      <span id="description_text" data-id="<?=$this->escapeHtmlAttr($this->driver->getUniqueID())?>" data-source="<?=$this->escapeHtmlAttr($this->driver->getSourceIdentifier())?>">
         <?=$this->icon('spinner') ?>
       </span>
     </div>

--- a/themes/finna2/templates/RecordDriver/SolrLido/core.phtml
+++ b/themes/finna2/templates/RecordDriver/SolrLido/core.phtml
@@ -106,7 +106,7 @@
 
       <div class="summary-wrapper">
         <div class="description recordSummary">
-        <span id="description_text" data-id="<?=$this->escapeHtmlAttr($this->driver->getUniqueID())?>">
+        <span id="description_text" data-id="<?=$this->escapeHtmlAttr($this->driver->getUniqueID())?>" data-source="<?=$this->escapeHtmlAttr($this->driver->getSourceIdentifier())?>">
           <?=$this->icon('spinner') ?>
         </span>
         </div>


### PR DESCRIPTION
Description loading has been refactored to proper providers. The configuration now allows one to choose the preferred service order and inject shared services with the desired priority. Kirjavalitys provider is meant to be enabled via datasources.ini only.