### PR TITLE
[FINNA-1446] Add pills navigation style to rss feed tabs.

### DIFF
--- a/module/Finna/src/Finna/View/Helper/Root/FeedTabs.php
+++ b/module/Finna/src/Finna/View/Helper/Root/FeedTabs.php
@@ -51,6 +51,8 @@ class FeedTabs extends \Laminas\View\Helper\AbstractHelper
     {
         $title = $feedIds['title'] ?? '';
         $ids = $feedIds['ids'];
+        $navStyle = $feedIds['navStyle'] ?? '';
+        $showMobileAccordion = $feedIds['showMobileAccordion'] ?? true;
         return $this->getView()->render(
             'Helpers/feedtabs.phtml',
             [
@@ -58,6 +60,8 @@ class FeedTabs extends \Laminas\View\Helper\AbstractHelper
                 'id' => md5(json_encode($ids)),
                 'feedIds' => $ids,
                 'active' => array_shift($ids),
+                'navStyle' => $navStyle,
+                'showMobileAccordion' => $showMobileAccordion,
             ]
         );
     }

--- a/themes/finna2/js/finna-linked-events.js
+++ b/themes/finna2/js/finna-linked-events.js
@@ -3,8 +3,8 @@ finna.linkedEvents = (function finnaLinkedEvents() {
   function getEvents(params, callback, append, container) {
     var limit = {'page_size': container.data('limit')};
     var lang = {};
-    if ($('.linked-events-tabs-container').data('lang')) {
-      lang = {'language': $('.linked-events-tabs-container').data('lang')};
+    if ($('.linked-events-tabs').data('lang')) {
+      lang = {'language': $('.linked-events-tabs').data('lang')};
     } else if ($('.linked-event-content').data('lang')) {
       lang = {'language': $('.linked-event-content').data('lang')};
     }
@@ -214,7 +214,7 @@ finna.linkedEvents = (function finnaLinkedEvents() {
   }
 
   function initEventsTabs(id) {
-    var container = $('.linked-events-tabs-container[id="' + id + '"]');
+    var container = $('.linked-events-tabs[id="' + id + '"]');
     var initial = container.find($('li.nav-item.event-tab.active'));
     var initialParams = {};
     initialParams.query = initial.data('params');

--- a/themes/finna2/less/finna/accordion.less
+++ b/themes/finna2/less/finna/accordion.less
@@ -90,8 +90,8 @@
     }
   }
 }
-// RSS-feed accordions
 
+// RSS-feed accordions
 .feed-accordions {
   .tab-content {
     margin-bottom: 0;
@@ -162,6 +162,25 @@
           margin: 10px 0;
         }
       }
+    }
+  }
+}
+
+// Show or hide feed tabs mobile accordion
+.feed-tabs.mobile-accordion-hide, .linked-events-tabs.mobile-accordion-hide {
+  .feed-accordions-title, .accordion {
+      display: none;
+  }
+  .events-tabs {
+      @media (max-width: @screen-sm-max) {
+          margin-bottom: 0;
+      }
+  }
+}
+.feed-tabs.mobile-accordion-show, .linked-events-tabs.mobile-accordion-show {
+  .feed-tabs-container {
+    @media (max-width: @screen-sm-max) {
+      display: none;
     }
   }
 }

--- a/themes/finna2/less/finna/feed.less
+++ b/themes/finna2/less/finna/feed.less
@@ -377,21 +377,6 @@
         }
     }
 }
-.mobile-accordion-hide {
-    .feed-accordions-title, .accordion {
-        display: none;
-    }
-    .events-tabs {
-        @media (max-width: @screen-sm-max) {
-            margin-bottom: 0;
-        }
-    }
-}
-.mobile-accordion-show .events-tabs {
-    @media (max-width: @screen-sm-max) {
-        display: none;
-    }
-}
 .event-accordions .tab-content {
     // Relative positioning for the absolutely positioned spinner:
     position: relative;

--- a/themes/finna2/less/finna/tabs.less
+++ b/themes/finna2/less/finna/tabs.less
@@ -131,8 +131,8 @@
   }
 }
 
