### PR TITLE
[FINNA-4025] Set limit for amount of images to render in search results.

### DIFF
--- a/local/config/finna/SearchApiRecordFields.yaml.sample
+++ b/local/config/finna/SearchApiRecordFields.yaml.sample
@@ -519,6 +519,10 @@ relationshipNotes:
   type: array
   items:
     type: string
+searchImagesCountNotice:
+  vufind.method: "Formatter::getSearchImagesCountNotice"
+  description: Displays current amount of images rendered out of total images,
+  type: string
 secondaryAuthors:
   vufind.method: getSecondaryAuthors
   description: Secondary authors

--- a/local/config/finna/SearchApiRecordFields.yaml.sample
+++ b/local/config/finna/SearchApiRecordFields.yaml.sample
@@ -521,7 +521,7 @@ relationshipNotes:
     type: string
 searchImagesCountNotice:
   vufind.method: "Formatter::getSearchImagesCountNotice"
-  description: Displays current amount of images rendered out of total images,
+  description: Displays current amount of images returned out of total images,
   type: string
 secondaryAuthors:
   vufind.method: getSecondaryAuthors

--- a/local/config/finna/config.ini.sample
+++ b/local/config/finna/config.ini.sample
@@ -827,6 +827,10 @@ recordMap = openlayers
 ; A colon-separated list of formats that are enabled for image zoom function
 zoomFormats = qdc:forward:ead3:ead:lido
 
+; Sets the amount of images allowed to be rendered in search context.
+; Default and hard limit is 20.
+;max_amount_of_images_in_search_context = 10
+
 [QRCode]
 ; This setting controls the image to display when no qrcode is available.
 ; The path is relative to the base of your theme directory.

--- a/local/config/finna/config.ini.sample
+++ b/local/config/finna/config.ini.sample
@@ -827,9 +827,9 @@ recordMap = openlayers
 ; A colon-separated list of formats that are enabled for image zoom function
 zoomFormats = qdc:forward:ead3:ead:lido
 
-; Sets the amount of images allowed to be rendered in search context.
+; Sets the amount of images allowed to be returned in search context.
 ; Default and hard limit is 20.
-;max_amount_of_images_in_search_context = 10
+;maxImagesInSearchContext = 10
 
 [QRCode]
 ; This setting controls the image to display when no qrcode is available.

--- a/module/Finna/src/Finna/RecordDriver/Feature/FinnaRecordTrait.php
+++ b/module/Finna/src/Finna/RecordDriver/Feature/FinnaRecordTrait.php
@@ -31,6 +31,8 @@
 
 namespace Finna\RecordDriver\Feature;
 
+use Finna\RecordDriver\RenderContext;
+
 use function count;
 use function in_array;
 use function is_array;
@@ -70,6 +72,50 @@ trait FinnaRecordTrait
      * @var string
      */
     protected $defaultRecordSpecsClass = 'DefaultRecord';
