### PR TITLE
FINNA-4795_recordAuthors_accessibility_fix

### DIFF
--- a/themes/finna2/templates/RecordDriver/DefaultRecord/popover-link-element.phtml
+++ b/themes/finna2/templates/RecordDriver/DefaultRecord/popover-link-element.phtml
@@ -6,7 +6,6 @@ $aAttrsBase = [
   'href' => '#',
   'id' => "field-anchor-$fieldId",
   'aria-expanded' => 'false',
-  'aria-haspopup' => 'true',
   'role' => 'button',
 ];
 $aAttributes = $this->htmlAttributes($aAttrsBase);
@@ -15,13 +14,13 @@ $aAttributes->add('aria-label', $this->title ?: ($this->label . ' ' . $this->tra
 $additionalDataElem = !empty($this->additionalDataHtml) ? "<span class=\"field-additional-data\">{$this->additionalDataHtml}</span>" : '';
 ?>
 <div class="inline-linked-field" data-ids="<?=$this->escapeHtmlAttr(json_encode($this->ids))?>" data-auth-ids="<?=$this->escapeHtmlAttr(json_encode($this->authIds))?>" data-type="<?=$this->escapeHtmlAttr($this->type)?>" data-record-id="<?=$this->escapeHtmlAttr($this->driver->getUniqueId())?>" data-record-source="<?=$this->escapeHtmlAttr($this->driver->getSourceIdentifier())?>" role="group">
-  <a<?=$aAttributes?>><span class="field-label"><?=$this->escapeHtml($this->label)?></span><?php if ($this->date): ?><span class="author-date"> (<?=$this->escapeHtml($this->date)?>)</span><?php endif; ?> <?=$this->icon('popover-expand', 'expand') ?><?=$this->icon('popover-collapse', 'collapse') ?></a><?=$additionalDataElem?>
+  <a<?=$aAttributes?>><span class="field-label" role="button"><?=$this->escapeHtml($this->label)?></span><?php if ($this->date): ?><span class="author-date"> (<?=$this->escapeHtml($this->date)?>)</span><?php endif; ?> <?=$this->icon('popover-expand', 'expand') ?><?=$this->icon('popover-collapse', 'collapse') ?></a><?=$additionalDataElem?>
   <?php if (!empty($this->description)): ?>
     <span class="authority-description"><?="({$this->escapeHtml($this->description)})"?></span>
   <?php endif; ?>
   <div class="field-info field-popover" id="field-popover-<?=$this->escapeHtmlAttr($fieldId)?>">
     <div class="content">
-      <h2 tabindex="0"><?=$this->escapeHtml($this->label)?></h2>
+      <h2><?=$this->escapeHtml($this->label)?></h2>
       <?php foreach ($this->fieldLinks as $link): ?>
         <span class="<?=$this->escapeHtmlAttr($link['linkType'])?>">
           <a href="<?=$link['escapedUrl']?>"><?=$this->transEsc($link['linkText'])?></a>
@@ -47,6 +46,6 @@ $additionalDataElem = !empty($this->additionalDataHtml) ? "<span class=\"field-a
         <?php endif; ?>
       <?php endif; ?>
       </div>
-      <a href="#" class="hide-info" role="button" class="link-text"><?=$this->translate('field_hide_info')?></a>
+      <a href="#" class="hide-info" role="button" tabindex="0"><?=$this->translate('field_hide_info')?></a>
   </div>
 </div>

--- a/themes/finna2/templates/RecordDriver/DefaultRecord/popover-link-element.phtml
+++ b/themes/finna2/templates/RecordDriver/DefaultRecord/popover-link-element.phtml
@@ -11,7 +11,7 @@ $aAttrsBase = [
 ];
 $aAttributes = $this->htmlAttributes($aAttrsBase);
 $aAttributes->add('class', 'show-info');
-$aAttributes->add('aria-label', $this->title ?: $this->label);
+$aAttributes->add('aria-label', $this->title ?: $this->label . $this->escapeHtmlAttr(' ') . $this->translate('field_info_link_title'));
 $additionalDataElem = !empty($this->additionalDataHtml) ? "<span class=\"field-additional-data\">{$this->additionalDataHtml}</span>" : '';
 ?>
 <div class="inline-linked-field" data-ids="<?=$this->escapeHtmlAttr(json_encode($this->ids))?>" data-auth-ids="<?=$this->escapeHtmlAttr(json_encode($this->authIds))?>" data-type="<?=$this->escapeHtmlAttr($this->type)?>" data-record-id="<?=$this->escapeHtmlAttr($this->driver->getUniqueId())?>" data-record-source="<?=$this->escapeHtmlAttr($this->driver->getSourceIdentifier())?>" role="group">

--- a/themes/finna2/templates/RecordDriver/DefaultRecord/popover-link-element.phtml
+++ b/themes/finna2/templates/RecordDriver/DefaultRecord/popover-link-element.phtml
@@ -11,7 +11,7 @@ $aAttrsBase = [
 ];
 $aAttributes = $this->htmlAttributes($aAttrsBase);
 $aAttributes->add('class', 'show-info');
-$aAttributes->add('aria-label', $this->title ?: $this->label . $this->escapeHtmlAttr(' ') . $this->translate('field_info_link_title'));
+$aAttributes->add('aria-label', $this->title ?: ($this->label . ' ' . $this->translate('field_info_link_title')));
 $additionalDataElem = !empty($this->additionalDataHtml) ? "<span class=\"field-additional-data\">{$this->additionalDataHtml}</span>" : '';
 ?>
 <div class="inline-linked-field" data-ids="<?=$this->escapeHtmlAttr(json_encode($this->ids))?>" data-auth-ids="<?=$this->escapeHtmlAttr(json_encode($this->authIds))?>" data-type="<?=$this->escapeHtmlAttr($this->type)?>" data-record-id="<?=$this->escapeHtmlAttr($this->driver->getUniqueId())?>" data-record-source="<?=$this->escapeHtmlAttr($this->driver->getSourceIdentifier())?>" role="group">
@@ -21,7 +21,7 @@ $additionalDataElem = !empty($this->additionalDataHtml) ? "<span class=\"field-a
   <?php endif; ?>
   <div class="field-info field-popover" id="field-popover-<?=$this->escapeHtmlAttr($fieldId)?>" aria-labelledby="field-anchor-<?=$this->escapeHtmlAttr($fieldId)?>" >
     <div class="content">
-      <h2 tabindex="0"><?=$this->escapeHtml($this->label)?></h2>
+      <h2><?=$this->escapeHtml($this->label)?></h2>
       <?php foreach ($this->fieldLinks as $link): ?>
         <span class="<?=$this->escapeHtmlAttr($link['linkType'])?>">
           <a href="<?=$link['escapedUrl']?>"><?=$this->transEsc($link['linkText'])?></a>

--- a/themes/finna2/templates/RecordDriver/DefaultRecord/popover-link-element.phtml
+++ b/themes/finna2/templates/RecordDriver/DefaultRecord/popover-link-element.phtml
@@ -11,7 +11,7 @@ $aAttrsBase = [
 ];
 $aAttributes = $this->htmlAttributes($aAttrsBase);
 $aAttributes->add('class', 'show-info');
-$aAttributes->add('aria-label', $this->title ?: $this->translate('field_info_link_title'));
+$aAttributes->add('aria-label', $this->title ?: $this->label);
 $additionalDataElem = !empty($this->additionalDataHtml) ? "<span class=\"field-additional-data\">{$this->additionalDataHtml}</span>" : '';
 ?>
 <div class="inline-linked-field" data-ids="<?=$this->escapeHtmlAttr(json_encode($this->ids))?>" data-auth-ids="<?=$this->escapeHtmlAttr(json_encode($this->authIds))?>" data-type="<?=$this->escapeHtmlAttr($this->type)?>" data-record-id="<?=$this->escapeHtmlAttr($this->driver->getUniqueId())?>" data-record-source="<?=$this->escapeHtmlAttr($this->driver->getSourceIdentifier())?>" role="group">

--- a/themes/finna2/templates/RecordDriver/DefaultRecord/popover-link-element.phtml
+++ b/themes/finna2/templates/RecordDriver/DefaultRecord/popover-link-element.phtml
@@ -19,9 +19,9 @@ $additionalDataElem = !empty($this->additionalDataHtml) ? "<span class=\"field-a
   <?php if (!empty($this->description)): ?>
     <span class="authority-description"><?="({$this->escapeHtml($this->description)})"?></span>
   <?php endif; ?>
-  <div class="field-info field-popover" id="field-popover-<?=$this->escapeHtmlAttr($fieldId)?>" aria-labelledby="field-anchor-<?=$this->escapeHtmlAttr($fieldId)?>" >
+  <div class="field-info field-popover" id="field-popover-<?=$this->escapeHtmlAttr($fieldId)?>">
     <div class="content">
-      <h2><?=$this->escapeHtml($this->label)?></h2>
+      <h2 tabindex="0"><?=$this->escapeHtml($this->label)?></h2>
       <?php foreach ($this->fieldLinks as $link): ?>
         <span class="<?=$this->escapeHtmlAttr($link['linkType'])?>">
           <a href="<?=$link['escapedUrl']?>"><?=$this->transEsc($link['linkText'])?></a>
@@ -46,7 +46,7 @@ $additionalDataElem = !empty($this->additionalDataHtml) ? "<span class=\"field-a
           </div>
         <?php endif; ?>
       <?php endif; ?>
-    </div>
-    <a href="#" class="hide-info" role="button"><span class="link-text"><?=$this->translate('field_hide_info')?></span></a>
+      </div>
+      <a href="#" class="hide-info" role="button" class="link-text"><?=$this->translate('field_hide_info')?></a>
   </div>
 </div>

--- a/themes/finna2/templates/RecordDriver/DefaultRecord/popover-link-element.phtml
+++ b/themes/finna2/templates/RecordDriver/DefaultRecord/popover-link-element.phtml
@@ -45,7 +45,7 @@ $additionalDataElem = !empty($this->additionalDataHtml) ? "<span class=\"field-a
           </div>
         <?php endif; ?>
       <?php endif; ?>
-      </div>
-      <a href="#" class="hide-info" role="button" tabindex="0"><?=$this->translate('field_hide_info')?></a>
+    </div>
+    <a href="#" class="hide-info" role="button" tabindex="0"><?=$this->translate('field_hide_info')?></a>
   </div>
 </div>


### PR DESCRIPTION
Author info dropdown title fixed to match author's name instead of plain "Hakutulokset" or "Results". 