### PR TITLE
[FINNA-2636] Set border-radius-base etc. properly, use as Finna default.

### DIFF
--- a/themes/finna2/less/global/bootstrap-variable-overrides.less
+++ b/themes/finna2/less/global/bootstrap-variable-overrides.less
@@ -140,9 +140,9 @@
 //
 //## Define common padding and border radius sizes and more. Values based on 14px text and 1.428 line-height (~20px to start).
 
-@border-radius-base:        10px;
-@border-radius-large:       20px;
-@border-radius-small:       5px;
+@border-radius-base:        4px;
+@border-radius-large:       10px;
+@border-radius-small:       2px;
 
 
 //== Tables

--- a/themes/finna2/less/global/variables.less
+++ b/themes/finna2/less/global/variables.less
@@ -47,7 +47,7 @@
 @field-margin-horizontal: 15px;
 @finna-text-shadow: 1px 1px 1px black;
 @finna-search-input-width: 0.655; //== THIS is percentage Change this if no prefilter-select change to 0.88
-@finna-button-radius: 4px; // Defines all button radiuses
+@finna-button-radius: @border-radius-base; // Defines all button radiuses
 @finna-header-font-size: 1.6em;
 @record-title-font-size: 1.65em;
 @record-holdings-title-background: @brand-primary;

--- a/themes/finna2/scss/global/bootstrap-variable-overrides.scss
+++ b/themes/finna2/scss/global/bootstrap-variable-overrides.scss
@@ -140,9 +140,9 @@ $icon-font-svg-id:        "finnaicons" !default;
 //
 //## Define common padding and border radius sizes and more. Values based on 14px text and 1.428 line-height (~20px to start).
 
-$border-radius-base:        10px !default;
-$border-radius-large:       20px !default;
-$border-radius-small:       5px !default;
+$border-radius-base:        4px !default;
+$border-radius-large:       10px !default;
+$border-radius-small:       2px !default;
 
 
 //== Tables

--- a/themes/finna2/scss/global/variables.scss
+++ b/themes/finna2/scss/global/variables.scss
@@ -47,7 +47,7 @@ $field-margin-vertical: 20px !default;
 $field-margin-horizontal: 15px !default;
 $finna-text-shadow: 1px 1px 1px black !default;
 $finna-search-input-width: 0.655 !default; //== THIS is percentage Change this if no prefilter-select change to 0.88
-$finna-button-radius: 4px !default; // Defines all button radiuses
+$finna-button-radius: $border-radius-base !default; // Defines all button radiuses
 $finna-header-font-size: 1.6em !default;
 $record-title-font-size: 1.65em !default;
 $record-holdings-title-background: $brand-primary !default;


### PR DESCRIPTION
The 10px default for border-radius-base was not properly overridden for cookie consent buttons in SCSS mode.