### PR TITLE
[FINNA-2675] Load encapsulated records without source limit

### DIFF
--- a/module/Finna/src/Finna/Record/Loader.php
+++ b/module/Finna/src/Finna/Record/Loader.php
@@ -215,7 +215,8 @@ class Loader extends \VuFind\Record\Loader
         $records = parent::loadBatchForSource(
             $ids,
             $source,
-            $tolerateBackendExceptions
+            $tolerateBackendExceptions,
+            $params
         );
 
         // Check the results for missing records and try to load them with their old IDs:

--- a/module/Finna/src/Finna/Record/Loader.php
+++ b/module/Finna/src/Finna/Record/Loader.php
@@ -182,6 +182,41 @@ class Loader extends \VuFind\Record\Loader
     }
 
     /**
+     * Given an array of associative arrays with id and source keys (or pipe-
+     * separated source|id strings), load all of the requested records in the
+     * requested order.
+     *
+     * Finna: Ignores 'sources' setting in search configuration.
+     *
+     * @param array      $ids                       Array of associative arrays with
+     * id/source keys or strings in source|id format. In associative array formats,
+     * there is also an optional "extra_fields" key which can be used to pass in data
+     * formatted as if it belongs to the Solr schema; this is used to create
+     * a mock driver object if the real data source is unavailable.
+     * @param bool       $tolerateBackendExceptions Whether to tolerate backend
+     * exceptions that may be caused by e.g. connection issues or changes in
+     * subscriptions
+     * @param ParamBag[] $params                    Associative array of search
+     * backend parameters keyed with source key
+     *
+     * @throws \Exception
+     * @return array     Array of record drivers
+     */
+    public function loadBatchIgnoringSourceFilter(
+        $ids,
+        $tolerateBackendExceptions = false,
+        $params = []
+    ) {
+        foreach (array_unique(array_column($ids, 'source')) as $source) {
+            if (!isset($params[$source])) {
+                $params[$source] = new ParamBag();
+            }
+            $params[$source]->set('finna.ignore_source_filter', 1);
+        }
+        return $this->loadBatch($ids, $tolerateBackendExceptions, $params);
+    }
+
+    /**
      * Given an array of IDs and a record source, load a batch of records for
      * that source.
      *

--- a/module/Finna/src/Finna/RecordDriver/Feature/ContainerFormatTrait.php
+++ b/module/Finna/src/Finna/RecordDriver/Feature/ContainerFormatTrait.php
@@ -347,7 +347,6 @@ trait ContainerFormatTrait
     {
         $neededMap = [];
         $ids = [];
-        $params = [];
         foreach ($records as $i => $record) {
             if (
                 $record instanceof EncapsulatedRecordInterface
@@ -356,13 +355,10 @@ trait ContainerFormatTrait
                 $source = $needed['source'];
                 $neededMap[$source][$needed['id']] = $i;
                 $ids[] = $needed;
-                if (!isset($params[$source])) {
-                    $params[$source] = new ParamBag(['finna.ignore_source_filter' => 1]);
-                }
             }
         }
         if (!empty($ids)) {
-            $loadedRecords = $this->recordLoader->loadBatch($ids, params: $params);
+            $loadedRecords = $this->recordLoader->loadBatchIgnoringSourceFilter($ids);
             foreach ($loadedRecords as $loadedRecord) {
                 $loadedSource = $loadedRecord->getSourceIdentifier();
                 $loadedId = $loadedRecord->getUniqueID();

--- a/module/Finna/src/Finna/Search/Solr/SolrExtensionsListener.php
+++ b/module/Finna/src/Finna/Search/Solr/SolrExtensionsListener.php
@@ -194,18 +194,15 @@ class SolrExtensionsListener
     {
         $command = $event->getParam('command');
         $params = $command->getSearchParameters();
-        if ($recordSources = $this->getActiveSources($event)) {
-            // Don't add the filter if we're retrieving a batch of records and requested so (e.g. AIPA encapsulated
-            // records):
-            $context = $command->getContext();
-            if (
-                'retrieve' !== $context
-                && ('retrieveBatch' !== $context || !$params->get('finna.ignore_source_filter'))
-            ) {
-                $params->add('fq', static::TERMS_FILTER_PREFIX_SOURCE . implode("\u{001f}", $recordSources));
-            }
+        // Don't add the filter if requested so (e.g. AIPA encapsulated records) or we're fetching a single record (to
+        // be able to link to encapsulated records):
+        if ($params->get('finna.ignore_source_filter') || $command->getContext() === 'retrieve') {
+            $params->remove('finna.ignore_source_filter');
+            return;
         }
-        $params->remove('finna.ignore_source_filter');
+        if ($recordSources = $this->getActiveSources($event)) {
+            $params->add('fq', static::TERMS_FILTER_PREFIX_SOURCE . implode("\u{001f}", $recordSources));
+        }
     }
 
     /**

--- a/module/Finna/src/Finna/View/Helper/Root/RecordFactory.php
+++ b/module/Finna/src/Finna/View/Helper/Root/RecordFactory.php
@@ -82,9 +82,9 @@ class RecordFactory implements FactoryInterface
             $container->get(\VuFind\Form\Form::class),
             $container->get(\Finna\Service\UserPreferenceService::class),
             function ($options) use ($container) {
-                $result = clone $container
+                $result = $container
                     ->get(\VuFind\Search\Results\PluginManager::class)
-                    ->get('EncapsulatedRecords');
+                    ->get(\Finna\Search\EncapsulatedRecords\Results::class);
                 $result->getParams()->initFromRequest(new Parameters($options));
                 return $result;
             }


### PR DESCRIPTION
Allows encapsulated records to be displayed regardless of the view's sources configuration.

Note: this allows any record to be linked to in any view, but there's currently no way around that.