### PR TITLE
FINNA-4288 Fix accessibility Skip-link target position issue on various templates

### DIFF
--- a/themes/finna2/templates/RecordDriver/DefaultRecord/core.phtml
+++ b/themes/finna2/templates/RecordDriver/DefaultRecord/core.phtml
@@ -95,8 +95,9 @@
   <?php if ($thumbnail && $thumbnailAlignment == 'left'): ?>
     <?=$thumbnail ?>
   <?php endif; ?>
-  <div class="media-body record-information">
-    <h1 class="record-title hidden-xs" id="results-heading"><?=$this->escapeHtml($this->driver->getTitle())?></h1>
+  <div class="media-body record-information" id="record-skip-link-target">
+    <div role="heading" aria-level="1" aria-label="<?=$this->escapeHtml($this->driver->getTitle())?>" class="visually-hidden"></div>
+    <h1 class="record-title hidden-xs" id="results-heading" aria-hidden="true"><?=$this->escapeHtml($this->driver->getTitle())?></h1>
     <?php foreach ($this->driver->tryMethod('getFullTitlesAltScript', [], []) as $altTitle): ?>
       <div class="record-title-alt-script">
         <?=$this->escapeHtml($altTitle)?>

--- a/themes/finna2/templates/RecordDriver/DefaultRecord/core.phtml
+++ b/themes/finna2/templates/RecordDriver/DefaultRecord/core.phtml
@@ -95,7 +95,7 @@
   <?php if ($thumbnail && $thumbnailAlignment == 'left'): ?>
     <?=$thumbnail ?>
   <?php endif; ?>
-  <div class="media-body record-information">
+  <div id="results-heading" class="media-body record-information">
     <h1 class="record-title hidden-xs"><?=$this->escapeHtml($this->driver->getTitle())?></h1>
     <?php foreach ($this->driver->tryMethod('getFullTitlesAltScript', [], []) as $altTitle): ?>
       <div class="record-title-alt-script">

--- a/themes/finna2/templates/RecordDriver/DefaultRecord/core.phtml
+++ b/themes/finna2/templates/RecordDriver/DefaultRecord/core.phtml
@@ -95,8 +95,8 @@
   <?php if ($thumbnail && $thumbnailAlignment == 'left'): ?>
     <?=$thumbnail ?>
   <?php endif; ?>
-  <div id="results-heading" class="media-body record-information">
-    <h1 class="record-title hidden-xs"><?=$this->escapeHtml($this->driver->getTitle())?></h1>
+  <div class="media-body record-information">
+    <h1 class="record-title hidden-xs" id="results-heading"><?=$this->escapeHtml($this->driver->getTitle())?></h1>
     <?php foreach ($this->driver->tryMethod('getFullTitlesAltScript', [], []) as $altTitle): ?>
       <div class="record-title-alt-script">
         <?=$this->escapeHtml($altTitle)?>

--- a/themes/finna2/templates/RecordDriver/SolrAipa/core.phtml
+++ b/themes/finna2/templates/RecordDriver/SolrAipa/core.phtml
@@ -52,7 +52,7 @@
     <?=$thumbnail ?>
   <?php endif; ?>
   <div class="media-body record-information">
-      <h1 class="record-title hidden-xs"><?=$this->escapeHtml($this->driver->getTitle())?></h1>
+      <h1 class="record-title hidden-xs" id="results-heading"><?=$this->escapeHtml($this->driver->getTitle())?></h1>
       <?php if ($results = $this->driver->getAlternativeTitles()): ?>
         <div class="recordAltTitles record-alt-titles">
           <?=implode('<br>', array_map([$this, 'escapeHtml'], $results))?>

--- a/themes/finna2/templates/RecordDriver/SolrAipa/core.phtml
+++ b/themes/finna2/templates/RecordDriver/SolrAipa/core.phtml
@@ -51,8 +51,9 @@
   <?php if ($thumbnail && $thumbnailAlignment == 'left'): ?>
     <?=$thumbnail ?>
   <?php endif; ?>
