### PR TITLE
Fix mediatype parsing in SolrFinnaTrait

### DIFF
--- a/module/Finna/src/Finna/RecordDriver/Feature/SolrFinnaTrait.php
+++ b/module/Finna/src/Finna/RecordDriver/Feature/SolrFinnaTrait.php
@@ -1183,7 +1183,7 @@ trait SolrFinnaTrait
         foreach ($urls as $url) {
             if (!empty($url['mediaType'])) {
                 $type = $embed = null;
-                $parts = explode('/', $url['mediaType']);
+                $parts = explode('/', $url['mediaType'], 2);
                 $mediaType = $parts[0];
                 if ($mediaType === 'audio') {
                     $type = $embed = 'audio';


### PR DESCRIPTION
A mediatype's subtype can contain '/' characters, so explode() with a limit of 2.

Previously, a mediatype:

    application/ld+json;profile="http://iiif.io/api/presentation/3/context.json"

resulted in a codec:

    ld+json;profile="http:

This fixes the codec to the correct:

    ld+json;profile="http://iiif.io/api/presentation/3/context.json"