### PR TITLE
FINNA-4288 Fix accessibility Skip-link target position issue on various templates

### DIFF
--- a/themes/finna2/templates/RecordDriver/DefaultRecord/core.phtml
+++ b/themes/finna2/templates/RecordDriver/DefaultRecord/core.phtml
@@ -95,7 +95,7 @@
   <?php if ($thumbnail && $thumbnailAlignment == 'left'): ?>
     <?=$thumbnail ?>
   <?php endif; ?>
-  <div class="media-body record-information">
+  <div id="results-heading" class="media-body record-information">
     <h1 class="record-title hidden-xs"><?=$this->escapeHtml($this->driver->getTitle())?></h1>
     <?php foreach ($this->driver->tryMethod('getFullTitlesAltScript', [], []) as $altTitle): ?>
       <div class="record-title-alt-script">

--- a/themes/finna2/templates/RecordDriver/SolrLido/core.phtml
+++ b/themes/finna2/templates/RecordDriver/SolrLido/core.phtml
@@ -76,7 +76,7 @@
   <?php if ($thumbnail && $thumbnailAlignment == 'left'): ?>
     <?=$thumbnail ?>
   <?php endif; ?>
-    <div class="media-body record-information">
+    <div id="results-heading" class="media-body record-information">
       <h1 class="record-title hidden-xs"><?=$this->escapeHtml($this->driver->getTitle())?></h1>
       <?php if ($results = $this->driver->getAlternativeTitles()): ?>
         <div class="recordAltTitles record-alt-titles">

--- a/themes/finna2/templates/layout/layout.phtml
+++ b/themes/finna2/templates/layout/layout.phtml
@@ -158,14 +158,14 @@
       <span class="visually-hidden"><?=$this->layout()->srmessage ?></span>
     <?php endif; ?>
       <?php
-        $contentElementId = 'results-heading';
+        $contentElementId = 'main';
         if (!empty($this->layout()->finnaUserAccountHeading)) {
           $contentElementId = 'useraccount-content-heading';
         } elseif (!empty($this->layout()->finnaMainHeader)) {
           $contentElementId = 'content-heading';
-        } elseif (!empty($this->layout()->finnaMainTabs)) {
+        } elseif (!empty($this->layout()->finnaMainTabs) || (!empty($this->layout()->finnaBasicView))) {
           $contentElementId = 'results-heading';
-        }
+        } 
       ?>
       <a class="skip-link" href="#<?=$contentElementId?>"><?=$this->transEsc('Skip to content') // skip to content ?></a>
       <?php if (isset($this->layout()->skiplink)): // additional skip links ?>

--- a/themes/finna2/templates/layout/layout.phtml
+++ b/themes/finna2/templates/layout/layout.phtml
@@ -165,8 +165,8 @@
           $contentElementId = 'content-heading';
         } elseif (!empty($this->layout()->finnaMainTabs)) {
           $contentElementId = 'results-heading';
-        } elseif (!empty($this->layout())) {
-          $contentElementId = 'results-heading'; 
+        } elseif (!($this->layout()->finnaMainTabs)) {
+          $contentElementId = 'results-heading';
         } 
       ?>
       <a class="skip-link" href="#<?=$contentElementId?>"><?=$this->transEsc('Skip to content') // skip to content ?></a>

--- a/themes/finna2/templates/layout/layout.phtml
+++ b/themes/finna2/templates/layout/layout.phtml
@@ -165,7 +165,9 @@
           $contentElementId = 'content-heading';
         } elseif (!empty($this->layout()->finnaMainTabs)) {
           $contentElementId = 'results-heading';
-        } else $contentElementId = 'results-heading';
+        } elseif (!empty($this->layout())) {
+          $contentElementId = 'results-heading'; 
+        } 
       ?>
       <a class="skip-link" href="#<?=$contentElementId?>"><?=$this->transEsc('Skip to content') // skip to content ?></a>
       <?php if (isset($this->layout()->skiplink)): // additional skip links ?>

--- a/themes/finna2/templates/layout/layout.phtml
+++ b/themes/finna2/templates/layout/layout.phtml
@@ -163,7 +163,9 @@
           $contentElementId = 'useraccount-content-heading';
         } elseif (!empty($this->layout()->finnaMainHeader)) {
           $contentElementId = 'content-heading';
-        } 
+        } elseif (!empty($this->layout()->finnaMainTabs)) {
+          $contentElementId = 'content-main-tabs';
+        }
       ?>
       <a class="skip-link" href="#<?=$contentElementId?>"><?=$this->transEsc('Skip to content') // skip to content ?></a>
       <?php if (isset($this->layout()->skiplink)): // additional skip links ?>

