### PR TITLE
[FINNA-2055] Improve the usability of the search results page for screen readers.

### DIFF
--- a/themes/finna2/js/finna-common.js
+++ b/themes/finna2/js/finna-common.js
@@ -61,6 +61,17 @@ finna.common = (function finnaCommon() {
    * Add event handlers for managing JS-loaded search results
    */
   function initResultsEventHandler() {
+    VuFind.listen('vf-results-load', () => {
+      setTimeout(
+        function focusHeading() {
+          const heading = document.getElementById("results-heading");
+          if (heading) {
+            heading.focus();
+          }
+        },
+        200
+      );
+    });
     VuFind.listen('vf-results-loaded', () => {
       initResultScripts(document.querySelector('.js-result-list'), false);
     });

--- a/themes/finna2/js/finna-layout.js
+++ b/themes/finna2/js/finna-layout.js
@@ -465,8 +465,9 @@ finna.layout = (function finnaLayout() {
 
   function initResultsLoadFocus () {
     VuFind.listen('vf-results-load', () => {
-      if (document.getElementById("results-heading")) {
-        document.getElementById("results-heading").focus();
+      const heading = document.getElementById("results-heading");
+      if (heading) {
+        heading.focus();
       }
     });
   }

--- a/themes/finna2/js/finna-layout.js
+++ b/themes/finna2/js/finna-layout.js
@@ -463,6 +463,14 @@ finna.layout = (function finnaLayout() {
     }
   }
 
+  function initResultsLoadFocus () {
+    VuFind.listen('vf-results-load', () => {
+      if (document.getElementById("results-heading")) {
+          document.getElementById("results-heading").focus();
+      }
+    });
+  }
+
   function initLightboxLogin() {
     if (!document.addEventListener) {
       return;
@@ -797,6 +805,7 @@ finna.layout = (function finnaLayout() {
     init: function init() {
       initResizeListener();
       initScrollRecord();
+      initResultsLoadFocus(),
       initJumpMenus();
       initAnchorNavigationLinks();
       initTruncate();

--- a/themes/finna2/js/finna-layout.js
+++ b/themes/finna2/js/finna-layout.js
@@ -463,15 +463,6 @@ finna.layout = (function finnaLayout() {
     }
   }
 
-  function initResultsLoadFocus () {
-    VuFind.listen('vf-results-load', () => {
-      const heading = document.getElementById("results-heading");
-      if (heading) {
-        heading.focus();
-      }
-    });
-  }
-
   function initLightboxLogin() {
     if (!document.addEventListener) {
       return;
@@ -806,7 +797,6 @@ finna.layout = (function finnaLayout() {
     init: function init() {
       initResizeListener();
       initScrollRecord();
-      initResultsLoadFocus();
       initJumpMenus();
       initAnchorNavigationLinks();
       initTruncate();

--- a/themes/finna2/js/finna-layout.js
+++ b/themes/finna2/js/finna-layout.js
@@ -466,7 +466,7 @@ finna.layout = (function finnaLayout() {
   function initResultsLoadFocus () {
     VuFind.listen('vf-results-load', () => {
       if (document.getElementById("results-heading")) {
-          document.getElementById("results-heading").focus();
+        document.getElementById("results-heading").focus();
       }
     });
   }
@@ -805,7 +805,7 @@ finna.layout = (function finnaLayout() {
     init: function init() {
       initResizeListener();
       initScrollRecord();
-      initResultsLoadFocus(),
+      initResultsLoadFocus();
       initJumpMenus();
       initAnchorNavigationLinks();
       initTruncate();

--- a/themes/finna2/templates/search/pagination.phtml
+++ b/themes/finna2/templates/search/pagination.phtml
@@ -29,7 +29,7 @@
                 'current' => $this->current,
                 'page' => $this->next,
                 'liClasses' => ['sr-only'],
-                'contentHtml' => '<h2>'. $this->transEsc('Seuraava sivu') .'</h2>',
+                'contentHtml' => '<h2>' . $this->translate('page_next') . '</h2>',
             ]
           )
         ?>

--- a/themes/finna2/templates/search/pagination.phtml
+++ b/themes/finna2/templates/search/pagination.phtml
@@ -20,6 +20,20 @@
       }
     ?>
     <ul<?=$ulAttrs?>>
+    <?php if (isset($this->next)): ?>
+        <?=
+          $this->render(
+              'Helpers/pagination-item.phtml',
+              [
+                'results' => $this->results,
+                'current' => $this->current,
+                'page' => $this->next,
+                'liClasses' => ['sr-only'],
+                'contentHtml' => '<h2>'. $this->transEsc('Seuraava sivu') .'</h2>',
+            ]
+          )
+        ?>
+      <?php endif; ?>
       <?php if (isset($this->previous)): ?>
         <?php if ($showFirstLast): ?>
           <?=

--- a/themes/finna2/templates/search/results.phtml
+++ b/themes/finna2/templates/search/results.phtml
@@ -110,7 +110,7 @@
   $recommendations = $this->results->getRecommendations('side');
 ?>
 
-<h1 class="sr-only"><?= $this->transEsc('Search Results'); ?></h1>
+<h1 tabindex="-1" id="results-heading" class="sr-only"><?= $this->transEsc('Search Results'); ?></h1>
 <?php if ($recordTotal > 0): ?>
   <div class="finna-search-filter-toggle-trigger visible-xs hidden-print"></div>
   <div class="finna-search-filter-toggle visible-xs hidden-print">
@@ -254,6 +254,14 @@
       <?=$this->context($this)->renderInContext('search/bulk-action-buttons.phtml', ['idPrefix' => 'bottom_', 'formAttr' => 'search-cart-form'])?>
     </div>
     <?php endif; ?>
+    <?php $pagination = $this->paginationControl($this->results->getPaginator()->setPageRange(5), 'Sliding', 'search/pagination.phtml', ['results' => $this->results]);
+      if (trim($pagination)): ?>
+      <div class="pagination">
+        <div class="<?=$this->layoutClass('mainbody', (bool)$recommendations)?> text-center">
+          <?=$pagination ?>
+        </div>
+      </div>
+    <?php endif; ?>
   </div>
   <?php /* End Main Listing */ ?>
 
@@ -282,16 +290,6 @@
 </div>
 <?php // Close the container div opened in layout: ?>
 </div>
-<?php $pagination = $this->paginationControl($this->results->getPaginator()->setPageRange(5), 'Sliding', 'search/pagination.phtml', ['results' => $this->results]);
-if (trim($pagination)): ?>
-<div class="container-fluid pagination-background">
-  <div class="container">
-    <div class="<?=$this->layoutClass('mainbody', (bool)$recommendations)?> text-center">
-      <?=$pagination ?>
-    </div>
-  </div>
-</div>
-<?php endif; ?>
 <?php if (!$browse): ?>
 <div class="container-fluid searchtools-background">
   <div class="container">


### PR DESCRIPTION
Siiretty hakutulosten sivutus alkamaan heti hakutulosten jälkeen sekä seuraava sivu näkyvämmäksi ruudunlukijoille (otsikoksi). Lisäksi selaimen fokus siiretty hakutulokset otsikkoon hakutulosten latauksen yhteydessä.
