### PR TITLE
[FINNA-4836] TIFY: Fix issues in horizontal mobile view

### DIFF
--- a/themes/finna2/scss/finna/iiif.scss
+++ b/themes/finna2/scss/finna/iiif.scss
@@ -6,7 +6,8 @@
 }
 
 #tify {
-    height: 65vh;
+    height: 75vh;
+    min-height: 340px;
     @include media-breakpoint-down(lg) {
         height: 60vh;
     }


### PR DESCRIPTION
Set the height of the #tify root element to 75vh and min-height to 340 pixels. This gives horizontal mobile clients more room to interact with TIFY and fixes an issue where the hamburger navigation menu triggered by the top right button was clipped because the TIFY container was not tall enough.