### PR TITLE
[FINNA-2912] Add back-compatibility support for sort tie breaker

### DIFF
--- a/local/config/finna/searches.ini.sample
+++ b/local/config/finna/searches.ini.sample
@@ -6,12 +6,18 @@ default_handler      = AllFields    ; Search handler to use if none is specified
 ; specific setting was present in the [DefaultSortingByType] section below; the
 ; selected option should be one of the options present in the [Sorting] section
 ; below.
-default_sort         = "relevance,id asc"
+default_sort         = "relevance"
+
+; This setting controls the default sort order of search results if multiple
+; records match the same value when records are sorted just using one field.
+; You can optionally include a direction (e.g. "id asc" or "id desc").
+; The selected field is used as a tie breaker to sort the matching results.
+tie_breaker_sort = "id asc"
 
 ; This setting controls the sort order to be used for empty search when relevance
 ; sort is selected. Since relevance doesn't have a meaningful function with an empty
 ; search, this can be set to e.g. "title".
-empty_search_relevance_override = "last_indexed desc,id asc"
+empty_search_relevance_override = "last_indexed desc"
 
 ; This setting controls the default view for search results; the selected option
 ; should be one of the options present in the [Views] section below.
@@ -169,7 +175,7 @@ Holdings            = adv_search_callnumber
 ;       "publishDateSort", "author_sort" and "title_sort" Solr fields; you can use
 ;       either form in this file.
 [Sorting]
-relevance,id asc = sort_relevance
+relevance = sort_relevance
 main_date_str desc = sort_year
 main_date_str asc = "sort_year_asc"
 
@@ -181,7 +187,7 @@ callnumber = sort_callnumber
 
 author = sort_author
 title = sort_title
-last_indexed desc,id asc = sort_last_indexed
+last_indexed desc = sort_last_indexed
 
 ; This section allows you to specify the default sort order for specific types of
 ; searches.  Each key in this section should correspond with a key in the