-  <div class="media-body record-information">
-      <h1 class="record-title hidden-xs" id="results-heading"><?=$this->escapeHtml($this->driver->getTitle())?></h1>
+  <div class="media-body record-information" id="record-skip-link-target">
+    <div role="heading" aria-level="1" id="record-skip-link-target" class="visually-hidden" aria-label="<?=$this->escapeHtml($this->driver->getTitle())?>"></div>
+      <h1 class="record-title hidden-xs" id="results-heading" aria-hidden="true"><?=$this->escapeHtml($this->driver->getTitle())?></h1>
       <?php if ($results = $this->driver->getAlternativeTitles()): ?>
         <div class="recordAltTitles record-alt-titles">
           <?=implode('<br>', array_map([$this, 'escapeHtml'], $results))?>

--- a/themes/finna2/templates/RecordDriver/SolrEad/core.phtml
+++ b/themes/finna2/templates/RecordDriver/SolrEad/core.phtml
@@ -51,8 +51,9 @@
   <?php if ($thumbnail && $thumbnailAlignment == 'left'): ?>
     <?=$thumbnail ?>
   <?php endif; ?>
-  <div class="media-body record-information">
-      <h1 class="record-title hidden-xs"><?=$this->escapeHtml($this->driver->getTitle())?></h1>
+  <div class="media-body record-information" id="record-skip-link-target">
+      <div role="heading" aria-level="1" aria-label="<?=$this->escapeHtml($this->driver->getTitle())?>" class="visually-hidden"></div>
+      <h1 class="record-title hidden-xs" aria-hidden="true"><?=$this->escapeHtml($this->driver->getTitle())?></h1>
       <?php if ($results = $this->driver->getAlternativeTitles()): ?>
         <div class="recordAltTitles record-alt-titles">
           <?=implode('<br>', array_map([$this, 'escapeHtml'], $results))?>

--- a/themes/finna2/templates/RecordDriver/SolrEad/core.phtml
+++ b/themes/finna2/templates/RecordDriver/SolrEad/core.phtml
@@ -52,7 +52,7 @@
     <?=$thumbnail ?>
   <?php endif; ?>
   <div class="media-body record-information">
-      <h1 class="record-title hidden-xs" id="results-heading"><?=$this->escapeHtml($this->driver->getTitle())?></h1>
+      <h1 class="record-title hidden-xs"><?=$this->escapeHtml($this->driver->getTitle())?></h1>
       <?php if ($results = $this->driver->getAlternativeTitles()): ?>
         <div class="recordAltTitles record-alt-titles">
           <?=implode('<br>', array_map([$this, 'escapeHtml'], $results))?>

--- a/themes/finna2/templates/RecordDriver/SolrEad/core.phtml
+++ b/themes/finna2/templates/RecordDriver/SolrEad/core.phtml
@@ -52,7 +52,7 @@
     <?=$thumbnail ?>
   <?php endif; ?>
   <div class="media-body record-information">
-      <h1 class="record-title hidden-xs"><?=$this->escapeHtml($this->driver->getTitle())?></h1>
+      <h1 class="record-title hidden-xs" id="results-heading"><?=$this->escapeHtml($this->driver->getTitle())?></h1>
       <?php if ($results = $this->driver->getAlternativeTitles()): ?>
         <div class="recordAltTitles record-alt-titles">
           <?=implode('<br>', array_map([$this, 'escapeHtml'], $results))?>

--- a/themes/finna2/templates/RecordDriver/SolrForward/core.phtml
+++ b/themes/finna2/templates/RecordDriver/SolrForward/core.phtml
@@ -75,7 +75,7 @@
     <?=$thumbnail ?>
   <?php endif; ?>
   <div class="media-body record-information">
-      <h1 class="record-title hidden-xs"><?=$this->escapeHtml($this->driver->getTitle())?></h1>
+      <h1 class="record-title hidden-xs" id="results-heading"><?=$this->escapeHtml($this->driver->getTitle())?></h1>
       <?php if ($altTitles): ?>
         <div class="alt-title-wrapper hidden-xs">
           <?=$altTitlesContent?>

--- a/themes/finna2/templates/RecordDriver/SolrForward/core.phtml
+++ b/themes/finna2/templates/RecordDriver/SolrForward/core.phtml
@@ -74,8 +74,9 @@
   <?php if ($thumbnail && $thumbnailAlignment == 'left'): ?>
     <?=$thumbnail ?>
   <?php endif; ?>
