### PR TITLE
[FINNA-3508] MARC: Make 647 subfield a searchable and display 647acd

### DIFF
--- a/module/Finna/src/Finna/RecordDriver/SolrMarc.php
+++ b/module/Finna/src/Finna/RecordDriver/SolrMarc.php
@@ -78,6 +78,7 @@ class SolrMarc extends \VuFind\RecordDriver\SolrMarc implements \Psr\Log\LoggerA
         '610' => 'corporate name',
         '611' => 'meeting name',
         '630' => 'uniform title',
+        '647' => 'named event',
         '648' => 'chronological',
         '650' => 'topic',
         '651' => 'geographic',

--- a/themes/finna2/templates/RecordDriver/DefaultRecord/data-allSubjectHeadingsExtended.phtml
+++ b/themes/finna2/templates/RecordDriver/DefaultRecord/data-allSubjectHeadingsExtended.phtml
@@ -13,6 +13,9 @@
     foreach ($field['heading'] as $subfield): ?>
       <?php
         $first = $i++ === 0;
+        if ($namedEvent = ($field['type'] === 'named event') && !$first) {
+          continue;
+        }
         $id = $first && isset($field['id']) ? $field['id'] : null;
         $ids = $first && isset($field['ids']) ? $field['ids'] : null;
         $authType = $field['authType'] ?? null;
@@ -21,6 +24,7 @@
       <?= $first ? '' : ' &#8594; '?>
       <?php $subject = trim($subject . ' ' . $subfield); ?>
       <?=$this->record($this->driver)->getLinkedFieldElement($this->headingType ?? 'subject', $subfield, ['name' => $subject, 'id' => $id, 'ids' => $ids, 'description' => $detail], ['authorityType' => $authType, 'class' => ['backlink'], 'description' => true])?>
+      <?= $namedEvent ? '' : implode(" ", array_slice($field['heading'], 1))?>
     <?php endforeach; ?>
   </div>
   <?php endforeach; ?>

--- a/themes/finna2/templates/RecordDriver/DefaultRecord/data-allSubjectHeadingsExtended.phtml
+++ b/themes/finna2/templates/RecordDriver/DefaultRecord/data-allSubjectHeadingsExtended.phtml
@@ -24,7 +24,7 @@
       <?= $first ? '' : ' &#8594; '?>
       <?php $subject = trim($subject . ' ' . $subfield); ?>
       <?=$this->record($this->driver)->getLinkedFieldElement($this->headingType ?? 'subject', $subfield, ['name' => $subject, 'id' => $id, 'ids' => $ids, 'description' => $detail], ['authorityType' => $authType, 'class' => ['backlink'], 'description' => true])?>
-      <?= $namedEvent ? '' : implode(" ", array_slice($field['heading'], 1))?>
+      <?= $namedEvent ? '' : implode(' ', array_slice($field['heading'], 1))?>
     <?php endforeach; ?>
   </div>
   <?php endforeach; ?>

--- a/themes/root/templates/searchapi/openapi.phtml
+++ b/themes/root/templates/searchapi/openapi.phtml
@@ -440,7 +440,7 @@
                     "type": {
                         "description": "Subject type",
                         "type": "string",
-                        "enum": ["", "personal name", "corporate name", "meeting name", "uniform title", "chronological", "topic", "geographic", "genre\/form", "occupation", "keyword"]
+                        "enum": ["", "personal name", "corporate name", "meeting name", "uniform title", "named event", "chronological", "topic", "geographic", "genre\/form", "occupation", "keyword"]
                     },
                     "source": {
                         "description": "Subject source/thesaurus (e.g. lcsh, mesh)",


### PR DESCRIPTION
Although the minimal changes that I in this PR made seem to work, there seems to be another place in the code base where subject fields are mentioned and 647 could be added there, too, if wanted: https://github.com/NatLibFi/NDL-VuFind2/blob/1cc49ad30532037b33837a1621a3bb6e7f08273b/module/VuFind/src/VuFind/RecordDriver/Feature/MarcAdvancedTrait.php#L55-L71 

However, that list is under `module/VuFind/` so I left them unchanged in this PR.