+
+    /**
+     * Maximum limit of images to get in search results per record.
+     *
+     * @var int
+     */
+    protected int $maxImagesInSearch = 20;
+
+    /**
+     * Current record render context
+     *
+     * @var RenderContext
+     */
+    protected RenderContext $renderContext = RenderContext::RECORD;
+
+    /**
+     * Current amount of images
+     *
+     * @var int
+     */
+    protected int $imagesCount = 0;
+
+    /**
+     * Set current record render context
+     *
+     * @param string $context Record render context
+     *
+     * @return void
+     */
+    public function setRenderContext(string $context): void
+    {
+        $this->renderContext = RenderContext::from($context);
+    }
+
+    /**
+     * Has the record exceeded maximum amount of images for its current context?
+     * Amount of images allowed when renderContext is search is 20.
+     *
+     * @return bool
+     */
+    public function maxAmountOfImages(): bool
+    {
+        return $this->renderContext === RenderContext::SEARCH && $this->imagesCount >= $this->maxImagesInSearch;
+    }
 
     /**
      * Get inappropriate comments for this record reported by the given user.

--- a/module/Finna/src/Finna/RecordDriver/Feature/FinnaRecordTrait.php
+++ b/module/Finna/src/Finna/RecordDriver/Feature/FinnaRecordTrait.php
@@ -118,6 +118,29 @@ trait FinnaRecordTrait
     }
 
     /**
+     * Get amount of images allowed to be rendered in current context.
+     *
+     * @return int Current images render limit or -1 for all.
+     */
+    public function getImagesRenderLimit(): int
+    {
+        if ($this->renderContext === RenderContext::SEARCH) {
+            return $this->maxImagesInSearch;
+        }
+        return -1;
+    }
+
+    /**
+     * Get the total image count for the record. Value is populated after calling the getAllImages function.
+     *
+     * @return int
+     */
+    public function getTotalAmountOfImages(): int
+    {
+        return $this->imagesCount;
+    }
+
+    /**
      * Get inappropriate comments for this record reported by the given user.
      *
      * @param ?int $userId Reporter ID or null to use current session

--- a/module/Finna/src/Finna/RecordDriver/Feature/SolrForwardTrait.php
+++ b/module/Finna/src/Finna/RecordDriver/Feature/SolrForwardTrait.php
@@ -65,6 +65,9 @@ trait SolrForwardTrait
 
         foreach ($this->getAllRecordsXML() as $xml) {
             foreach ($xml->ProductionEvent as $event) {
+                if ($this->maxAmountOfImages()) {
+                    break;
+                }
                 $attributes = $event->ProductionEventType->attributes();
                 if (empty($attributes->{'elokuva-elonet-materiaali-kuva-url'})) {
                     continue;
@@ -100,6 +103,7 @@ trait SolrForwardTrait
                 ];
                 $image['downloadable'] = $this->allowRecordImageDownload($image);
                 $images[] = $image;
+                $this->imagesCount++;
             }
         }
         return $images;

--- a/module/Finna/src/Finna/RecordDriver/Feature/SolrForwardTrait.php
+++ b/module/Finna/src/Finna/RecordDriver/Feature/SolrForwardTrait.php
@@ -65,9 +65,6 @@ trait SolrForwardTrait
 
         foreach ($this->getAllRecordsXML() as $xml) {
             foreach ($xml->ProductionEvent as $event) {
-                if ($this->maxAmountOfImages()) {
-                    break;
-                }
                 $attributes = $event->ProductionEventType->attributes();
                 if (empty($attributes->{'elokuva-elonet-materiaali-kuva-url'})) {
                     continue;
@@ -92,17 +89,19 @@ trait SolrForwardTrait
                         $rights['link'] = $link;
                     }
                 }
-                $image = [
-                    'urls' => [
-                        'small' => $url,
-                        'medium' => $url,
-                        'large' => $url,
-                    ],
-                    'description' => $desc,
-                    'rights' => $rights,
-                ];
-                $image['downloadable'] = $this->allowRecordImageDownload($image);
-                $images[] = $image;
+                if (!$this->maxAmountOfImages()) {
+                    $image = [
+                        'urls' => [
+                            'small' => $url,
+                            'medium' => $url,
+                            'large' => $url,
+                        ],
+                        'description' => $desc,
+                        'rights' => $rights,
+                    ];
+                    $image['downloadable'] = $this->allowRecordImageDownload($image);
+                    $images[] = $image;
+                }
                 $this->imagesCount++;
             }
         }

--- a/module/Finna/src/Finna/RecordDriver/RenderContext.php
+++ b/module/Finna/src/Finna/RecordDriver/RenderContext.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * Record render context enum.
+ *
+ * PHP Version 8
+ *
+ * Copyright (C) The National Library of Finland 2025.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * @category VuFind
+ * @package  RecordDriver
+ * @author   Juha Luoma <juha.luoma@helsinki.fi>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     http://vufind.org/wiki/vufind2:developer_manual Wiki
+ */
+
+namespace Finna\RecordDriver;
+
+/**
+ * Record render context enum.
+ *
+ * @category VuFind
+ * @package  RecordDriver
+ * @author   Juha Luoma <juha.luoma@helsinki.fi>
+ * @license  http://opensource.org/licenses/gpl-2.0.php GNU General Public License
+ * @link     http://vufind.org/wiki/vufind2:developer_manual Wiki
+ */
+enum RenderContext: string
+{
+    case SEARCH = 'search';
+    case RECORD = 'record';
+
+    /**
+     * Get render context from view type
+     *
+     * @param string $view View type i.e list, list-grid
+     *
+     * @return static
+     */
+    public static function fromView(string $view): static
+    {
+        return match ($view) {
+            'list', 'list-grid' => self::SEARCH,
+            default => self::RECORD
+        };
+    }
+}

--- a/module/Finna/src/Finna/RecordDriver/RenderContext.php
+++ b/module/Finna/src/Finna/RecordDriver/RenderContext.php
@@ -53,7 +53,7 @@ enum RenderContext: string
     public static function fromView(string $view): static
     {
         return match ($view) {
-            'list', 'list-grid' => self::SEARCH,
+            'list', 'list grid' => self::SEARCH,
             default => self::RECORD
         };
     }

--- a/module/Finna/src/Finna/RecordDriver/SolrAipa.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrAipa.php
@@ -125,7 +125,11 @@ class SolrAipa extends SolrQdc implements ContainerFormatInterface
                         'rights' => [],
                         'downloadable' => false,
                     ];
+                    $this->imagesCount++;
                 }
+            }
+            if ($this->maxAmountOfImages()) {
+                break;
             }
         }
 

--- a/module/Finna/src/Finna/RecordDriver/SolrAipa.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrAipa.php
@@ -115,21 +115,20 @@ class SolrAipa extends SolrQdc implements ContainerFormatInterface
             if ($format && in_array($format, $images)) {
                 $url = (string)$desc;
                 if ($this->isUrlLoadable($url, $uniqueId)) {
-                    $result[] = [
-                        'urls' => [
-                            'small' => $url,
-                            'medium' => $url,
-                            'large' => $url,
-                        ],
-                        'description' => '',
-                        'rights' => [],
-                        'downloadable' => false,
-                    ];
+                    if (!$this->maxAmountOfImages()) {
+                        $result[] = [
+                            'urls' => [
+                                'small' => $url,
+                                'medium' => $url,
+                                'large' => $url,
+                            ],
+                            'description' => '',
+                            'rights' => [],
+                            'downloadable' => false,
+                        ];
+                    }
                     $this->imagesCount++;
                 }
-            }
-            if ($this->maxAmountOfImages()) {
-                break;
             }
         }
 

--- a/module/Finna/src/Finna/RecordDriver/SolrDefault.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrDefault.php
@@ -61,7 +61,7 @@ class SolrDefault extends \VuFind\RecordDriver\SolrDefault
     ) {
         parent::__construct($mainConfig, $recordConfig, $searchSettings);
         $this->searchSettings = $searchSettings;
-        $maxImagesInSearch = $mainConfig->Content->max_amount_of_images_in_search_context ?? 0;
+        $maxImagesInSearch = $mainConfig->Content->maxImagesInSearchContext ?? 0;
         if ($maxImagesInSearch > 0) {
             $this->maxImagesInSearch = min($maxImagesInSearch, $this->maxImagesInSearch);
         }

--- a/module/Finna/src/Finna/RecordDriver/SolrDefault.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrDefault.php
@@ -61,5 +61,9 @@ class SolrDefault extends \VuFind\RecordDriver\SolrDefault
     ) {
         parent::__construct($mainConfig, $recordConfig, $searchSettings);
         $this->searchSettings = $searchSettings;
+        $maxImagesInSearch = $mainConfig->Content->max_amount_of_images_in_search_context ?? 0;
+        if ($maxImagesInSearch > 0) {
+            $this->maxImagesInSearch = min($maxImagesInSearch, $this->maxImagesInSearch);
+        }
     }
 }