-  <div class="media-body record-information">
-      <h1 class="record-title hidden-xs" id="results-heading"><?=$this->escapeHtml($this->driver->getTitle())?></h1>
+  <div class="media-body record-information" id="record-skip-link-target">
+      <div role="heading" aria-level="1" aria-label="<?=$this->escapeHtml($this->driver->getTitle())?>" class="visually-hidden"></div>
+      <h1 class="record-title hidden-xs" id="results-heading" aria-hidden="true"><?=$this->escapeHtml($this->driver->getTitle())?></h1>
       <?php if ($altTitles): ?>
         <div class="alt-title-wrapper hidden-xs">
           <?=$altTitlesContent?>

--- a/themes/finna2/templates/RecordDriver/SolrLido/core.phtml
+++ b/themes/finna2/templates/RecordDriver/SolrLido/core.phtml
@@ -17,8 +17,6 @@
       }
     }
   }
-  
-  $skipLinkPosition = 'id="results-heading"';
 
   $thumbnail = false;
   $thumbnailAlignment = $this->record($this->driver)->getThumbnailAlignment('result');
@@ -79,8 +77,8 @@
   <?php if ($thumbnail && $thumbnailAlignment == 'left'): ?>
     <?=$thumbnail ?>
   <?php endif; ?>
-    <div class="media-body record-information" <?=$skipLinkPosition ?>>
-      <div role="heading" aria-level="1" aria-label="<?=$this->escapeHtml($this->driver->getTitle())?>" visually-hidden></div>
+    <div class="media-body record-information" id="record-skip-link-target">
+      <div role="heading" aria-level="1" aria-label="<?=$this->escapeHtml($this->driver->getTitle())?>" class="visually-hidden"></div>
       <h1 class="record-title hidden-xs" aria-hidden="true"><?=$this->escapeHtml($this->driver->getTitle())?></h1>
       <?php if ($results = $this->driver->getAlternativeTitles()): ?>
         <div class="recordAltTitles record-alt-titles">

--- a/themes/finna2/templates/RecordDriver/SolrLido/core.phtml
+++ b/themes/finna2/templates/RecordDriver/SolrLido/core.phtml
@@ -76,7 +76,7 @@
   <?php if ($thumbnail && $thumbnailAlignment == 'left'): ?>
     <?=$thumbnail ?>
   <?php endif; ?>
-    <div class="media-body record-information">
+    <div id="results-heading" class="media-body record-information">
       <h1 class="record-title hidden-xs"><?=$this->escapeHtml($this->driver->getTitle())?></h1>
       <?php if ($results = $this->driver->getAlternativeTitles()): ?>
         <div class="recordAltTitles record-alt-titles">

--- a/themes/finna2/templates/RecordDriver/SolrLido/core.phtml
+++ b/themes/finna2/templates/RecordDriver/SolrLido/core.phtml
@@ -17,6 +17,7 @@
       }
     }
   }
+  
   $skipLinkPosition = 'id="results-heading"';
 
   $thumbnail = false;
@@ -73,12 +74,14 @@
 ?>
 <?php $this->metadata()->generateMetatags($this->driver);?>
 <div class="media">
-  <h1 class="record-title visible-xs"  <?=$skipLinkPosition ?>><?=$this->escapeHtml($this->driver->getTitle())?></h1>
+  <h1 class="record-title visible-xs">
+  <?=$this->escapeHtml($this->driver->getTitle())?></h1>
   <?php if ($thumbnail && $thumbnailAlignment == 'left'): ?>
     <?=$thumbnail ?>
   <?php endif; ?>
-    <div class="media-body record-information">
-      <h1 class="record-title hidden-xs"><?=$this->escapeHtml($this->driver->getTitle())?></h1>
+    <div class="media-body record-information" <?=$skipLinkPosition ?>>
+      <div role="heading" aria-level="1" aria-label="<?=$this->escapeHtml($this->driver->getTitle())?>" visually-hidden></div>
+      <h1 class="record-title hidden-xs" aria-hidden="true"><?=$this->escapeHtml($this->driver->getTitle())?></h1>
       <?php if ($results = $this->driver->getAlternativeTitles()): ?>
         <div class="recordAltTitles record-alt-titles">
           <?=implode('<br>', array_map([$this, 'escapeHtml'], $results))?>

