### PR TITLE
Fix undefined variable $selectedTabLabel in search/searchTabs.phtml

### DIFF
--- a/themes/finna2/templates/search/searchTabs.phtml
+++ b/themes/finna2/templates/search/searchTabs.phtml
@@ -3,6 +3,7 @@
   $isManyTabs = (count($searchTabs) > 2);
   $module = $this->layout()->templateDir;
   $hasSelectedTab = false;
+  $selectedTabLabel = 'empty_label';
 ?>
 <?php if (!$isManyTabs): ?>
   <div class="tabs-table">

--- a/themes/finna2/templates/search/searchTabs.phtml
+++ b/themes/finna2/templates/search/searchTabs.phtml
@@ -3,7 +3,7 @@
   $isManyTabs = (count($searchTabs) > 2);
   $module = $this->layout()->templateDir;
   $hasSelectedTab = false;
-  $selectedTabLabel = 'empty_label';
+  $selectedTabLabel = 'default_empty_label';
 ?>
 <?php if (!$isManyTabs): ?>
   <div class="tabs-table">


### PR DESCRIPTION
Initialized with the value default_empty_label to avoid any simple translations to be printed out accidentally.