--- a/themes/finna2/templates/layout/layout.phtml
+++ b/themes/finna2/templates/layout/layout.phtml
@@ -163,9 +163,7 @@
           $contentElementId = 'useraccount-content-heading';
         } elseif (!empty($this->layout()->finnaMainHeader)) {
           $contentElementId = 'content-heading';
-        } elseif (!empty($this->layout()->finnaMainTabs)) {
-          $contentElementId = 'results-heading';
-        } elseif (!($this->layout()->finnaMainTabs)) {
+        } elseif (!empty($this->layout())) {
           $contentElementId = 'results-heading';
         } 
       ?>

--- a/themes/finna2/templates/layout/layout.phtml
+++ b/themes/finna2/templates/layout/layout.phtml
@@ -164,7 +164,7 @@
         } elseif (!empty($this->layout()->finnaMainHeader)) {
           $contentElementId = 'content-heading';
         } elseif (!empty($this->layout()->finnaMainTabs)) {
-          $contentElementId = 'content-main-tabs';
+          $contentElementId = 'results-heading';
         }
       ?>
       <a class="skip-link" href="#<?=$contentElementId?>"><?=$this->transEsc('Skip to content') // skip to content ?></a>

--- a/themes/finna2/templates/layout/layout.phtml
+++ b/themes/finna2/templates/layout/layout.phtml
@@ -163,8 +163,6 @@
           $contentElementId = 'useraccount-content-heading';
         } elseif (!empty($this->layout()->finnaMainHeader)) {
           $contentElementId = 'content-heading';
-        } elseif (!empty($this->layout()->finnaMainTabs)) {
-          $contentElementId = 'results-heading';
         } 
       ?>
       <a class="skip-link" href="#<?=$contentElementId?>"><?=$this->transEsc('Skip to content') // skip to content ?></a>

--- a/themes/finna2/templates/layout/layout.phtml
+++ b/themes/finna2/templates/layout/layout.phtml
@@ -158,12 +158,12 @@
       <span class="visually-hidden"><?=$this->layout()->srmessage ?></span>
     <?php endif; ?>
       <?php
-        $contentElementId = 'main';
+        $contentElementId = 'results-heading';
         if (!empty($this->layout()->finnaUserAccountHeading)) {
           $contentElementId = 'useraccount-content-heading';
         } elseif (!empty($this->layout()->finnaMainHeader)) {
           $contentElementId = 'content-heading';
-        } elseif (!empty($this->layout())) {
+        } elseif (!empty($this->layout()->finnaMainTabs)) {
           $contentElementId = 'results-heading';
         } 
       ?>

--- a/themes/finna2/templates/layout/layout.phtml
+++ b/themes/finna2/templates/layout/layout.phtml
@@ -164,8 +164,8 @@
         } elseif (!empty($this->layout()->finnaMainHeader)) {
           $contentElementId = 'content-heading';
         } elseif (!empty($this->layout()->finnaMainTabs)) {
-          $contentElementId = 'content-main-tabs';
-        }
+          $contentElementId = 'results-heading';
+        } else $contentElementId = 'results-heading';
       ?>
       <a class="skip-link" href="#<?=$contentElementId?>"><?=$this->transEsc('Skip to content') // skip to content ?></a>
       <?php if (isset($this->layout()->skiplink)): // additional skip links ?>

--- a/themes/finna2/templates/record/view.phtml
+++ b/themes/finna2/templates/record/view.phtml
@@ -14,6 +14,9 @@
     $this->headLink()->appendAlternate($this->recordLinker()->getActionUrl($this->driver, 'RDF'), 'application/rdf+xml', 'RDF Representation');
   }
 
+  // Set skip-link address
+  $this->layout()->finnaBasicView = 'results-heading';
+
   // Set up breadcrumbs:
   $this->breadcrumbs()->reset();
   if ($url = $this->searchMemory()->getLastSearchUrl()) {

--- a/themes/finna2/templates/search/home.phtml
+++ b/themes/finna2/templates/search/home.phtml
@@ -30,7 +30,7 @@
 <!-- Create different sections for home page (home-1 - home-10) -->
 <?php for ($i = 1; $i <= 10; $i++): ?>
 <?php if ($template = $this->content()->findTemplateForLng("search/home/home-$i")): ?>
-<div class="container-fluid home-<?=$i; ?>">
+<div id="results-heading" class="container-fluid home-<?=$i; ?>">
   <div class="container">
     <?=$this->render($template)?>
   </div>


### PR DESCRIPTION
These fixes should solve the problem of skip-link incorrect target positions. When user clicks the - Skip to content - link with screenreader, the link must take user to the actual content, not any menu or tab section etc. 