-// RSS-feed tabs
-.feed-tabs .nav-tabs {
+// RSS-feed and Linked Events tabs
+.feed-tabs .nav-tabs, .linked-events-tabs .nav-tabs {
   border-bottom: 1px solid @nav-tabs-border-color;
   margin-left: 6px;
   > li {

--- a/themes/finna2/templates/Helpers/feedtabs.phtml
+++ b/themes/finna2/templates/Helpers/feedtabs.phtml
@@ -1,12 +1,8 @@
 <!-- START of: finna - Helpers/feedtabs.phtml -->
-<div class="feed-tabs" id="feed-tabs-<?=$this->escapeHtmlAttr($this->id)?>">
-  <?php if (count($this->feedIds) > 3): ?>
-    <div class="tabs-responsive">
-  <?php endif; ?>
-  <div class="visible-md visible-lg">
+<div class="feed-tabs <?= $showMobileAccordion ? 'mobile-accordion-show' : 'mobile-accordion-hide'; ?>"" id="feed-tabs-<?=$this->escapeHtmlAttr($this->id)?>">
     <div class="feed-tabs-container">
       <h2 class="feed-tabs-title"><?= $this->transEsc($this->title);?></h2>
-      <ul class="nav nav-tabs" role="tablist">
+      <ul class="nav <?= !empty($navStyle) ? 'feed-nav-' . $this->escapeHtmlAttr($this->navStyle) : 'nav-tabs' ?>" role="tablist">
       <?php $tabNames = []; ?>
       <?php $id = 0; ?>
       <?php foreach ($this->feedIds as $desc => $feed): ?>
@@ -24,11 +20,6 @@
         <?php endforeach; ?>
       </ul>
     </div>
-  </div>
-  <?php if (count($this->feedIds) > 3): ?>
-    </div>
-  <?php endif; ?>
-
   <div class="feed-accordions" role="tablist">
     <h2 class="feed-accordions-title"><?= $this->transEsc($this->title); ?></h2>
     <?php $i = 0;

--- a/themes/finna2/templates/Helpers/feedtabs.phtml
+++ b/themes/finna2/templates/Helpers/feedtabs.phtml
@@ -1,5 +1,5 @@
 <!-- START of: finna - Helpers/feedtabs.phtml -->
-<div class="feed-tabs <?= $showMobileAccordion ? 'mobile-accordion-show' : 'mobile-accordion-hide'; ?>"" id="feed-tabs-<?=$this->escapeHtmlAttr($this->id)?>">
+<div class="feed-tabs <?= $showMobileAccordion ? 'mobile-accordion-show' : 'mobile-accordion-hide'; ?>" id="feed-tabs-<?=$this->escapeHtmlAttr($this->id)?>">
     <div class="feed-tabs-container">
       <h2 class="feed-tabs-title"><?= $this->transEsc($this->title);?></h2>
       <ul class="nav <?= !empty($navStyle) ? 'feed-nav-' . $this->escapeHtmlAttr($this->navStyle) : 'nav-tabs' ?>" role="tablist">

--- a/themes/finna2/templates/Helpers/linkedeventstabs.phtml
+++ b/themes/finna2/templates/Helpers/linkedeventstabs.phtml
@@ -1,8 +1,8 @@
 <!-- START of: finna - Helpers/linkedeventstabs.phtml -->
-<div class="linked-events-tabs-container <?= $showMobileAccordion ? 'mobile-accordion-show' : 'mobile-accordion-hide'; ?>" id="<?= $this->escapeHtmlAttr($this->id) ?>" data-limit="<?= $this->escapeHtmlAttr($this->limit) ?>" data-lang="<?= $this->layout()->userLang; ?>">
-  <div class="events-tabs feed-tabs-container feed-tabs">
+<div class="linked-events-tabs <?= $showMobileAccordion ? 'mobile-accordion-show' : 'mobile-accordion-hide'; ?>" id="<?= $this->escapeHtmlAttr($this->id) ?>" data-limit="<?= $this->escapeHtmlAttr($this->limit) ?>" data-lang="<?= $this->layout()->userLang; ?>">
+  <div class="feed-tabs-container">
     <h2 class="feed-tabs-title"><?= $this->transEsc('Events'); ?></h2>
-    <ul class="nav  <?= !empty($navStyle) ? 'feed-nav-' . $this->escapeHtmlAttr($this->navStyle) : 'nav-tabs' ?>" role="tablist">
+    <ul class="nav <?= !empty($navStyle) ? 'feed-nav-' . $this->escapeHtmlAttr($this->navStyle) : 'nav-tabs' ?>" role="tablist">
       <?php $i = 0;
       foreach ($this->tabs as $id => $tab): ?>
         <?php


### PR DESCRIPTION
Toimii vastaavasti kuin Linked Eventsin pills-tyyli. Jouduin hieman yhtenäistämään Linked Events tabin ja RSS feed tabin rakennetta. Poistin myös tabs-responsive RSS feedin rakenteesta, kun se tuntui vähän turhalta säädöltä.

Upotus:
<?=$this->feedTabs(['title' => 'Otsikko', 'ids' => ['Tapahtumat' => 'news', 'Muuta' => 'carousel-small' ], 'navStyle' => 'pills',   'showMobileAccordion' => false,])?> 