--- a/module/Finna/src/Finna/Search/Solr/Params.php
+++ b/module/Finna/src/Finna/Search/Solr/Params.php
@@ -741,6 +741,13 @@ class Params extends \VuFind\Search\Solr\Params
      */
     public function setSort($sort, $force = false)
     {
+        // We used to include the tie breaker in all sort options, so strip it out before doing anything else so that
+        // any saved searches or links containing it still work properly and display the correct value:
+        if ($sort && ($tieBreaker = $this->getOptions()->getSortTieBreaker())) {
+            if (str_ends_with($sort, ",$tieBreaker")) {
+                $sort = substr($sort, 0, -strlen($tieBreaker) - 1);
+            }
+        }
         if (!$force) {
             // Check if we need to convert the sort to a currently valid option
             // (it must be a prefix of a currently valid option):

--- a/module/Finna/tests/unit-tests/src/FinnaTest/Search/Solr/ParamsTest.php
+++ b/module/Finna/tests/unit-tests/src/FinnaTest/Search/Solr/ParamsTest.php
@@ -1,0 +1,153 @@
+<?php
+
+/**
+ * Solr Search Object Parameters Test
+ *
+ * PHP version 8
+ *
+ * Copyright (C) The National Library of Finland 2025.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Ere Maijala <ere.maijala@helsinki.fi>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development:testing:unit_tests Wiki
+ */
+
+namespace FinnaTest\Search\Solr;
+
+use Finna\Search\Solr\AuthorityHelper;
+use Finna\Search\Solr\HierarchicalFacetHelper;
+use Finna\Search\Solr\Options;
+use Finna\Search\Solr\Params;
+use VuFind\Config\PluginManager;
+use VuFind\Date\Converter as DateConverter;
+
+/**
+ * Solr Search Object Parameters Test
+ *
+ * @category VuFind
+ * @package  Tests
+ * @author   Ere Maijala <ere.maijala@helsinki.fi>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     https://vufind.org/wiki/development:testing:unit_tests Wiki
+ */
+class ParamsTest extends \PHPUnit\Framework\TestCase
+{
+    use \VuFindTest\Feature\ConfigPluginManagerTrait;
+
+    /**
+     * Data provider for testSort
+     *
+     * @return array
+     */
+    public static function sortDataProvider(): array
+    {
+        $searchConfigLegacy = [
+            'Sorting' => [
+                'relevance,id asc' => 'Relevance',
+                'title,id asc' => 'Title',
+            ],
+        ];
+        $searchConfigLegacyWithTieBreaker = [
+            'General' => [
+                'tie_breaker_sort' => 'id asc',
+            ],
+            'Sorting' => [
+                'relevance,id asc' => 'Relevance',
+                'title_sort,id asc' => 'Title',
+            ],
+        ];
+        $searchConfigCurrent = [
+            'General' => [
+                'tie_breaker_sort' => 'id asc',
+            ],
+            'Sorting' => [
+                'relevance' => 'Relevance',
+                'title_sort' => 'Title',
+            ],
+        ];
+        return [
+            'legacy config, relevance and id'
+                => [$searchConfigLegacy, 'relevance,id asc', 'score desc,id asc'],
+            'legacy config, relevance only'
+                => [$searchConfigLegacy, 'relevance', 'score desc,id asc'],
+            'legacy config, title and id'
+                => [$searchConfigLegacy, 'title,id asc', 'title_sort asc,id asc'],
+            'legacy config, title only'
+                => [$searchConfigLegacy, 'title', 'title_sort asc,id asc'],
+
+            'mixed config, relevance and id'
+                => [$searchConfigLegacyWithTieBreaker, 'relevance,id asc', 'score desc,id asc'],
+            'mixed config, relevance only'
+                => [$searchConfigLegacyWithTieBreaker, 'relevance', 'score desc,id asc'],
+            'mixed config, title and id'
+                => [$searchConfigLegacyWithTieBreaker, 'title,id asc', 'title_sort asc,id asc'],
+            'mixed config, title only'
+                => [$searchConfigLegacyWithTieBreaker, 'title', 'title_sort asc,id asc'],
+
+            'current config, relevance and id'
+                => [$searchConfigCurrent, 'relevance,id asc', 'score desc,id asc'],
+            'current config, relevance only'
+                => [$searchConfigCurrent, 'relevance', 'score desc,id asc'],
+            'current config, title and id'
+                => [$searchConfigCurrent, 'title,id asc', 'title_sort asc,id asc'],
+            'current config, title only'
+                => [$searchConfigCurrent, 'title', 'title_sort asc,id asc'],
+        ];
+    }
+
+    /**
+     * Test sort option handling
+     *
+     * @param array  $searchConfig Search configuration
+     * @param string $sort         Selected sort option
+     * @param string $expectedSort Expected Solr sort string
+     *
+     * @return void
+     *
+     * @dataProvider sortDataProvider
+     */
+    public function testSort(array $searchConfig, string $sort, string $expectedSort): void
+    {
+        $params = $this->getParams(mockConfig: $this->getMockConfigPluginManager(['searches' => $searchConfig]));
+        $params->setSort($sort);
+        $backendParams = $params->getBackendParameters();
+        $this->assertEquals([$expectedSort], $backendParams->get('sort'));
+    }
+
+    /**
+     * Get Params object
+     *
+     * @param Options       $options    Options object (null to create)
+     * @param PluginManager $mockConfig Mock config plugin manager (null to create)
+     *
+     * @return Params
+     */
+    protected function getParams(
+        Options $options = null,
+        PluginManager $mockConfig = null
+    ): Params {
+        $mockConfig ??= $this->createMock(PluginManager::class);
+        return new Params(
+            $options ?? new Options($mockConfig),
+            $mockConfig,
+            $this->createMock(HierarchicalFacetHelper::class),
+            $this->createMock(AuthorityHelper::class),
+            $this->createMock(DateConverter::class)
+        );
+    }
+}


### PR DESCRIPTION
- Adds support for handling sort parameters that already contain the tie breaker field.
- Adds tests to confirm proper results with all combinations of configuration and sort parameter.