### PR TITLE
Fix downloadModelAction: explicit null check

### DIFF
--- a/module/Finna/src/Finna/Controller/RecordController.php
+++ b/module/Finna/src/Finna/Controller/RecordController.php
@@ -711,7 +711,7 @@ class RecordController extends \VuFind\Controller\RecordController implements Lo
         $index = $params->fromQuery('index');
         $format = $params->fromQuery('format');
         $response = $this->getResponse();
-        if ($format && $index) {
+        if (null !== $format && null !== $index) {
             $driver = $this->loadRecord();
             $id = $driver->getUniqueID();
             $models = $driver->tryMethod('getModels')[$index]['models'] ?? [];


### PR DESCRIPTION
Here, a value of "0" for $index was being coerced to false, making this if expression always evaluate to false, always returning 400 bad request.