### PR TITLE
[FINNA-4608] Improvements to IIIF manifest generator

### DIFF
--- a/module/Finna/src/Finna/Record/IIIF/IIIFManifestGenerator.php
+++ b/module/Finna/src/Finna/Record/IIIF/IIIFManifestGenerator.php
@@ -222,12 +222,12 @@ class IIIFManifestGenerator implements HttpServiceAwareInterface, TranslatorAwar
         // See: https://iiif.io/api/presentation/3.0/#45-html-markup-in-property-values
 
         $metadata = [];
-        if (isset($image['description']) && $image['description'] !== '') {
+        if ('' !== ($description = $image['description'] ?? '')) {
             $metadata[] = (object)[
                 'label' => $this->getTranslations('image_description'),
                 'value' => (object)array_fill_keys(
                     $this->metadataLangKeys,
-                    [$image['description'] . ' ']
+                    [$description . ' ']
                 ),
             ];
         }

--- a/module/Finna/src/Finna/Record/IIIF/IIIFManifestGenerator.php
+++ b/module/Finna/src/Finna/Record/IIIF/IIIFManifestGenerator.php
@@ -216,9 +216,8 @@ class IIIFManifestGenerator implements HttpServiceAwareInterface, TranslatorAwar
      */
     protected function createCanvasMetadata(array $image): array
     {
-        // TODO: Currently it is a bit unclear if the 'value' fields should
-        // always be considered HTML text and therefore if we should escape the
-        // contents here.
+        // Metadata 'value' fields are appended with a single whitespace
+        // character to enforce a plain-text interpretation
         //
         // See: https://iiif.io/api/presentation/3.0/#45-html-markup-in-property-values
 
@@ -228,7 +227,7 @@ class IIIFManifestGenerator implements HttpServiceAwareInterface, TranslatorAwar
                 'label' => $this->getTranslations('image_description'),
                 'value' => (object)array_fill_keys(
                     $this->metadataLangKeys,
-                    [$image['description']]
+                    [$image['description'] . ' ']
                 ),
             ];
         }
@@ -238,7 +237,7 @@ class IIIFManifestGenerator implements HttpServiceAwareInterface, TranslatorAwar
                 'label' => $this->getTranslations('image_identifier'),
                 'value' => (object)array_fill_keys(
                     $this->metadataLangKeys,
-                    [$image['identifier']]
+                    [$image['identifier'] . ' ']
                 ),
             ];
         }

--- a/module/Finna/src/Finna/Record/IIIF/IIIFManifestGenerator.php
+++ b/module/Finna/src/Finna/Record/IIIF/IIIFManifestGenerator.php
@@ -172,6 +172,19 @@ class IIIFManifestGenerator implements HttpServiceAwareInterface, TranslatorAwar
                     break; // only take the largest $size
                 }
             }
+
+            $thumbUrl = $this->createBodyId(
+                $recordId,
+                $idx,
+                'small',
+                $source
+            );
+            $canvasItem['thumbnail'] = [(object)[
+                'id' => $thumbUrl,
+                'type' => 'Image',
+                'format' => 'image/jpeg',
+            ]];
+
             $manifestItems[] = (object)$canvasItem;
         }
 
@@ -203,8 +216,14 @@ class IIIFManifestGenerator implements HttpServiceAwareInterface, TranslatorAwar
      */
     protected function createCanvasMetadata(array $image): array
     {
+        // TODO: Currently it is a bit unclear if the 'value' fields should
+        // always be considered HTML text and therefore if we should escape the
+        // contents here.
+        //
+        // See: https://iiif.io/api/presentation/3.0/#45-html-markup-in-property-values
+
         $metadata = [];
-        if (isset($image['description'])) {
+        if (isset($image['description']) && $image['description'] !== '') {
             $metadata[] = (object)[
                 'label' => $this->getTranslations('image_description'),
                 'value' => (object)array_fill_keys(


### PR DESCRIPTION
* Add thumbnail images to canvases
* Omit image descriptions when the 'description' key is present in the image object but the value is an empty string