### PR TITLE
[FINNA-3869] Fix IIIF badge size in Chrome/Firefox

### DIFF
--- a/themes/finna2/scss/finna/iiif.scss
+++ b/themes/finna2/scss/finna/iiif.scss
@@ -86,10 +86,7 @@
 }
 
 .iiif-menu-button-badge {
-    min-width: 22pt;
-    min-height: 22pt;
-    max-height: 33%;
-    max-width: 33%;
+    width: 2em;
     border: none;
     border-radius: 0;
     border-start-start-radius: $finna-button-radius;


### PR DESCRIPTION
Chrome was preferring the max-width, while Firefox was applying some other algorithm. A static size makes both behave the same.