### PR TITLE
AIPA: Cast subject heading values into arrays

### DIFF
--- a/module/Finna/src/Finna/RecordDriver/SolrAipa.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrAipa.php
@@ -129,7 +129,10 @@ class SolrAipa extends SolrQdc implements ContainerFormatInterface
      */
     public function getAllSubjectHeadings($extended = false)
     {
-        return $this->getFieldData('subject', $extended);
+        return array_map(
+            fn ($value) => (array)$value,
+            $this->getFieldData('subject', $extended)
+        );
     }
 
     /**


### PR DESCRIPTION
Now this function returns strings if not extended, but to be in par with other implementations, nonextended values should be also arrays.