--- a/themes/finna2/templates/RecordDriver/SolrLido/core.phtml
+++ b/themes/finna2/templates/RecordDriver/SolrLido/core.phtml
@@ -17,6 +17,7 @@
       }
     }
   }
+  $skipLinkPosition = 'id="results-heading"';
 
   $thumbnail = false;
   $thumbnailAlignment = $this->record($this->driver)->getThumbnailAlignment('result');
@@ -72,12 +73,12 @@
 ?>
 <?php $this->metadata()->generateMetatags($this->driver);?>
 <div class="media">
-  <h1 class="record-title visible-xs"><?=$this->escapeHtml($this->driver->getTitle())?></h1>
+  <h1 class="record-title visible-xs"  <?=$skipLinkPosition ?>><?=$this->escapeHtml($this->driver->getTitle())?></h1>
   <?php if ($thumbnail && $thumbnailAlignment == 'left'): ?>
     <?=$thumbnail ?>
   <?php endif; ?>
     <div class="media-body record-information">
-      <h1 class="record-title hidden-xs" id="results-heading"><?=$this->escapeHtml($this->driver->getTitle())?></h1>
+      <h1 class="record-title hidden-xs"><?=$this->escapeHtml($this->driver->getTitle())?></h1>
       <?php if ($results = $this->driver->getAlternativeTitles()): ?>
         <div class="recordAltTitles record-alt-titles">
           <?=implode('<br>', array_map([$this, 'escapeHtml'], $results))?>

--- a/themes/finna2/templates/RecordDriver/SolrLido/core.phtml
+++ b/themes/finna2/templates/RecordDriver/SolrLido/core.phtml
@@ -76,8 +76,8 @@
   <?php if ($thumbnail && $thumbnailAlignment == 'left'): ?>
     <?=$thumbnail ?>
   <?php endif; ?>
-    <div id="results-heading" class="media-body record-information">
-      <h1 class="record-title hidden-xs"><?=$this->escapeHtml($this->driver->getTitle())?></h1>
+    <div class="media-body record-information">
+      <h1 class="record-title hidden-xs" id="results-heading"><?=$this->escapeHtml($this->driver->getTitle())?></h1>
       <?php if ($results = $this->driver->getAlternativeTitles()): ?>
         <div class="recordAltTitles record-alt-titles">
           <?=implode('<br>', array_map([$this, 'escapeHtml'], $results))?>

--- a/themes/finna2/templates/RecordDriver/SolrLrmi/core.phtml
+++ b/themes/finna2/templates/RecordDriver/SolrLrmi/core.phtml
@@ -29,8 +29,9 @@
   <?php if ($thumbnail && $thumbnailAlignment == 'left'): ?>
     <?=$thumbnail ?>
   <?php endif; ?>
-  <div class="media-body record-information">
-    <h1 class="record-title hidden-xs" id="results-heading"><?=$this->escapeHtml($this->driver->getTitle())?></h1>
+  <div class="media-body record-information" id="record-skip-link-target">
+    <div role="heading" aria-level="1" id="record-skip-link-target" class="visually-hidden" aria-label="<?=$this->escapeHtml($this->driver->getTitle())?>"></div>
+    <h1 class="record-title hidden-xs" id="results-heading" aria-hidden="true"><?=$this->escapeHtml($this->driver->getTitle())?></h1>
     <?php if ($results = $this->driver->getAlternativeTitles()): ?>
       <div class="recordAltTitles record-alt-titles">
         <?=implode('<br>', array_map([$this, 'escapeHtml'], $results))?>

--- a/themes/finna2/templates/RecordDriver/SolrLrmi/core.phtml
+++ b/themes/finna2/templates/RecordDriver/SolrLrmi/core.phtml
@@ -30,7 +30,7 @@
     <?=$thumbnail ?>
   <?php endif; ?>
   <div class="media-body record-information">
