### PR TITLE
DefaultRecord: Remove unused onclick handler

### DIFF
--- a/themes/finna2/templates/RecordDriver/DefaultRecord/record-post-thumbnail.phtml
+++ b/themes/finna2/templates/RecordDriver/DefaultRecord/record-post-thumbnail.phtml
@@ -12,16 +12,3 @@
     </div>
   </div>
 <?php endif; ?>
-<?php
-  $script = <<<JS
-      $('.rating-link').on('click', function () {
-        $('a.usercomments').click();
-        $('html, body').animate(
-          {
-            scrollTop: $('.record-tabs').offset().top
-          }, 500
-        );
-      });
-      JS;
-  echo $this->assetManager()->outputInlineScriptString($script);
-?>


### PR DESCRIPTION
This code doesn't do anything anymore, because `<div class="rating-link">` has been removed in commit 3efbd74a698048b6596400956822064b8c159c00.