### PR TITLE
[FINNA-1432] Define base font size for the html element.

### DIFF
--- a/themes/finna2/scss/finna-other.scss
+++ b/themes/finna2/scss/finna-other.scss
@@ -65,6 +65,10 @@
 @import 'finna/select-a11y';
 @import 'finna/reservationlist';
 
+html {
+    font-size: $font-size-base;
+}
+
 ::-ms-clear {
     display: none;
 }


### PR DESCRIPTION
Allows use of relative font sizes and paves way for Bootstrap 5 migration.