-    <h1 class="record-title hidden-xs"><?=$this->escapeHtml($this->driver->getTitle())?></h1>
+    <h1 class="record-title hidden-xs" id="results-heading"><?=$this->escapeHtml($this->driver->getTitle())?></h1>
     <?php if ($results = $this->driver->getAlternativeTitles()): ?>
       <div class="recordAltTitles record-alt-titles">
         <?=implode('<br>', array_map([$this, 'escapeHtml'], $results))?>

--- a/themes/finna2/templates/RecordDriver/SolrQdc/core.phtml
+++ b/themes/finna2/templates/RecordDriver/SolrQdc/core.phtml
@@ -73,8 +73,9 @@
   <?php if ($thumbnail && $thumbnailAlignment == 'left'): ?>
     <?=$thumbnail ?>
   <?php endif; ?>
-  <div class="media-body record-information">
-      <h1 class="record-title hidden-xs" id="results-heading"><?=$this->escapeHtml($this->driver->getTitle())?></h1>
+  <div class="media-body record-information" id="record-skip-link-target">
+      <div role="heading" aria-level="1" aria-label="<?=$this->escapeHtml($this->driver->getTitle())?>" class="visually-hidden"></div>
+      <h1 class="record-title hidden-xs" id="results-heading" aria-hidden="true"><?=$this->escapeHtml($this->driver->getTitle())?></h1>
       <?php if ($results = $this->driver->getAlternativeTitles()): ?>
         <div class="recordAltTitles record-alt-titles">
           <?=implode('<br>', array_map([$this, 'escapeHtml'], $results))?>

--- a/themes/finna2/templates/RecordDriver/SolrQdc/core.phtml
+++ b/themes/finna2/templates/RecordDriver/SolrQdc/core.phtml
@@ -74,7 +74,7 @@
     <?=$thumbnail ?>
   <?php endif; ?>
   <div class="media-body record-information">
-      <h1 class="record-title hidden-xs"><?=$this->escapeHtml($this->driver->getTitle())?></h1>
+      <h1 class="record-title hidden-xs" id="results-heading"><?=$this->escapeHtml($this->driver->getTitle())?></h1>
       <?php if ($results = $this->driver->getAlternativeTitles()): ?>
         <div class="recordAltTitles record-alt-titles">
           <?=implode('<br>', array_map([$this, 'escapeHtml'], $results))?>

--- a/themes/finna2/templates/layout/layout.phtml
+++ b/themes/finna2/templates/layout/layout.phtml
@@ -165,8 +165,7 @@
           $contentElementId = 'content-heading';
         } elseif (!empty($this->layout()->finnaMainTabs) || (!empty($this->layout()->finnaSkipLinkTarget))) {
           $contentElementId = 'results-heading';
-        } 
-      ?>
+        } ?>
       <a class="skip-link" href="#<?=$contentElementId?>"><?=$this->transEsc('Skip to content') // skip to content ?></a>
       <?php if (isset($this->layout()->skiplink)): // additional skip links ?>
         <?=$this->layout()->skiplink ?>

--- a/themes/finna2/templates/layout/layout.phtml
+++ b/themes/finna2/templates/layout/layout.phtml
@@ -163,7 +163,7 @@
           $contentElementId = 'useraccount-content-heading';
         } elseif (!empty($this->layout()->finnaMainHeader)) {
           $contentElementId = 'content-heading';
-        } elseif (!empty($this->layout()->finnaMainTabs) || (!empty($this->layout()->finnaBasicView))) {
+        } elseif (!empty($this->layout()->finnaMainTabs) || (!empty($this->layout()->finnaSkipLinkTarget))) {
           $contentElementId = 'results-heading';
         } 
       ?>

--- a/themes/finna2/templates/layout/layout.phtml
+++ b/themes/finna2/templates/layout/layout.phtml
@@ -164,7 +164,7 @@
         } elseif (!empty($this->layout()->finnaMainHeader)) {
           $contentElementId = 'content-heading';
         } elseif (!empty($this->layout()->finnaMainTabs) || (!empty($this->layout()->finnaSkipLinkTarget))) {
-          $contentElementId = 'results-heading';
+          $contentElementId = 'record-skip-link-target';
         } ?>
       <a class="skip-link" href="#<?=$contentElementId?>"><?=$this->transEsc('Skip to content') // skip to content ?></a>
       <?php if (isset($this->layout()->skiplink)): // additional skip links ?>

