### PR TITLE
[FINNA-2916] Fix aria errors on the navibar.

### DIFF
--- a/themes/finna2/scss/global/navbar-bootstrap.scss
+++ b/themes/finna2/scss/global/navbar-bootstrap.scss
@@ -27,11 +27,13 @@
 }
 
 .navbar {
-  .dropdown .dropdown-menu > li > a > div:not(.description) {
+  .dropdown .dropdown-menu > li > a > div:not(.description), .dropdown .dropdown-menu > li > a > span:not(.description) {
     font-weight: bold;
+    display: inline-block;
   }
   .dropdown .dropdown-menu > li > a > div.description {
     font-size: .9em;
+    display: inline-block;
   }
 }
 

--- a/themes/finna2/scss/global/navbar-bootstrap.scss
+++ b/themes/finna2/scss/global/navbar-bootstrap.scss
@@ -27,7 +27,7 @@
 }
 
 .navbar {
-  .dropdown .dropdown-menu > li > a > div:not(.description), .dropdown .dropdown-menu > li > a > span:not(.description) {
+  .dropdown .dropdown-menu > li > a > div:not(.description) {
     font-weight: bold;
     display: inline-block;
   }

--- a/themes/finna2/scss/global/navbar-bootstrap.scss
+++ b/themes/finna2/scss/global/navbar-bootstrap.scss
@@ -27,13 +27,11 @@
 }
 
 .navbar {
-  .dropdown .dropdown-menu > li > a > div:not(.description) {
+  .dropdown .dropdown-menu > li > a > *:not(.description) {
     font-weight: bold;
-    display: inline-block;
   }
-  .dropdown .dropdown-menu > li > a > div.description {
+  .dropdown .dropdown-menu > li > a > .description {
     font-size: .9em;
-    display: inline-block;
   }
 }
 

--- a/themes/finna2/templates/librarycards/selectcard.phtml
+++ b/themes/finna2/templates/librarycards/selectcard.phtml
@@ -5,7 +5,7 @@
     <?php $targetCount = $this->ils()->checkCapability('getLoginDrivers') ? count($this->ils()->getLoginDrivers()) : 1; ?>
     <?php if (isset($loginMenu) && $loginMenu): ?>
       <li class="logoutOptions card-selection" role="none">
-        <a class="card-header" role="menuitem" href="<?=$this->url('librarycards-home')?>">
+        <a class="card-header" href="<?=$this->url('librarycards-home')?>">
           <?=$this->transEsc($this->label ?? 'Kirjastokortti') ?>
         </a>
         <label id="select-card-label-dropdown"><?= $this->transEsc('Library Card') ?></label>
@@ -26,7 +26,7 @@
               }
             ?>
             <?php $selectedCard = (!isset($this->displaySelected) || $this->displaySelected) && (strcasecmp($card->getCatUsername(), $this->user->getCatUsername() ?? '') === 0); ?>
-            <a aria-describedby="select-card-label-dropdown" role="menuitem" href="<?=$this->url('librarycards-selectcard')?>?cardID=<?=$this->escapeHtmlAttr($card->getId())?>" data-clear-account-cache><?=$selectedCard ? $this->icon('library-card-selected') . '<span class="sr-only">(' . $this->transEsc('selected') . ')</span> ' : '' ?><?=$display ?></a>
+            <a aria-describedby="select-card-label-dropdown" href="<?=$this->url('librarycards-selectcard')?>?cardID=<?=$this->escapeHtmlAttr($card->getId())?>" data-clear-account-cache><?=$selectedCard ? $this->icon('library-card-selected') . '<span class="sr-only">(' . $this->transEsc('selected') . ')</span> ' : '' ?><?=$display ?></a>
           <?php endforeach; ?>
         <?php endif; ?>
       </li>
@@ -80,7 +80,7 @@
               }
             ?>
             <li>
-              <a aria-describedby="select-card-label-maincontent" role="menuitem" href="<?=$this->url('librarycards-selectcard')?>?cardID=<?=$this->escapeHtmlAttr($card->getId());?>" data-clear-account-cache><?=$display ?></a>
+              <a aria-describedby="select-card-label-maincontent" href="<?=$this->url('librarycards-selectcard')?>?cardID=<?=$this->escapeHtmlAttr($card->getId());?>" data-clear-account-cache><?=$display ?></a>
             </li>
         <?php endforeach; ?>
         </ul>

--- a/themes/finna2/templates/navibar.phtml
+++ b/themes/finna2/templates/navibar.phtml
@@ -35,9 +35,9 @@
                 ?>
                   <li>
                     <a <?=$url === $_SERVER['REQUEST_URI'] ? 'aria-current="page"' : ''?> <?= $target ? ' target="' . $this->escapeHtmlAttr($target) . '"' : ''?> href="<?=$this->escapeHtmlAttr($url)?>">
-                      <div><?= $this->transEsc($label) ?></div>
+                      <span><?= $this->transEsc($label) ?></span>
                       <?php if ($desc): ?>
-                        <div class="description"><?= $this->transEsc($desc) ?></div>
+                        <span class="description"><?= $this->transEsc($desc) ?></span>
                       <?php endif; ?>
                     </a>
                   </li>

--- a/themes/finna2/templates/navibar.phtml
+++ b/themes/finna2/templates/navibar.phtml
@@ -34,7 +34,7 @@
                   $desc = !empty($itemVal['desc']) ? $itemVal['desc'] : null;
                 ?>
                   <li>
-                    <a <?=$url === $_SERVER['REQUEST_URI'] ? 'aria-current="page"' : ''?> role="menuitem" <?= $target ? ' target="' . $this->escapeHtmlAttr($target) . '"' : ''?> href="<?=$this->escapeHtmlAttr($url)?>">
+                    <a <?=$url === $_SERVER['REQUEST_URI'] ? 'aria-current="page"' : ''?> <?= $target ? ' target="' . $this->escapeHtmlAttr($target) . '"' : ''?> href="<?=$this->escapeHtmlAttr($url)?>">
                       <div><?= $this->transEsc($label) ?></div>
                       <?php if ($desc): ?>
                         <div class="description"><?= $this->transEsc($desc) ?></div>
@@ -101,7 +101,7 @@
           <?php foreach ($this->layout()->allLangs as $langCode => $langName): ?>
             <?php if ($this->layout()->userLang == $langCode): ?>
               <li>
-                <a class="preserve-anchor active" role="menuitem" aria-description="<?=$this->transEscAttr('selected')?>" lang="<?=$this->escapeHtmlAttr($langCode)?>"> <?=$this->displayLanguageOption($langName)?></a>
+                <a class="preserve-anchor active" aria-description="<?=$this->transEscAttr('selected')?>" lang="<?=$this->escapeHtmlAttr($langCode)?>" href="<?=$this->escapeHtmlAttr($this->navibar()->getLanguageUrl($langCode))?>"> <?=$this->displayLanguageOption($langName)?></a>
               </li>
               <?php break; ?>
             <?php endif ?>
@@ -109,7 +109,7 @@
           <?php foreach ($this->layout()->allLangs as $langCode => $langName): ?>
             <?php if ($this->layout()->userLang != $langCode): ?>
               <li>
-                <a class="preserve-anchor" role="menuitem" lang="<?=$this->escapeHtmlAttr($langCode)?>" href="<?=$this->escapeHtmlAttr($this->navibar()->getLanguageUrl($langCode))?>"><?=$this->displayLanguageOption($langName)?></a>
+                <a class="preserve-anchor" lang="<?=$this->escapeHtmlAttr($langCode)?>" href="<?=$this->escapeHtmlAttr($this->navibar()->getLanguageUrl($langCode))?>"><?=$this->displayLanguageOption($langName)?></a>
               </li>
             <?php endif ?>
           <?php endforeach; ?>
@@ -123,20 +123,20 @@
           <ul id="my-info-dropdown-menu" class="dropdown-menu dropdown-menu-right">
             <?php if ($this->libraryCards()->getCardsForUser($user)): ?>
               <li>
-                <a <?=$this->url('myresearch-checkedout') === $_SERVER['REQUEST_URI'] ? 'aria-current="page"' : ''?> role="menuitem" href="<?=$this->url('myresearch-checkedout')?>">
+                <a <?=$this->url('myresearch-checkedout') === $_SERVER['REQUEST_URI'] ? 'aria-current="page"' : ''?> href="<?=$this->url('myresearch-checkedout')?>">
                   <?=$this->transEsc('Checked Out Items')?>
                   <span class="checkedout-status status hidden"><?=$this->icon('spinner') ?></span>
                 </a>
               </li>
               <li>
-                <a <?=$this->url('holds-list') === $_SERVER['REQUEST_URI'] ? 'aria-current="page"' : ''?> role="menuitem" href="<?=$this->url('holds-list')?>">
+                <a <?=$this->url('holds-list') === $_SERVER['REQUEST_URI'] ? 'aria-current="page"' : ''?> href="<?=$this->url('holds-list')?>">
                   <?=$this->transEsc('Holds and Recalls')?>
                   <span class="holds-status status hidden"><?=$this->icon('spinner') ?></span>
                 </a>
               </li>
               <?php if ($this->ils()->checkFunction('StorageRetrievalRequests', $capabilityParams)): ?>
                 <li>
-                  <a <?=$this->url('myresearch-storageretrievalrequests') === $_SERVER['REQUEST_URI'] ? 'aria-current="page"' : ''?> role="menuitem" href="<?=$this->url('myresearch-storageretrievalrequests')?>">
+                  <a <?=$this->url('myresearch-storageretrievalrequests') === $_SERVER['REQUEST_URI'] ? 'aria-current="page"' : ''?> href="<?=$this->url('myresearch-storageretrievalrequests')?>">
                     <?=$this->transEsc('Storage Retrieval Requests')?>
                     <span class="storageretrievalrequests-status status hidden"><?=$this->icon('spinner') ?></span>
                   </a>
@@ -144,7 +144,7 @@
               <?php endif; ?>
               <?php if ($this->ils()->checkFunction('ILLRequests', $capabilityParams)): ?>
                 <li role="none">
-                  <a <?=$this->url('myresearch-illrequests') === $_SERVER['REQUEST_URI'] ? 'aria-current="page"' : ''?> role="menuitem" href="<?=$this->url('myresearch-illrequests')?>">
+                  <a <?=$this->url('myresearch-illrequests') === $_SERVER['REQUEST_URI'] ? 'aria-current="page"' : ''?> href="<?=$this->url('myresearch-illrequests')?>">
                     <?=$this->transEsc('Interlibrary Loan Requests')?>
                     <span class="illrequests-status status hidden"><?=$this->icon('spinner') ?></span>
                   </a>
@@ -152,13 +152,13 @@
               <?php endif; ?>
               <?php if ($this->ils()->checkCapability('getMyTransactionHistory', $capabilityParams)): ?>
                 <li role="none">
-                  <a <?=$this->url('checkouts-history') === $_SERVER['REQUEST_URI'] ? 'aria-current="page"' : ''?> role="menuitem" href="<?=$this->url('myresearch-historicloans')?>">
+                  <a <?=$this->url('checkouts-history') === $_SERVER['REQUEST_URI'] ? 'aria-current="page"' : ''?> href="<?=$this->url('myresearch-historicloans')?>">
                     <?=$this->transEsc('Loan History')?>
                   </a>
                 </li>
               <?php endif; ?>
               <li>
-                <a <?=$this->url('myresearch-fines') === $_SERVER['REQUEST_URI'] ? 'aria-current="page"' : ''?> role="menuitem" href="<?=$this->url('myresearch-fines')?>">
+                <a <?=$this->url('myresearch-fines') === $_SERVER['REQUEST_URI'] ? 'aria-current="page"' : ''?> href="<?=$this->url('myresearch-fines')?>">
                   <?=$this->transEsc('Fines')?>
                   <span class="fines-status status hidden"><?=$this->icon('spinner') ?></span>
                 </a>
@@ -166,32 +166,32 @@
             <?php endif; ?>
             <?=$this->context($this)->renderInContext('librarycards/selectcard.phtml', ['user' => $user, 'loginMenu' => 'true', 'label' => 'Library Cards','limit' => 0]);?>
             <li>
-              <a <?=$this->url('myresearch-profile') === $_SERVER['REQUEST_URI'] ? 'aria-current="page"' : ''?> role="menuitem" href="<?=$this->url('myresearch-profile')?>">
+              <a <?=$this->url('myresearch-profile') === $_SERVER['REQUEST_URI'] ? 'aria-current="page"' : ''?> href="<?=$this->url('myresearch-profile')?>">
                 <?=$this->transEsc('Profile')?>
                 <span class="profile-status status hidden"><?=$this->icon('spinner') ?></span>
               </a>
             </li>
             <li>
-              <a <?=$this->url('search-history') === $_SERVER['REQUEST_URI'] ? 'aria-current="page"' : ''?> role="menuitem" href="<?=$this->url('search-history')?>?require_login">
+              <a <?=$this->url('search-history') === $_SERVER['REQUEST_URI'] ? 'aria-current="page"' : ''?> href="<?=$this->url('search-history')?>?require_login">
                 <?=$this->transEsc('history_saved_searches')?>
               </a>
             </li>
             <?php if ($this->userlist()->getMode() !== 'disabled'): ?>
               <li>
-                <a <?=$this->url('myresearch-favorites') === $_SERVER['REQUEST_URI'] ? 'aria-current="page"' : ''?> role ="menuitem" href="<?=$this->url('myresearch-favorites')?>">
+                <a <?=$this->url('myresearch-favorites') === $_SERVER['REQUEST_URI'] ? 'aria-current="page"' : ''?> href="<?=$this->url('myresearch-favorites')?>">
                   <?=$this->transEsc('saved_items')?>
                 </a>
               </li>
             <?php endif; ?>
             <?php if ($this->reservationList()->isFunctionalityEnabled()): ?>
               <li>
-                <a <?=$this->url('myresearch-favorites') === $_SERVER['REQUEST_URI'] ? 'aria-current="page"' : ''?> role ="menuitem" href="<?=$this->url('reservationlist-displaylists')?>">
+                <a <?=$this->url('myresearch-favorites') === $_SERVER['REQUEST_URI'] ? 'aria-current="page"' : ''?> href="<?=$this->url('reservationlist-displaylists')?>">
                   <?=$this->transEsc('ReservationList::Reservation Lists')?>
                 </a>
               </li>
             <?php endif; ?>
             <li>
-              <a <?=$this->url('myresearch-logout') === $_SERVER['REQUEST_URI'] ? 'aria-current="page"' : ''?> role="menuitem" href="<?=$this->url('myresearch-logout')?>" title="<?=$this->transEsc('Log Out')?>"><?=$this->transEsc('Log Out')?><?=$this->icon('sign-out', 'sign-out-icon pull-right') ?></a>
+              <a <?=$this->url('myresearch-logout') === $_SERVER['REQUEST_URI'] ? 'aria-current="page"' : ''?> href="<?=$this->url('myresearch-logout')?>" title="<?=$this->transEsc('Log Out')?>"><?=$this->transEsc('Log Out')?><?=$this->icon('sign-out', 'sign-out-icon pull-right') ?></a>
             </li>
           </ul>
         </li>


### PR DESCRIPTION
Valikon linkit on muutettu linkeiksi; aiemmin ne olivat menuitem-elementtejä. Menuitem-rooleja ei tulisi käyttää valikoissa, jotka sisältävät linkkejä. 

Tämä korjaus pitäisi poistaa kaikki validaattorivirheet (virheet johtu tästä [PR:stä](https://github.com/NatLibFi/NDL-VuFind2/pull/3087)). Linkkien elementit muutettu inline-blockiksi jotta ruudunlukijat lukisi sisällön yhtenä kokonaisuuteena. 

Tarkista @JJManner kaikilla ruudunlukijoilla. 