### PR TITLE
[FINNA-2279] Exclude large-image-layout rules from record-accordions

### DIFF
--- a/themes/finna2/less/finna/record.less
+++ b/themes/finna2/less/finna/record.less
@@ -142,20 +142,22 @@ a.authority {
 
 .authoritybox,
 .large-image-layout.record {
-  .media-left,
-  .media-right {
-    @media (min-width: @screen-sm) {
-      width: 50%;
-    }
-    .record-image-container {
-      .open-link {
-        margin-top: 10px;
+  :not('.record-accordions') {
+    .media-left,
+    .media-right {
+      @media (min-width: @screen-sm) {
+        width: 50%;
       }
-      .open-link, .model-link {
-        i, b {
-          color: tint(@action-link-color, 22%);
-          margin-right: 0;
-          font-style: normal;
+      .record-image-container {
+        .open-link {
+          margin-top: 10px;
+        }
+        .open-link, .model-link {
+          i, b {
+            color: tint(@action-link-color, 22%);
+            margin-right: 0;
+            font-style: normal;
+          }
         }
       }
     }

--- a/themes/finna2/less/finna/record.less
+++ b/themes/finna2/less/finna/record.less
@@ -141,12 +141,15 @@ a.authority {
 }
 
 .authoritybox,
-.large-image-layout.record {
-  :not('.record-accordions') {
-    .media-left,
-    .media-right {
-      @media (min-width: @screen-sm) {
-        width: 50%;
+.large-image-layout.record .record-main > :not(.record-tabs) {
+  .media-left,
+  .media-right {
+    @media (min-width: @screen-sm) {
+      width: 50%;
+    }
+    .record-image-container {
+      .open-link {
+        margin-top: 10px;
       }
       .record-image-container {
         .open-link {

--- a/themes/finna2/less/finna/record.less
+++ b/themes/finna2/less/finna/record.less
@@ -141,7 +141,7 @@ a.authority {
 }
 
 .authoritybox,
-.large-image-layout.record .record-main > :not(.record-tabs) {
+.large-image-layout.record .record-main > .media {
   .media-left,
   .media-right {
     @media (min-width: @screen-sm) {


### PR DESCRIPTION
Other versions tab images looks pretty bonkers now: Record/ham.2B534BB442C44A1D964357F8581850EB?sid=4716189690&imgid=1#versions