--- a/themes/finna2/templates/layout/layout.phtml
+++ b/themes/finna2/templates/layout/layout.phtml
@@ -163,9 +163,9 @@
           $contentElementId = 'useraccount-content-heading';
         } elseif (!empty($this->layout()->finnaMainHeader)) {
           $contentElementId = 'content-heading';
-        } elseif (!empty($this->layout()->finnaMainTabs)) {
-          $contentElementId = 'content-main-tabs';
-        }
+        } elseif (!empty($this->layout()->finnaMainTabs) || (!empty($this->layout()->finnaBasicView))) {
+          $contentElementId = 'results-heading';
+        } 
       ?>
       <a class="skip-link" href="#<?=$contentElementId?>"><?=$this->transEsc('Skip to content') // skip to content ?></a>
       <?php if (isset($this->layout()->skiplink)): // additional skip links ?>

--- a/themes/finna2/templates/record/view.phtml
+++ b/themes/finna2/templates/record/view.phtml
@@ -24,7 +24,7 @@
   $this->headMeta()->appendName('format-detection', 'telephone=no');
 
   // Set skip-link address
-  $this->layout()->finnaSkipLinkTarget = 'results-heading';
+  $this->layout()->finnaSkipLinkTarget = 'record-skip-link-target';
 
   // Set page title.
   $title = $this->truncate($this->driver->getTitle(), 180);

--- a/themes/finna2/templates/record/view.phtml
+++ b/themes/finna2/templates/record/view.phtml
@@ -24,7 +24,7 @@
   $this->headMeta()->appendName('format-detection', 'telephone=no');
 
   // Set skip-link address
-  $this->layout()->finnaSkipLinkTarget='results-heading';
+  $this->layout()->finnaSkipLinkTarget = 'results-heading';
 
   // Set page title.
   $title = $this->truncate($this->driver->getTitle(), 180);

--- a/themes/finna2/templates/record/view.phtml
+++ b/themes/finna2/templates/record/view.phtml
@@ -23,6 +23,9 @@
 
   $this->headMeta()->appendName('format-detection', 'telephone=no');
 
+    // Set skip-link address
+  $this->layout()->finnaBasicView = 'results-heading';
+
   // Set page title.
   $title = $this->truncate($this->driver->getTitle(), 180);
   $this->layout()->title = $title;

--- a/themes/finna2/templates/record/view.phtml
+++ b/themes/finna2/templates/record/view.phtml
@@ -23,8 +23,8 @@
 
   $this->headMeta()->appendName('format-detection', 'telephone=no');
 
-    // Set skip-link address
-  $this->layout()->finnaBasicView = 'results-heading';
+  // Set skip-link address
+  $this->layout()->finnaSkipLinkTarget='results-heading';
 
   // Set page title.
   $title = $this->truncate($this->driver->getTitle(), 180);

--- a/themes/finna2/templates/search/results.phtml
+++ b/themes/finna2/templates/search/results.phtml
@@ -110,7 +110,8 @@
   $recommendations = $this->results->getRecommendations('side');
 ?>
 
-<h1 tabindex="-1" id="results-heading" class="visually-hidden"><?= $this->transEsc('Search Results'); ?></h1>
+<h1 tabindex="-1" id="results-heading" class="visually-hidden" aria-hidden="true"><?= $this->transEsc('Search Results'); ?></h1>
+<div role="heading" aria-level="1" id="record-skip-link-target" class="visually-hidden" aria-label="<?= $this->transEsc('Search Results'); ?>"></div>
 <?php if ($recordTotal > 0): ?>
   <div class="mobile-nav-toggle-trigger visible-xs hidden-print"></div>
   <div class="mobile-nav-toggle visible-xs hidden-print">


### PR DESCRIPTION
These fixes should solve the problem of skip-link incorrect target positions. When user clicks the - Skip to content - link with screenreader, the link must take user to the actual content, not any menu or tab section etc.
