### PR TITLE
Fix RecordDataFormatter skipGroup option

### DIFF
--- a/module/Finna/src/Finna/View/Helper/Root/RecordDataFormatter.php
+++ b/module/Finna/src/Finna/View/Helper/Root/RecordDataFormatter.php
@@ -689,7 +689,7 @@ class RecordDataFormatter extends \VuFind\View\Helper\Root\RecordDataFormatter
         // Apply the group spec.
         $result = [];
         foreach ($groups as $group) {
-            if (!empty($group['skipGroup'])) {
+            if (!empty($group['options']['skipGroup'])) {
                 continue;
             }
             $lines = $group['lines'];


### PR DESCRIPTION
Tätä on toistaiseksi käytetty vain AipaLrmi:ssä. Nyt näyttää rajapinnan virhetilanteessa ylimääräiset kentät sisältävän ryhmän vaikka ei pitäisi.