### PR TITLE
[FINNA-4295] Disable IIIF viewer for collection records

### DIFF
--- a/module/Finna/src/Finna/RecordDriver/SolrMarc.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrMarc.php
@@ -177,6 +177,12 @@ class SolrMarc extends \VuFind\RecordDriver\SolrMarc implements \Psr\Log\LoggerA
      */
     public function getIiifManifests(): array
     {
+        // FINNA-4295: Temporarily disable all collection manifests until such
+        // time that we have resolved some UX issues
+        if (in_array('1/Other/Collection/', $this->getFormats())) {
+            return [];
+        }
+
         $reader = $this->getMarcReader();
         $field856 = $reader->getFields('856', ['q', 'u']);
         $manifests = [];

--- a/module/Finna/src/Finna/View/Helper/Root/Record.php
+++ b/module/Finna/src/Finna/View/Helper/Root/Record.php
@@ -1561,4 +1561,22 @@ class Record extends \VuFind\View\Helper\Root\Record
         }
         return parent::getListNotes($list_id, $user_id);
     }
+
+    /**
+     * Returns true if this record is a collection record
+     *
+     * NOTE: This would be cleaner with array_any(), but it is not available
+     * before PHP 8.4.
+     *
+     * @return bool
+     */
+    public function isCollectionRecord(): bool
+    {
+        foreach ($this->getDriver()->getFormats() as $fmt) {
+            if ($fmt->__toString() == '1/Other/Collection/') {
+                return true;
+            }
+        }
+        return false;
+    }
 }

--- a/themes/finna2/templates/RecordDriver/DefaultRecord/core.phtml
+++ b/themes/finna2/templates/RecordDriver/DefaultRecord/core.phtml
@@ -57,7 +57,7 @@
   $img = $this->recordImage($this->record($this->driver));
 
   $thumbnail = false;
-  if (!$iiifManifests):
+  if (!$iiifManifests || $this->record($this->driver)->isCollectionRecord()):
     $thumbnailAlignment = $this->record($this->driver)->getThumbnailAlignment('result');
     ob_start(); ?>
     <div class="media-<?=$thumbnailAlignment ?><?=!empty($audioUrls) ? ' audio' : ''?>">

--- a/themes/finna2/templates/record/view.phtml
+++ b/themes/finna2/templates/record/view.phtml
@@ -114,9 +114,13 @@
         <div class="inline-video" id="inline-video"></div>
         <?=$this->record($this->driver)->renderTemplate('record-video-player.phtml', ['videoUrls' => $videoUrls, 'inlineVideo' => true]);?>
       </div>
-    <?php endif; ?>
-  <?php endif; ?>
-  <?php if ($iiifManifests = $this->driver->tryMethod('getIiifManifests')):
+    <?php endif;
+  endif;
+
+  if (
+      $iiifManifests = $this->driver->tryMethod('getIiifManifests') &&
+      !$this->record($this->driver)->isCollectionRecord()
+    ):
       echo $this->record($this->driver)->renderTemplate(
           'record-iiif-viewer.phtml',
           ['manifests' => $iiifManifests]


### PR DESCRIPTION
There was some good feedback pointing out that collection records were not displayed optimally in TIFY (at least with the currently available manifests). This change selectively reverts to pre-IIIF behaviour only for collection records.