### PR TITLE
Rewrite downloadModelAction()

### DIFF
--- a/module/Finna/src/Finna/Controller/RecordController.php
+++ b/module/Finna/src/Finna/Controller/RecordController.php
@@ -710,60 +710,57 @@ class RecordController extends \VuFind\Controller\RecordController implements Lo
         $params = $this->params();
         $index = $params->fromQuery('index');
         $format = $params->fromQuery('format');
-        $response = $this->getResponse();
-        if (null !== $format && null !== $index) {
-            $driver = $this->loadRecord();
-            $id = $driver->getUniqueID();
-            $models = $driver->tryMethod('getModels')[$index]['models'] ?? [];
-            $found = array_search('preview', array_column($models, 'type'));
-            if (false === $found) {
-                $response->setStatusCode(404);
-                return $response;
-            }
-            // Always force preview model to be fetched
-            $url = $models[$found]['url'];
-            if (!empty($url)) {
-                $fileName = urlencode($id) . '-' . $index . '.' . $format;
-                $fileLoader = $this->serviceLocator->get(\Finna\File\Loader::class);
-                $file = $fileLoader->getFile(
-                    $url,
-                    $fileName,
-                    'Models',
-                    'public'
-                );
-                if (empty($file['result'])) {
-                    $response->setStatusCode(500);
-                } else {
-                    $contentType = '';
-                    switch ($format) {
-                        case 'gltf':
-                            $contentType = 'model/gltf+json';
-                            break;
-                        case 'glb':
-                            $contentType = 'model/gltf+binary';
-                            break;
-                        default:
-                            $contentType = 'application/octet-stream';
-                            break;
-                    }
-                    // Set headers for downloadable file
-                    header("Content-Type: $contentType");
-                    header(
-                        "Content-disposition: attachment; filename=\"{$fileName}\""
-                    );
-                    header('Pragma: public');
-                    header('Content-Length: ' . filesize($file['path']));
-                    if (ob_get_level()) {
-                        ob_end_clean();
-                    }
-                    readfile($file['path']);
-                }
-            } else {
-                $response->setStatusCode(404);
-            }
-        } else {
+        $response = new \Laminas\Http\Response\Stream();
+        if (null === $format || null === $index) {
             $response->setStatusCode(400);
+            return $response;
         }
+        $driver = $this->loadRecord();
+        $models = $driver->tryMethod('getModels')[$index]['models'] ?? [];
+        $found = array_search('preview', array_column($models, 'type'));
+        if (false === $found) {
+            $response->setStatusCode(404);
+            return $response;
+        }
+        // Always force preview model to be fetched
+        $url = $models[$found]['url'];
+        if (empty($url)) {
+            $response->setStatusCode(404);
+            return $response;
+        }
+        $id = $driver->getUniqueID();
+        $fileName = urlencode($id) . '-' . $index . '.' . $format;
+        $fileLoader = $this->serviceLocator->get(\Finna\File\Loader::class);
+        $file = $fileLoader->getFile(
+            $url,
+            $fileName,
+            'Models',
+            'public'
+        );
+        if (empty($file['result'])) {
+            $response->setStatusCode(500);
+            return $response;
+        }
+        $contentType = match ($format) {
+            'gltf' => 'model/gltf+json',
+            'glb' => 'model/gltf+binary',
+            default => 'application/octet-stream'
+        };
+        // Set headers for downloadable file
+        $headers = $response->getHeaders();
+        $headers->addHeaderLine('Content-Type', $contentType);
+        $headers->addHeaderLine(
+            'Content-Disposition',
+            "attachment; filename=\"{$fileName}\""
+        );
+        $headers->addHeaderLine(
+            'Cache-Control',
+            'public, s-maxage=' . (string)(24 * 60 * 60)
+        );
+        $headers->addHeaderLine('Content-Length', filesize($file['path']));
+
+        $stream = fopen($file['path'], 'r');
+        $response->setStream($stream);
 
         return $response;
     }


### PR DESCRIPTION
* Use Laminas\Http\Response\Stream to return the file contents
* Simplify flow control with early returns
* Use Laminas framework methods to set response headers
* Change deprecated Pragma header to Cache-Control

Could still benefit from ETag, but at that point it would probably be better to harness the wider Finna caching functionality.