### PR TITLE
FINNA-3573_facet_items_truncation_accessibility_fix

### DIFF
--- a/themes/bootstrap5/scss/components/trees.scss
+++ b/themes/bootstrap5/scss/components/trees.scss
@@ -56,8 +56,8 @@
 
       .facet-value {
         overflow: hidden;
-        white-space: nowrap;
-        text-overflow: ellipsis;
+        white-space: pre-wrap;
+        overflow-wrap: break-word;
         display: inline;
       }
     }

--- a/themes/finna2/scss/finna/facets.scss
+++ b/themes/finna2/scss/finna/facets.scss
@@ -84,7 +84,9 @@ div.facet {
     }
     .text .facet-value {
       overflow: hidden;
-      text-overflow: ellipsis;
+      white-space: pre-wrap;
+      overflow-wrap: break-word;
+      display: inline;
     }
   }
   .title {


### PR DESCRIPTION
Traficom demands that all texts in the facets must be readable with screen readers. Currently longer texts that don't fit on narrow screens to the facets are always truncated and therefore not readable with screenreaders. 

This fix will use  - **white-space: pre-wrap;** - and - **overflow-wrap: break-word;** - to fix this issue. All texts will be first divided naturally on multiple lines using white spaces and in case there are super long words, they will be broken also on multiple lines. This system will make sure, that under any circumstances all texts are readable with screen readers on all devices. One must note, that resorting to these word manipulation measures is very rare, and for most users all texts will be visually as they were. 