--- a/module/Finna/src/Finna/RecordDriver/SolrEad.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrEad.php
@@ -151,6 +151,9 @@ class SolrEad extends SolrDefault implements \Laminas\Log\LoggerAwareInterface
         // All images have same rights..
         $rights = $this->getImageRights($language, true);
         foreach ($this->getXmlRecord()->xpath('did/daogrp') as $daogrp) {
+            if ($this->maxAmountOfImages()) {
+                break;
+            }
             $urls = [];
             foreach ($daogrp->daoloc as $daoloc) {
                 $attributes = $daoloc->attributes();
@@ -199,6 +202,7 @@ class SolrEad extends SolrDefault implements \Laminas\Log\LoggerAwareInterface
             ];
             $image['downloadable'] = $this->allowRecordImageDownload($image);
             $result[] = $image;
+            $this->imagesCount++;
         }
 
         $this->cache[$cacheKey] = $result;

--- a/module/Finna/src/Finna/RecordDriver/SolrEad.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrEad.php
@@ -151,9 +151,6 @@ class SolrEad extends SolrDefault implements \Laminas\Log\LoggerAwareInterface
         // All images have same rights..
         $rights = $this->getImageRights($language, true);
         foreach ($this->getXmlRecord()->xpath('did/daogrp') as $daogrp) {
-            if ($this->maxAmountOfImages()) {
-                break;
-            }
             $urls = [];
             foreach ($daogrp->daoloc as $daoloc) {
                 $attributes = $daoloc->attributes();
@@ -195,13 +192,15 @@ class SolrEad extends SolrDefault implements \Laminas\Log\LoggerAwareInterface
             } else {
                 $description = '';
             }
-            $image = [
-                'urls' => $urls,
-                'description' => (string)$description,
-                'rights' => $rights,
-            ];
-            $image['downloadable'] = $this->allowRecordImageDownload($image);
-            $result[] = $image;
+            if (!$this->maxAmountOfImages()) {
+                $image = [
+                    'urls' => $urls,
+                    'description' => (string)$description,
+                    'rights' => $rights,
+                ];
+                $image['downloadable'] = $this->allowRecordImageDownload($image);
+                $result[] = $image;
+            }
             $this->imagesCount++;
         }
 

--- a/module/Finna/src/Finna/RecordDriver/SolrEad3.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrEad3.php
@@ -974,6 +974,7 @@ class SolrEad3 extends SolrEad
             }
             $formatted['downloadable'] = $this->allowRecordImageDownload($formatted);
             $result['displayImages'][] = $formatted;
