### PR TITLE
[FINNA-2902] Quria: Set language param to 'fi' for getReservationBranches and getR…

### DIFF
--- a/module/Finna/src/Finna/ILS/Driver/Quria.php
+++ b/module/Finna/src/Finna/ILS/Driver/Quria.php
@@ -150,7 +150,7 @@ class Quria extends AxiellWebServices
             'arenaMember' => $this->arenaMember,
             'user' => $username,
             'password' => $password,
-            'language' => $this->getLanguage(),
+            'language' => 'fi',
             'country' => 'FI',
             'reservationEntities' => $id,
             'reservationType' => $holdType,
@@ -1013,7 +1013,7 @@ class Quria extends AxiellWebServices
             'arenaMember' => $this->arenaMember,
             'user' => $username,
             'password' => $password,
-            'language' => $this->getLanguage(),
+            'language' => 'fi',
             'patronId' => $user['patronId'],
         ];
 


### PR DESCRIPTION
…eservations

Muilla kielillä getReservationBranches:issa ei tule nimikenttiä ollenkaan. Lisäksi getReservationBranches:issa muilla kielillä pickupBranchId -kentässä tulee ID, kun suomeksi taas kutsuttuna tulee paikan nimi