### PR TITLE
[FINNA-2912] Use catalog_date instead of first_indexed when appropriate.

### DIFF
--- a/local/config/finna/Blender.ini.sample
+++ b/local/config/finna/Blender.ini.sample
@@ -166,6 +166,7 @@ hierarchicalFacetSortOptions[building] = top
 hierarchicalFacetSeparators[format] = " > "
 ; Any fields listed below will be treated as new items facets
 newItems[] = first_indexed
+newItems[] = catalog_date
 ; Date visualisations
 dateVis[] = main_date_str
 dateRangeVis = search_daterange_mv:main_date_str

--- a/local/config/finna/facets.ini.sample
+++ b/local/config/finna/facets.ini.sample
@@ -30,7 +30,7 @@ topic_facet         = Topic
 ;usage_rights_str_mv = "Usage Rights"
 usage_rights_ext_str_mv = usage_rights_ext
 hierarchy_parent_title = component_part_is_part_of
-first_indexed       = "New Items in Index"
+catalog_date       = "New Items in Index"
 category_str_mv     = category_facet_heading
 
 ; Facets that will appear at the top of search results when the TopFacets

--- a/local/config/finna/searches.ini.sample
+++ b/local/config/finna/searches.ini.sample
@@ -198,6 +198,17 @@ last_indexed desc = sort_last_indexed
 CallNumber = callnumber
 WorkKeys = "main_date_str desc"
 
+; This section allows you to specify hidden sorting options. They can be used to
+; create a whitelist of sort values using regular expressions. If you want to do
+; this add regexes to the pattern[] array. All sort values that match at least one
+; of these pattern are allowed in searches.
+; The first matching option is shown in the sort selection in the result list when
+; none of the normal options in [Sorting] section is selected. The labels for the
+; entries can be defined in pattern[] array keys or a separate label[] array.
+[HiddenSorting]
+pattern[sort_first_indexed_desc] = "^first_indexed desc$"
+pattern[sort_first_indexed_desc] = "^catalog_date desc$"
+
 ; These settings control which fields are available to sort on in the collections
 ; module.
 [CollectionModuleSort]

--- a/local/config/vufind/facets-browse.ini.sample
+++ b/local/config/vufind/facets-browse.ini.sample
@@ -4,7 +4,7 @@ relative_path = ../finna/facets.ini
 override_full_sections = "CheckboxFacets,BrowseDatabase,BrowseJournal"
 
 [Results_Settings]
-collapsedFacets = author2Str,genre_facet,language,topic_facet,first_indexed
+collapsedFacets = author2Str,genre_facet,language,topic_facet,first_indexed,catalog_date
 
 [CheckboxFacets]
 
@@ -17,5 +17,5 @@ genre_facet            = Genre
 category_str_mv        = category_facet_heading
 language               = Language
 topic_facet            = Topic
-first_indexed          = "New Items in Index"
+catalog_date           = "New Items in Index"
 

--- a/module/Finna/src/Finna/RecordDriver/Feature/SolrFinnaTrait.php
+++ b/module/Finna/src/Finna/RecordDriver/Feature/SolrFinnaTrait.php
@@ -760,7 +760,7 @@ trait SolrFinnaTrait
      */
     public function getFirstIndexed()
     {
-        return $this->fields['first_indexed'] ?? '';
+        return $this->fields['catalog_date'] ?? $this->fields['first_indexed'] ?? '';
     }
 
     /**

--- a/module/Finna/src/Finna/View/Helper/Root/Navibar.php
+++ b/module/Finna/src/Finna/View/Helper/Root/Navibar.php
@@ -413,7 +413,6 @@ class Navibar extends \Laminas\View\Helper\AbstractHelper
             if (preg_match('/^__(.*)_sort__$/', $menuKey, $matches)) {
                 // Sort section
                 $menuKey = $matches[1];
-                $items = $items->toArray();
                 // Re-order menu-level sort entries in descending order
                 asort($items);
                 $sortData[$menuKey] = $items;

--- a/module/FinnaConsole/src/FinnaConsole/Command/ScheduledSearch/NotifyCommand.php
+++ b/module/FinnaConsole/src/FinnaConsole/Command/ScheduledSearch/NotifyCommand.php
@@ -287,10 +287,24 @@ class NotifyCommand extends \VuFindConsole\Command\ScheduledSearch\NotifyCommand
                 !$this->validateSchedule($todayTime, $lastTime, $s)
                 || !($user = $this->getUserForSearch($s))
                 || !($searchObject = $this->getObjectForSearch($s))
-                || !($newRecords = $this->getNewRecords($searchObject, $lastTime))
             ) {
                 continue;
             }
+
+            // Use catalog_date if available as sort option:
+            $this->sort = 'first_indexed desc';
+            $sortOptions = $searchObject->getOptions()->getSortOptions();
+            foreach (array_keys($sortOptions) as $key) {
+                if (str_starts_with($key, 'catalog_date desc')) {
+                    $this->sort = $key;
+                    break;
+                }
+            }
+
+            if (!($newRecords = $this->getNewRecords($searchObject, $lastTime))) {
+                continue;
+            }
+
             // Set email language
             $this->setLanguage($user->getLastLanguage());
 


### PR DESCRIPTION
Uses catalog_date in scheduled alerts when it's enabled as a sort option.
HiddenSorting is used to ensure that any old searches and links still work if sorting is changed from first_indexed to catalog_date.