### PR TITLE
[FINNA-4472] Fix IIIF badge in grid view

### DIFF
--- a/themes/finna2/scss/finna/iiif.scss
+++ b/themes/finna2/scss/finna/iiif.scss
@@ -89,6 +89,7 @@
 }
 
 .iiif-menu-button-badge {
+    @extend .badge, .position-absolute, .bottom-0, .end-0;
     width: 2em;
     border: none;
     border-radius: 0;
@@ -100,18 +101,12 @@
         height: 98%;
     }
 
-    @include media-breakpoint-down(md) {
-        position: relative;
-        width: 100%;
-        max-width: 100%;
-        border-radius: $finna-button-radius;
+    @include media-breakpoint-only(md) {
+        right: 1.5em;
+    }
 
-        img.bi {
-            margin-left: auto;
-            margin-right: auto;
-            width: 27.5%;
-            height: auto;
-        }
+    @include media-breakpoint-only(sm) {
+        right: .5em;
     }
 
     @media print {

--- a/themes/finna2/templates/RecordDriver/DefaultRecord/record-image-paginator.phtml
+++ b/themes/finna2/templates/RecordDriver/DefaultRecord/record-image-paginator.phtml
@@ -91,7 +91,7 @@
     <img src="<?=$this->imageSrc()->getDataPixel()?>" data-src="<?=$this->url('cover-unavailable')?>" class="recordcover<?= ($images[0]['pdf'] ?? false) ? ' pdf-cover' : ''?>" alt="<?=$this->transEsc('No Cover Image')?>">
   </a>
   <?php if ($manifests): ?>
-    <span class="badge text-bg-light position-absolute bottom-0 end-0 iiif-menu-button-badge">
+    <span class="text-bg-light iiif-menu-button-badge">
         <img src="<?=$this->escapeHtmlAttr($iiifLogo)?>" alt="IIIF" class="bi">
     </span>
   <?php endif ?>


### PR DESCRIPTION
* Adjust positioning in certain screen sizes
* Unify appearance in all screen sizes.
  * Previously this badge was a functional button, so we made it larger for mobile to make it usable by touch screen. UX testing led us to remove the button functionality a while ago already, so the badge can consistently be a small visual indicator, simplifying the CSS.