### PR TITLE
[FINNA-4841] IIIF: Don't hide TIFY button labels

### DIFF
--- a/themes/finna2/scss/finna/iiif.scss
+++ b/themes/finna2/scss/finna/iiif.scss
@@ -58,15 +58,6 @@
         }
     }
 
-    // Hide button labels
-    .tify-header-button > span {
-        // In a narrow viewport, Tify wants to show these labels in a hamburger
-        // menu, so we allow it. On larger viewports, we want them hidden.
-        @include media-breakpoint-up(lg) {
-            @include visually-hidden;
-        }
-    }
-
     .tify-icon {
         height: 28px;
     }


### PR DESCRIPTION
Previously a UI planning decision was made to hide these three `<span>` elements because they stood out awkwardly in the layout. However, usability testers noticed that these buttons lacked tooltips, whereas other buttons had them.

The reason for the missing tooltips is that the `<button>` elements containing these spans don't have a `title` attribute, which browsers render as a tooltip. Adding a title to these buttons from CSS in a way that respects the user's language choice is not possible. It could perhaps be doable with a JS hack, but I hesitate to go that route without a thorough discussion first.

This commit removes the SCSS rule to hide the `<span>`elements to explain the buttons in the way that upstream TIFY developers intended.  Whether this is a good solution -- temporarily or permanently -- should be discussed.

See: my comment in issue FINNA-4841