### PR TITLE
[FINNA-3151] IIIF tweaks

### DIFF
--- a/local/config/finna/config.ini.sample
+++ b/local/config/finna/config.ini.sample
@@ -1949,6 +1949,6 @@ externalViewers[] = "Mirador|https://projectmirador.org/embed/?iiif-content={man
 externalViewers[] = "Universal Viewer|https://uv-v4.netlify.app/#?manifest={manifest}"
 
 ; Origins to be listed in Access-Control-Allow-Origin headers in the
-; RecordController IIIFManifest action. Recommended to allow all origins for
-; general IIIF use
-;manifestCORS[] = "*"
+; RecordController IIIFManifest action. Use "*" for general use, or site URL
+; to restrict to local
+manifestCORS[] = "*"

--- a/local/config/finna/config.ini.sample
+++ b/local/config/finna/config.ini.sample
@@ -1951,4 +1951,4 @@ externalViewers[] = "Universal Viewer|https://uv-v4.netlify.app/#?manifest={mani
 ; Origins to be listed in Access-Control-Allow-Origin headers in the
 ; RecordController IIIFManifest action. Use "*" for general use, or site URL
 ; to restrict to local
-manifestCORS[] = "*"
+;manifestCORS[] = "*"

--- a/local/config/vufind/contentsecuritypolicy.ini.sample
+++ b/local/config/vufind/contentsecuritypolicy.ini.sample
@@ -35,6 +35,9 @@ merge_array_settings = true
 ;script-src[] = "'unsafe-inline'"
 ;script-src[] = "'unsafe-eval'"
 
+; IIIF
+;connect-src[] = "https://digi.kansalliskirjasto.fi/"
+
 ; Kirjastokartta:
 ;connect-src[] = "https://kirjastokartta.kansalliskirjasto.fi"
 ;frame-src[] = "https://kirjastokartta.kansalliskirjasto.fi"