+            $this->imagesCount++;
         };
         $isExcludedFromOCR = function ($title) {
             foreach (self::EXCLUDE_OCR_TITLE_PARTS as $part) {
@@ -990,6 +991,9 @@ class SolrEad3 extends SolrEad
         $fullResImages = [];
         foreach ([$xml->did ?? [], $xml->did->daoset ?? []] as $root) {
             foreach ($root as $set) {
+                if ($this->maxAmountOfImages()) {
+                    break 2;
+                }
                 if (!isset($set->dao)) {
                     continue;
                 }
@@ -1011,6 +1015,9 @@ class SolrEad3 extends SolrEad
                 $displayImage = [];
                 $highResolution = [];
                 foreach ($set->dao as $dao) {
+                    if ($this->maxAmountOfImages()) {
+                        break 3;
+                    }
                     $attr = $dao->attributes();
                     if (
                         !($title = (string)($attr->linktitle ?? ''))

--- a/module/Finna/src/Finna/RecordDriver/SolrEad3.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrEad3.php
@@ -961,20 +961,24 @@ class SolrEad3 extends SolrEad
         ];
         $xml = $this->getXmlRecord();
         $addToResults = function ($imageData) use (&$result) {
-            $imageData = $this->ensureImageSizes($imageData);
-            $sizes = ['small', 'medium', 'large'];
-            $formatted = $imageData;
-            if (!empty($imageData['urls'])) {
-                foreach ($sizes as $size) {
-                    $from = $imageData['cacheSizes'][$size] ?? null;
-                    if ($from) {
-                        $formatted['pdf'][$size] = $imageData['pdf'][$from];
+            if (!$this->maxAmountOfImages()) {
+                $imageData = $this->ensureImageSizes($imageData);
+                $sizes = ['small', 'medium', 'large'];
+                $formatted = $imageData;
+                if (!empty($imageData['urls'])) {
+                    foreach ($sizes as $size) {
+                        $from = $imageData['cacheSizes'][$size] ?? null;
+                        if ($from) {
+                            $formatted['pdf'][$size] = $imageData['pdf'][$from];
+                        }
                     }
                 }
+                $formatted['downloadable'] = $this->allowRecordImageDownload($formatted);
+                $result['displayImages'][] = $formatted;
             }
-            $formatted['downloadable'] = $this->allowRecordImageDownload($formatted);
-            $result['displayImages'][] = $formatted;
-            $this->imagesCount++;
+            if (!empty($imageData['urls'])) {
+                $this->imagesCount++;
+            }
         };
         $isExcludedFromOCR = function ($title) {
             foreach (self::EXCLUDE_OCR_TITLE_PARTS as $part) {
@@ -991,9 +995,6 @@ class SolrEad3 extends SolrEad
         $fullResImages = [];
         foreach ([$xml->did ?? [], $xml->did->daoset ?? []] as $root) {
             foreach ($root as $set) {
-                if ($this->maxAmountOfImages()) {
-                    break 2;
-                }
                 if (!isset($set->dao)) {
                     continue;
                 }
@@ -1015,9 +1016,6 @@ class SolrEad3 extends SolrEad
                 $displayImage = [];
                 $highResolution = [];
                 foreach ($set->dao as $dao) {
-                    if ($this->maxAmountOfImages()) {
-                        break 3;
-                    }
                     $attr = $dao->attributes();
                     if (
                         !($title = (string)($attr->linktitle ?? ''))
@@ -1125,7 +1123,9 @@ class SolrEad3 extends SolrEad
         if (!empty($fullResImages['items'])) {
             $result['fullres'] = $fullResImages;
         }
-
+        $images = [];
+        $fullResImages = [];
+        $ocrImages = [];
         return $this->cache[$cacheKey] = $result;
     }
 

--- a/module/Finna/src/Finna/RecordDriver/SolrLido.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrLido.php
@@ -536,7 +536,7 @@ class SolrLido extends \VuFind\RecordDriver\SolrDefault implements \Laminas\Log\
                 'documents'
             );
         };
-        $imageCount = 0;
+
         $xpath = '/lidoWrap/lido/administrativeMetadata/resourceWrap/resourceSet';
         foreach ($this->getXmlRecord()->xpath($xpath) as $resourceSet) {
             // Process rights first since we may need to duplicate them if there

--- a/module/Finna/src/Finna/RecordDriver/SolrLido.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrLido.php
@@ -524,8 +524,10 @@ class SolrLido extends \VuFind\RecordDriver\SolrDefault implements \Laminas\Log\
             array $documents = []
         ) use (&$results) {
             if ($images) {
-                $images = $this->ensureImageSizes($images);
-                $images['downloadable'] = $this->allowRecordImageDownload($images);
+                if (!$this->maxAmountOfImages()) {
+                    $images = $this->ensureImageSizes($images);
+                    $images['downloadable'] = $this->allowRecordImageDownload($images);
+                }
                 $this->imagesCount++;
             }
             $results[] = compact(
@@ -567,7 +569,7 @@ class SolrLido extends \VuFind\RecordDriver\SolrDefault implements \Laminas\Log\
                     // final results first. This shouldn't
                     // happen unless there are multiple
                     // images without type in the same set.
-                    if ($imageUrls && !$this->maxAmountOfImages()) {
+                    if ($imageUrls) {
                         $addToResults(
                             [
                                 'urls' => $imageUrls,
@@ -629,7 +631,7 @@ class SolrLido extends \VuFind\RecordDriver\SolrDefault implements \Laminas\Log\
                     }
                 }
                 // Representation is an image
-                if (in_array($type, $imageTypeKeys) && !$this->maxAmountOfImages()) {
+                if (in_array($type, $imageTypeKeys)) {
                     $image = $this->getImage(
                         $url,
                         $type,

--- a/module/Finna/src/Finna/RecordDriver/SolrLido.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrLido.php
@@ -526,6 +526,7 @@ class SolrLido extends \VuFind\RecordDriver\SolrDefault implements \Laminas\Log\
             if ($images) {
                 $images = $this->ensureImageSizes($images);
                 $images['downloadable'] = $this->allowRecordImageDownload($images);
+                $this->imagesCount++;
             }
             $results[] = compact(
                 'images',
@@ -535,7 +536,7 @@ class SolrLido extends \VuFind\RecordDriver\SolrDefault implements \Laminas\Log\
                 'documents'
             );
         };
-
+        $imageCount = 0;
         $xpath = '/lidoWrap/lido/administrativeMetadata/resourceWrap/resourceSet';
         foreach ($this->getXmlRecord()->xpath($xpath) as $resourceSet) {
             // Process rights first since we may need to duplicate them if there
@@ -566,7 +567,7 @@ class SolrLido extends \VuFind\RecordDriver\SolrDefault implements \Laminas\Log\
                     // final results first. This shouldn't
                     // happen unless there are multiple
                     // images without type in the same set.
-                    if ($imageUrls) {
+                    if ($imageUrls && !$this->maxAmountOfImages()) {
                         $addToResults(
                             [
                                 'urls' => $imageUrls,
@@ -628,7 +629,7 @@ class SolrLido extends \VuFind\RecordDriver\SolrDefault implements \Laminas\Log\
                     }
                 }
                 // Representation is an image
-                if (in_array($type, $imageTypeKeys)) {
+                if (in_array($type, $imageTypeKeys) && !$this->maxAmountOfImages()) {
                     $image = $this->getImage(
                         $url,
                         $type,

--- a/module/Finna/src/Finna/RecordDriver/SolrLrmi.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrLrmi.php
@@ -354,6 +354,9 @@ class SolrLrmi extends SolrQdc
         $result = [];
         $images = ['image/png', 'image/jpeg'];
         foreach ($xml->description as $desc) {
+            if ($this->maxAmountOfImages()) {
+                break;
+            }
             $attr = $desc->attributes();
             $format = trim((string)($attr['format'] ?? ''));
             if ($format && in_array($format, $images)) {
@@ -369,6 +372,7 @@ class SolrLrmi extends SolrQdc
                         'rights' => [],
                         'downloadable' => false,
                     ];
+                    $this->imagesCount++;
                 }
             }
         }

--- a/module/Finna/src/Finna/RecordDriver/SolrLrmi.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrLrmi.php
@@ -354,24 +354,23 @@ class SolrLrmi extends SolrQdc
         $result = [];
         $images = ['image/png', 'image/jpeg'];
         foreach ($xml->description as $desc) {
-            if ($this->maxAmountOfImages()) {
-                break;
-            }
             $attr = $desc->attributes();
             $format = trim((string)($attr['format'] ?? ''));
             if ($format && in_array($format, $images)) {
                 $url = (string)$desc;
                 if ($this->isUrlLoadable($url, $uniqueId)) {
-                    $result[] = [
-                        'urls' => [
-                            'small' => $url,
-                            'medium' => $url,
-                            'large' => $url,
-                        ],
-                        'description' => '',
-                        'rights' => [],
-                        'downloadable' => false,
-                    ];
+                    if (!$this->maxAmountOfImages()) {
+                        $result[] = [
+                            'urls' => [
+                                'small' => $url,
+                                'medium' => $url,
+                                'large' => $url,
+                            ],
+                            'description' => '',
+                            'rights' => [],
+                            'downloadable' => false,
+                        ];
+                    }
                     $this->imagesCount++;
                 }
             }

--- a/module/Finna/src/Finna/RecordDriver/SolrQdc.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrQdc.php
@@ -237,20 +237,20 @@ class SolrQdc extends \VuFind\RecordDriver\SolrDefault implements \Laminas\Log\L
         $highResolution = [];
         $rights = $this->getRights($language);
         $addToResults = function ($imageData) use (&$results) {
-            if (!isset($imageData['urls']['small'])) {
-                $imageData['urls']['small'] = $imageData['urls']['medium']
-                    ?? $imageData['urls']['large']
-                    ?? $imageData['urls']['original'];
+            if (!$this->maxAmountOfImages()) {
+                if (!isset($imageData['urls']['small'])) {
+                    $imageData['urls']['small'] = $imageData['urls']['medium']
+                        ?? $imageData['urls']['large']
+                        ?? $imageData['urls']['original'];
+                }
+                $imageData = $this->ensureImageSizes($imageData);
+                $imageData['downloadable'] = $this->allowRecordImageDownload($imageData);
+                $results[] = $imageData;
             }
-            $imageData = $this->ensureImageSizes($imageData);
-            $imageData['downloadable'] = $this->allowRecordImageDownload($imageData);
-            $results[] = $imageData;
+            $this->imagesCount++;
         };
 
         foreach ($xml->file as $node) {
-            if ($this->maxAmountOfImages()) {
-                break;
-            }
             $attributes = $node->attributes();
             $type = (string)($attributes->type ?? '');
             $url = (string)($attributes->href ?? $node);
@@ -284,7 +284,6 @@ class SolrQdc extends \VuFind\RecordDriver\SolrDefault implements \Laminas\Log\L
                     $otherSizes[$size] = $url;
                 }
             }
-            $this->imagesCount++;
         }
 
         if ($thumbnails && !$otherSizes) {
@@ -307,6 +306,8 @@ class SolrQdc extends \VuFind\RecordDriver\SolrDefault implements \Laminas\Log\L
                 ]
             );
         }
+        $thumbnails = [];
+        $otherSizes = [];
         // Attempt to find a PDF file to be converted to a coverimage
         if ($includePdf && empty($results)) {
             $urls = [];

--- a/module/Finna/src/Finna/RecordDriver/SolrQdc.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrQdc.php
@@ -248,6 +248,9 @@ class SolrQdc extends \VuFind\RecordDriver\SolrDefault implements \Laminas\Log\L
         };
 
         foreach ($xml->file as $node) {
+            if ($this->maxAmountOfImages()) {
+                break;
+            }
             $attributes = $node->attributes();
             $type = (string)($attributes->type ?? '');
             $url = (string)($attributes->href ?? $node);
@@ -281,6 +284,7 @@ class SolrQdc extends \VuFind\RecordDriver\SolrDefault implements \Laminas\Log\L
                     $otherSizes[$size] = $url;
                 }
             }
+            $this->imagesCount++;
         }
 
         if ($thumbnails && !$otherSizes) {

--- a/module/Finna/src/Finna/View/Helper/Root/RecordImage.php
+++ b/module/Finna/src/Finna/View/Helper/Root/RecordImage.php
@@ -31,10 +31,10 @@
 
 namespace Finna\View\Helper\Root;
 
+use Finna\RecordDriver\RenderContext;
 use Laminas\View\Helper\Url;
 
 use function func_get_args;
-use function in_array;
 
 /**
  * Header view helper
@@ -343,6 +343,8 @@ class RecordImage extends \Laminas\View\Helper\AbstractHelper
         $imageToRecord = $extraParams['imageToRecord'] ?? false;
 
         $view = $this->getView();
+        $renderContext = RenderContext::fromView($type);
+        $this->record->getDriver()->tryMethod('setRenderContext', [$renderContext->value]);
         $images = $this->getAllImagesAsCoverLinks(
             $view->layout()->userLang,
             $params,
@@ -351,7 +353,7 @@ class RecordImage extends \Laminas\View\Helper\AbstractHelper
         );
         // Get plausible model data
         if (
-            !in_array($type, ['list', 'list grid'])
+            $renderContext === RenderContext::RECORD
             && $this->record->getDriver()->tryMethod('getModels')
         ) {
             $images = $this->mergeModelDataToImages($images);

--- a/module/FinnaApi/src/FinnaApi/Controller/SearchApiController.php
+++ b/module/FinnaApi/src/FinnaApi/Controller/SearchApiController.php
@@ -56,8 +56,12 @@ class SearchApiController extends \VuFindApi\Controller\SearchApiController
 
         $spec['paths']['/record']['get']['description']
             = $this->getViewRenderer()->render('searchapi/record-description.phtml');
+        $maxImagesInSearch = $this->getConfig()->Content->max_amount_of_images_in_search_context ?? 20;
+        if ($maxImagesInSearch > 0) {
+            $maxImagesInSearch = min($maxImagesInSearch, 20);
+        }
         $spec['paths']['/search']['get']['description']
-            = $this->getViewRenderer()->render('searchapi/search-description.phtml');
+            = $this->getViewRenderer()->render('searchapi/search-description.phtml', compact('maxImagesInSearch'));
         foreach ($spec['paths']['/search']['get']['parameters'] as &$param) {
             if ('facet[]' === $param['name']) {
                 $param['description'] = '';

--- a/module/FinnaApi/src/FinnaApi/Controller/SearchApiController.php
+++ b/module/FinnaApi/src/FinnaApi/Controller/SearchApiController.php
@@ -56,7 +56,7 @@ class SearchApiController extends \VuFindApi\Controller\SearchApiController
 
         $spec['paths']['/record']['get']['description']
             = $this->getViewRenderer()->render('searchapi/record-description.phtml');
-        $maxImagesInSearch = $this->getConfig()->Content->max_amount_of_images_in_search_context ?? 20;
+        $maxImagesInSearch = $this->getConfig()->Content->maxImagesInSearchContext ?? 20;
         if ($maxImagesInSearch > 0) {
             $maxImagesInSearch = min($maxImagesInSearch, 20);
         }

--- a/module/FinnaApi/src/FinnaApi/Controller/SearchApiController.php
+++ b/module/FinnaApi/src/FinnaApi/Controller/SearchApiController.php
@@ -29,6 +29,8 @@
 
 namespace FinnaApi\Controller;
 
+use Finna\RecordDriver\RenderContext;
+
 /**
  * Search API Controller
  *
@@ -70,5 +72,16 @@ class SearchApiController extends \VuFindApi\Controller\SearchApiController
         ksort($spec['components']['schemas']);
 
         return json_encode($spec);
+    }
+
+    /**
+     * Search action
+     *
+     * @return \Laminas\Http\Response
+     */
+    public function searchAction()
+    {
+        $this->recordFormatter->setRecordRenderContext(RenderContext::SEARCH->value);
+        return parent::searchAction();
     }
 }

--- a/module/FinnaApi/src/FinnaApi/Formatter/RecordFormatter.php
+++ b/module/FinnaApi/src/FinnaApi/Formatter/RecordFormatter.php
@@ -30,6 +30,7 @@
 
 namespace FinnaApi\Formatter;
 
+use Finna\RecordDriver\RenderContext;
 use Laminas\View\HelperPluginManager;
 
 use function count;
@@ -55,6 +56,13 @@ class RecordFormatter extends \VuFindApi\Formatter\RecordFormatter
     protected $locale;
 
     /**
+     * Current record render context
+     *
+     * @var RenderContext
+     */
+    protected RenderContext $renderContext = RenderContext::RECORD;
+
+    /**
      * Constructor
      *
      * @param array               $recordFields  Record field definitions
@@ -68,6 +76,18 @@ class RecordFormatter extends \VuFindApi\Formatter\RecordFormatter
     ) {
         parent::__construct($recordFields, $helperManager);
         $this->locale = $locale;
+    }
+
+    /**
+     * Set current record render context
+     *
+     * @param string $context Render context
+     *
+     * @return void
+     */
+    public function setRecordRenderContext(string $context): void
+    {
+        $this->renderContext = RenderContext::tryFrom($context);
     }
 
     /**
@@ -403,5 +423,25 @@ class RecordFormatter extends \VuFindApi\Formatter\RecordFormatter
             $backend = '__primary__';
         }
         return $backend;
+    }
+
+    /**
+     * Format the results.
+     *
+     * @param array $results         Results to process (array of record drivers)
+     * @param array $requestedFields Fields to include in response
+     *
+     * @return array
+     */
+    public function format($results, $requestedFields)
+    {
+        $results = array_map(
+            function ($record) {
+                $record->tryMethod('setRenderContext', [$this->renderContext->value]);
+                return $record;
+            },
+            $results
+        );
+        return parent::format($results, $requestedFields);
     }
 }

--- a/module/FinnaApi/src/FinnaApi/Formatter/RecordFormatter.php
+++ b/module/FinnaApi/src/FinnaApi/Formatter/RecordFormatter.php
@@ -34,6 +34,7 @@ use Finna\RecordDriver\RenderContext;
 use Laminas\View\HelperPluginManager;
 
 use function count;
+use function in_array;
 use function is_array;
 
 /**
@@ -135,6 +136,36 @@ class RecordFormatter extends \VuFindApi\Formatter\RecordFormatter
     }
 
     /**
+     * Get amount of current images rendered if result does not contain all the results.
+     * This result will be added to the search result if any field related to images is being
+     * requested in search context.
+     *
+     * @param \VuFind\RecordDriver\SolrDefault $record Record driver
+     *
+     * @return string
+     */
+    public function getSearchImagesCountNotice($record): string
+    {
+        $imageRenderLimit = $record->tryMethod('getImagesRenderLimit');
+        $translate = $this->helperManager->get('translate');
+        $totalAmountOfImages = $record->tryMethod('getTotalAmountOfImages');
+        if (in_array($imageRenderLimit, [null, -1])) {
+            return '';
+        }
+        if ($imageRenderLimit < $totalAmountOfImages) {
+            return $translate(
+                'component_parts_entries_on_page',
+                [
+                        '_START_' => 1,
+                        '_END_' => $imageRenderLimit,
+                        '_TOTAL_' => $totalAmountOfImages,
+                    ]
+            );
+        }
+        return '';
+    }
+
+    /**
      * Get image rights
      *
      * @param \VuFind\RecordDriver\SolrDefault $record Record driver
@@ -156,32 +187,11 @@ class RecordFormatter extends \VuFindApi\Formatter\RecordFormatter
      */
     protected function getImages($record)
     {
-        $images = [];
-        $imageHelper = $this->helperManager->get('recordImage');
-        $recordHelper = $this->helperManager->get('record');
-        $serverUrlHelper = $this->helperManager->get('serverUrl');
-        for (
-            $i = 0;
-            $i < $recordHelper($record)->getNumOfRecordImages('large', false);
-            $i++
-        ) {
-            $images[] = $serverUrlHelper()
-                . $imageHelper($recordHelper($record))
-                    ->getLargeImage($i, [], false, false);
-        }
-        if (empty($images) && $record->getCleanISBN()) {
-            $url = $imageHelper($recordHelper($record))
-                ->getLargeImage(0, [], true, false);
-            if ($url) {
-                $images[] = $url;
-            }
-        }
-        // Output relative Cover generator urls
-        foreach ($images as &$image) {
-            $parts = parse_url($image);
-            $image = $parts['path'] . '?' . $parts['query'];
-        }
-        return $images;
+        $images = $this->getExtendedImages($record);
+        return array_map(
+            fn ($url) => $url['urls']['large'],
+            $images
+        );
     }
 
     /**
@@ -435,6 +445,14 @@ class RecordFormatter extends \VuFindApi\Formatter\RecordFormatter
      */
     public function format($results, $requestedFields)
     {
+        if (
+            $this->renderContext === RenderContext::SEARCH
+            && isset($this->recordFields['searchImagesCountNotice'])
+            && array_intersect($requestedFields, ['images', 'imagesExtended', 'imageRights'])
+            && !in_array('searchImagesCountNotice', $requestedFields)
+        ) {
+            $requestedFields[] = 'searchImagesCountNotice';
+        }
         $results = array_map(
             function ($record) {
                 $record->tryMethod('setRenderContext', [$this->renderContext->value]);

--- a/themes/finna2/js/finna-image-paginator.js
+++ b/themes/finna2/js/finna-image-paginator.js
@@ -508,13 +508,16 @@ FinnaPaginator.prototype.setButtons = function setButtons() {
 FinnaPaginator.prototype.setPagerInfo = function setPagerInfo() {
   var _ = this;
   var imageIndex = +_.openImageIndex + 1;
-  var advanced = translations.image + ' ' + imageIndex + ' / ' + _.images.length;
-  var plain = imageIndex + ' / ' + _.images.length;
+  let imageOfImages = `${imageIndex} - ${_.images.length}`;
+  if (_.images.length < _.settings.totalImagesCount) {
+    imageOfImages += ` / ${_.settings.totalImagesCount}`;
+  }
+  var advanced = `${translations.image} ${imageOfImages}`;
 
   if (_.popup.pagerInfo) {
     _.popup.pagerInfo.find('.image-index').html(advanced);
   }
-  _.pagerInfo.find('.image-index').html(plain);
+  _.pagerInfo.find('.image-index').html(imageOfImages);
 };
 
 /**

--- a/themes/finna2/js/finna-image-paginator.js
+++ b/themes/finna2/js/finna-image-paginator.js
@@ -64,6 +64,11 @@ function FinnaPaginator(element, images, settings) {
   _.onDocumentLoadCallbacks = [];
   _.openImageIndex = 0;
   _.imagePopup = $(imageElement).clone();
+  // Prevent toggletip click event from propagating to other elements.
+  _.root.find('.finna-toggletip .partial-images').on('click', (e) => {
+    e.stopPropagation();
+    e.preventDefault();
+  });
   _.init();
 }
 

--- a/themes/finna2/scss/finna/image-popup.scss
+++ b/themes/finna2/scss/finna/image-popup.scss
@@ -598,10 +598,8 @@
             top: 0px;
             color: black;
             z-index: 6;
-            .image-index {
-                background-color: #efefefcc;
-                padding: 2px;
-            }
+            background-color: #efefefcc;
+            padding: 2px;
         }
         .iconlabel {
             display: none;

--- a/themes/finna2/templates/RecordDriver/DefaultRecord/record-image-paginator.phtml
+++ b/themes/finna2/templates/RecordDriver/DefaultRecord/record-image-paginator.phtml
@@ -50,7 +50,16 @@
   <button class="next-image left" type="button"><?=$this->icon('image-previous') ?><span class="visually-hidden"><?= $this->transEsc('previous_image') ?></span></button>
   <a class="image-popup-trigger init" draggable="false" href="<?=$this->escapeHtmlAttr($this->recordLinker()->getUrl($this->driver)) ?>" data-images="<?=htmlspecialchars(json_encode($images ?? []), ENT_QUOTES, 'UTF-8');?>" data-settings="<?=htmlspecialchars(json_encode($settings ?? []), ENT_QUOTES, 'UTF-8');?>" tabindex="-1">
     <div class="iconlabel format-<?=$this->record($this->driver)->getFormatClass(end($formats))?>"></div>
-    <div class="paginator-info"><span class="image-index"></span></div>
+    <div class="paginator-info">
+      <span class="image-index"></span>
+      <?php if ($this->driver->tryMethod('maxAmountOfImages')): ?>
+        <?=$this->component('finna-toggletip', [
+          'icon' => 'help',
+          'contentHtml' => $this->translate('Displaying the top') . ' ' . count($images),
+          'class' => 'partial-images',
+        ]);?>
+      <?php endif; ?>
+    </div>
     <img src="<?=$this->imageSrc()->getDataPixel()?>" data-src="<?=$this->url('cover-unavailable')?>" class="recordcover<?= ($images[0]['pdf'] ?? false) ? ' pdf-cover' : ''?>" alt="<?=$this->transEsc('No Cover Image')?>">
   </a>
   <span class="hidden-trigger" hidden></span>

--- a/themes/finna2/templates/RecordDriver/DefaultRecord/record-image-paginator.phtml
+++ b/themes/finna2/templates/RecordDriver/DefaultRecord/record-image-paginator.phtml
@@ -27,6 +27,8 @@
 <?php endif; ?>
 
 <?php
+  $renderedImagesCount = count($images);
+  $totalImagesCount = $this->driver->tryMethod('getTotalAmountOfImages') ?? $renderedImagesCount;
   $settings = [
     'recordId' => $this->driver->getUniqueId(),
     'recordType' => $this->driver->tryMethod('getRecordFormat'),
@@ -38,6 +40,7 @@
     'recordCovers' => 'recordcovers',
     'displayIcon' => $displayIcon,
     'triggerClick' => $this->imageClick ?? 'modal',
+    'totalImagesCount' => $totalImagesCount,
   ];
   if ($this->driver->tryMethod('getModels')) {
     $modelSettings = $this->driver->tryMethod('getModelSettings', [], []);
@@ -52,10 +55,10 @@
     <div class="iconlabel format-<?=$this->record($this->driver)->getFormatClass(end($formats))?>"></div>
     <div class="paginator-info">
       <span class="image-index"></span>
-      <?php if ($this->driver->tryMethod('maxAmountOfImages')): ?>
+      <?php if ($renderedImagesCount < $totalImagesCount): ?>
         <?=$this->component('finna-toggletip', [
           'icon' => 'help',
-          'contentHtml' => $this->translate('Displaying the top') . ' ' . count($images),
+          'contentHtml' => $this->translate('showing_results_of_html', ['%%start%%' => 1, '%%end%%' => $renderedImagesCount, '%%total%%' => $totalImagesCount]),
           'class' => 'partial-images',
         ]);?>
       <?php endif; ?>

--- a/themes/finna2/templates/RecordDriver/DefaultRecord/record-image-paginator.phtml
+++ b/themes/finna2/templates/RecordDriver/DefaultRecord/record-image-paginator.phtml
@@ -53,7 +53,7 @@
   <button class="next-image left" type="button"><?=$this->icon('image-previous') ?><span class="visually-hidden"><?= $this->transEsc('previous_image') ?></span></button>
   <a class="image-popup-trigger init" draggable="false" href="<?=$this->escapeHtmlAttr($this->recordLinker()->getUrl($this->driver)) ?>" data-images="<?=htmlspecialchars(json_encode($images ?? []), ENT_QUOTES, 'UTF-8');?>" data-settings="<?=htmlspecialchars(json_encode($settings ?? []), ENT_QUOTES, 'UTF-8');?>" tabindex="-1">
     <div class="iconlabel format-<?=$this->record($this->driver)->getFormatClass(end($formats))?>"></div>
-    <div class="paginator-info">
+    <div class="paginator-info d-flex align-items-center">
       <span class="image-index"></span>
       <?php if ($renderedImagesCount < $totalImagesCount): ?>
         <?=$this->component('finna-toggletip', [

--- a/themes/finna2/templates/searchapi/search-description.phtml
+++ b/themes/finna2/templates/searchapi/search-description.phtml
@@ -7,6 +7,6 @@ See https://www.kiwi.fi/display/Finna/Finna+API+Terms+of+Use for Finna API Terms
 
 Notes:
   - The CC0 metadata licence does not pertain to the resources linked to the metadata, such as images relating to the entries.
-  - Only first 20 images are displayed per record when using the search API.
+  - Only first 20 images are returned per record when using the search API.
 
 See https://www.kiwi.fi/pages/viewpage.action?pageId=53839221 for more information and examples.

--- a/themes/finna2/templates/searchapi/search-description.phtml
+++ b/themes/finna2/templates/searchapi/search-description.phtml
@@ -5,6 +5,8 @@ The URL syntax here is the same as the one used in Finna user interface. It is p
 
 See https://www.kiwi.fi/display/Finna/Finna+API+Terms+of+Use for Finna API Terms of Use.
 
-Note: The CC0 metadata licence does not pertain to the resources linked to the metadata, such as images relating to the entries.
+Notes:
+  - The CC0 metadata licence does not pertain to the resources linked to the metadata, such as images relating to the entries.
+  - Only first 20 images are displayed per record when using the search API.
 
 See https://www.kiwi.fi/pages/viewpage.action?pageId=53839221 for more information and examples.

--- a/themes/finna2/templates/searchapi/search-description.phtml
+++ b/themes/finna2/templates/searchapi/search-description.phtml
@@ -7,6 +7,6 @@ See https://www.kiwi.fi/display/Finna/Finna+API+Terms+of+Use for Finna API Terms
 
 Notes:
   - The CC0 metadata licence does not pertain to the resources linked to the metadata, such as images relating to the entries.
-  - Only first 20 images are returned per record when using the search API.
+  - Only first <?=$this->maxImagesInSearch?> images are returned per record when using the search API.
 
 See https://www.kiwi.fi/pages/viewpage.action?pageId=53839221 for more information and examples.


### PR DESCRIPTION
Adds an enum to keep track of current render context.

- Adds a toggletip showing displaying first n in the search results. Does not affect record context.
- Adjusts paginator-info to show 1 - 20 / 123
- Adds a note to search API about displaying only n first images.
- New configuration: config.ini->Content->max_amount_of_images_in_search_results, hard max limit is 20.
- New API field: searchImagesCountNotice. Contains information about current amount of images being returned when using search API. Will be added to requested fields if not requested and request contains image specific fields.