### PR TITLE
[FINNA-3933] Fix image/model handling in LIDO records and helper.

### DIFF
--- a/module/Finna/src/Finna/RecordDriver/SolrLido.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrLido.php
@@ -413,7 +413,9 @@ class SolrLido extends \VuFind\RecordDriver\SolrDefault implements \Psr\Log\Logg
     {
         $language ??= $this->getTranslatorLocale();
         $representations = $this->getRepresentations($language);
-        return array_values(array_filter(array_column($representations, 'images')));
+        // Note: Do not reindex the results e.g. with array_values, the keys are important! See FINNA-3933 and
+        // RecordImage::mergeModelDataToImages.
+        return array_filter(array_column($representations, 'images'));
     }
 
     /**
@@ -473,9 +475,9 @@ class SolrLido extends \VuFind\RecordDriver\SolrDefault implements \Psr\Log\Logg
     {
         $language = $this->getTranslatorLocale();
         $representations = $this->getRepresentations($language);
-        return array_values(
-            array_filter(array_column($representations, 'models'))
-        );
+        // Note: Do not reindex the results e.g. with array_values, the keys are important! See FINNA-3933 and
+        // RecordImage::mergeModelDataToImages.
+        return array_filter(array_column($representations, 'models'));
     }
 
     /**

--- a/module/Finna/src/Finna/View/Helper/Root/RecordImage.php
+++ b/module/Finna/src/Finna/View/Helper/Root/RecordImage.php
@@ -451,6 +451,8 @@ class RecordImage extends \Laminas\View\Helper\AbstractHelper
             }
             $images[$ind]['type'] = 'model';
         }
+        // Sort the array to ensure correct order:
+        ksort($images);
         return $images;
     }
 

--- a/module/Finna/src/Finna/View/Helper/Root/RecordImage.php
+++ b/module/Finna/src/Finna/View/Helper/Root/RecordImage.php
@@ -362,6 +362,10 @@ class RecordImage extends \Laminas\View\Helper\AbstractHelper
             // Limit combined results to a single image
             $images = [reset($images)];
         }
+
+        // Ensure that the array is a list so that image paginator can handle it properly:
+        $images = array_values($images);
+
         $context = [
             'type' => $type,
             'images' => $images,

--- a/module/Finna/tests/unit-tests/src/FinnaTest/RecordDriver/SolrLidoTest.php
+++ b/module/Finna/tests/unit-tests/src/FinnaTest/RecordDriver/SolrLidoTest.php
@@ -56,7 +56,7 @@ class SolrLidoTest extends \PHPUnit\Framework\TestCase
         yield 'getModels method' => [
             'getModels',
             [
-                [
+                2 => [
                     'models' => [
                         [
                             'url' => 'https://gltfmalli.gltf',
@@ -88,7 +88,7 @@ class SolrLidoTest extends \PHPUnit\Framework\TestCase
         yield 'getAllImages method' => [
             'getAllImages',
             [
-                [
+                0 => [
                     'urls' => [
                         'large' => 'https://largekuvanlinkki.com',
                         'small' => 'https://largekuvanlinkki.com',
@@ -139,7 +139,7 @@ class SolrLidoTest extends \PHPUnit\Framework\TestCase
                         'medium' => 'large',
                     ],
                 ],
-                [
+                1 => [
                     'urls' => [
                         'large' => 'https://largekuvanlinkki2.com',
                         'small' => 'https://thumbkuvanlinkki2.com',
@@ -200,7 +200,7 @@ class SolrLidoTest extends \PHPUnit\Framework\TestCase
                         'Suoristettu',
                     ],
                 ],
-                2 => [
+                7 => [
                     'urls' => [
                         'large' => 'https://kaikkilinkit.com',
                         'small' => 'https://kaikkilinkit.com',


### PR DESCRIPTION
This is a partial fix to model handling that fixes the record page. Some issues with the image popup remain.