--- a/themes/finna2/scss/finna/iiif.scss
+++ b/themes/finna2/scss/finna/iiif.scss
@@ -86,8 +86,6 @@
 }
 
 .iiif-menu-button-badge {
-    @extend .btn, .btn-secondary;
-
     min-width: 22pt;
     min-height: 22pt;
     max-height: 33%;

--- a/themes/finna2/templates/RecordDriver/DefaultRecord/record-image-paginator.phtml
+++ b/themes/finna2/templates/RecordDriver/DefaultRecord/record-image-paginator.phtml
@@ -91,17 +91,9 @@
     <img src="<?=$this->imageSrc()->getDataPixel()?>" data-src="<?=$this->url('cover-unavailable')?>" class="recordcover<?= ($images[0]['pdf'] ?? false) ? ' pdf-cover' : ''?>" alt="<?=$this->transEsc('No Cover Image')?>">
   </a>
   <?php if ($manifests): ?>
-    <button type="button"
-            class="badge text-bg-light position-absolute bottom-0 end-0 icon-link iiif-menu-button-badge"
-            data-bs-toggle="dropdown"
-            aria-expanded="false">
-        <img src="<?=$this->escapeHtmlAttr($iiifLogo)?>"
-            alt="IIIF"
-            class="bi">
-    </button>
-    <?=$this->component('finna-iiif-menu',
-                        ['manifestUrls' => $manifests,
-                        'uniqueID' => md5($settings['recordId'])]);?>
+    <span class="badge text-bg-light position-absolute bottom-0 end-0 iiif-menu-button-badge">
+        <img src="<?=$this->escapeHtmlAttr($iiifLogo)?>" alt="IIIF" class="bi">
+    </span>
   <?php endif ?>
   <span class="hidden-trigger" hidden></span>
   <button class="next-image right" type="button"><?=$this->icon('image-next') ?><span class="visually-hidden"><?= $this->transEsc('next_image') ?></span></button>

--- a/themes/finna2/templates/_ui/components/finna-iiif-viewer.phtml
+++ b/themes/finna2/templates/_ui/components/finna-iiif-viewer.phtml
@@ -43,9 +43,9 @@ $tifyConfig = json_encode([
 ]);
 
 $js = <<<JS
-  import Tify from $tifyJsPath;
-  new Tify($tifyConfig);
-  JS;
+    import Tify from $tifyJsPath;
+    new Tify($tifyConfig);
+    JS;
 
 echo $this->assetManager()->outputInlineScriptString($js, ['type' => 'module']);
 ?>

--- a/themes/finna2/templates/_ui/components/finna-iiif-viewer.phtml
+++ b/themes/finna2/templates/_ui/components/finna-iiif-viewer.phtml
@@ -10,7 +10,7 @@ $iiifLogo = $this->imageSrc()->getSourceAddress('iiif_logo.min', allowParentThem
 <div class="record-viewer-container container">
   <div class="tify" id="tify"></div>
 
-  <footer class="record-iiif-toolbar container">
+  <div class="record-iiif-toolbar container">
     <span class="record-iiif-functions dropdown hstack gap-3">
       <button type="button"
         class="btn btn-outline-primary p-2 ms-auto icon-link"
@@ -27,7 +27,7 @@ $iiifLogo = $this->imageSrc()->getSourceAddress('iiif_logo.min', allowParentThem
       ['manifestUrls' => $this->manifestUrls, 'alignRight' => true]
       );?>
     </span>
-  </footer>
+  </div>
 </div>
 
 <?php

--- a/themes/finna2/templates/_ui/components/finna-iiif-viewer.phtml
+++ b/themes/finna2/templates/_ui/components/finna-iiif-viewer.phtml
@@ -8,44 +8,44 @@ $iiifLogo = $this->imageSrc()->getSourceAddress('iiif_logo.min');
 ?>
 
 <div class="record-viewer-container container">
-    <div class="tify" id="tify"></div>
-</div>
+  <div class="tify" id="tify"></div>
 
-<div class="record-iiif-toolbar container">
-  <span class="record-iiif-functions dropdown hstack gap-3">
-    <button type="button"
-            class="btn btn-outline-primary p-2 ms-auto icon-link"
-            data-bs-toggle="dropdown"
-            aria-expanded="false">
+  <footer class="record-iiif-toolbar container">
+    <span class="record-iiif-functions dropdown hstack gap-3">
+      <button type="button"
+        class="btn btn-outline-primary p-2 ms-auto icon-link"
+        data-bs-toggle="dropdown"
+        aria-expanded="false">
       <img src="<?=$this->escapeHtmlAttr($iiifLogo)?>"
-           alt="IIIF"
-           class="bi icon-link__icon">
+        alt="IIIF"
+        class="bi icon-link__icon">
       <span class="icon-link__label"><?=$this->transEsc('iiif_tools')?></span>
       <?=$this->icon('dropdown-open')?>
-    </button>
-    <?=$this->component(
+      </button>
+      <?=$this->component(
       'finna-iiif-menu',
       ['manifestUrls' => $this->manifestUrls, 'alignRight' => true]
-    );?>
-  </span>
+      );?>
+    </span>
+  </footer>
 </div>
 
 <?php
 $tifyJsPath = json_encode($this->scriptSrc('vendor/tify/tify.min.js'));
 $tifyConfig = json_encode([
-    'container' => '#tify',
-    'manifestUrl' => $this->manifestUrls[0]['url'],
-    'language' => substr($this->layout()->userLang, 0, 2) ?? 'fi',
-    // Default colorMode is "auto" which autodetects the browser preference.
-    // Finna does not currently support dark modes, so we must force "light" to
-    // prevent mismatching colors.
-    'colorMode' => 'light',
+  'container' => '#tify',
+  'manifestUrl' => $this->manifestUrls[0]['url'],
+  'language' => substr($this->layout()->userLang, 0, 2) ?? 'fi',
+  // Default colorMode is "auto" which autodetects the browser preference.
+  // Finna does not currently support dark modes, so we must force "light" to
+  // prevent mismatching colors.
+  'colorMode' => 'light',
 ]);
 
 $js = <<<JS
-    import Tify from $tifyJsPath;
-    new Tify($tifyConfig);
-    JS;
+  import Tify from $tifyJsPath;
+  new Tify($tifyConfig);
+  JS;
 
 echo $this->assetManager()->outputInlineScriptString($js, ['type' => 'module']);
 ?>

--- a/themes/finna2/templates/_ui/components/finna-iiif-viewer.phtml
+++ b/themes/finna2/templates/_ui/components/finna-iiif-viewer.phtml
@@ -4,7 +4,7 @@
  *
  * @param array    manifestUrls   URLs of IIIF manifests to load
  */
-$iiifLogo = $this->imageSrc()->getSourceAddress('iiif_logo.min');
+$iiifLogo = $this->imageSrc()->getSourceAddress('iiif_logo.min', allowParentThemes: true);
 ?>
 
 <div class="record-viewer-container container">

--- a/themes/finna2/templates/_ui/components/finna-iiif-viewer.phtml
+++ b/themes/finna2/templates/_ui/components/finna-iiif-viewer.phtml
@@ -15,16 +15,18 @@ $iiifLogo = $this->imageSrc()->getSourceAddress('iiif_logo.min', allowParentThem
       <button type="button"
         class="btn btn-outline-primary p-2 ms-auto icon-link"
         data-bs-toggle="dropdown"
-        aria-expanded="false">
-      <img src="<?=$this->escapeHtmlAttr($iiifLogo)?>"
-        alt="IIIF"
-        class="bi icon-link__icon">
-      <span class="icon-link__label"><?=$this->transEsc('iiif_tools')?></span>
-      <?=$this->icon('dropdown-open')?>
+        aria-expanded="false"
+      >
+        <img src="<?=$this->escapeHtmlAttr($iiifLogo)?>"
+             alt="IIIF"
+             class="bi icon-link__icon"
+        >
+        <span class="icon-link__label"><?=$this->transEsc('iiif_tools')?></span>
+        <?=$this->icon('dropdown-open')?>
       </button>
       <?=$this->component(
-      'finna-iiif-menu',
-      ['manifestUrls' => $this->manifestUrls, 'alignRight' => true]
+        'finna-iiif-menu',
+        ['manifestUrls' => $this->manifestUrls, 'alignRight' => true]
       );?>
     </span>
   </div>


### PR DESCRIPTION
* Revert FINNA-4110: leave IIIF badge on thumbnails in search results, but remove the button and drop-down behaviour
  * This was deemed "too much" and potentially confusing for users in an internal workshop
  * Can be revisited later
* Improve semantic HTML
* Nicer indentation in template component
* Fix $iiifLogo in child themes