### PR TITLE
FINNA-4773_user_rights_hover-text_and_accessibility_fix

### DIFF
--- a/themes/finna2/templates/RecordDriver/DefaultRecord/document-links.phtml
+++ b/themes/finna2/templates/RecordDriver/DefaultRecord/document-links.phtml
@@ -33,7 +33,7 @@
         <?php $aAttrs = [
             'href' => $this->proxyUrl($document['url']),
             'target' => '_blank',
-            'aria-label' => $this->escapeHtml($description) . $this->escapeHtmlAttr(' ') . $this->translate('external_online_link'),
+            'aria-label' => $this->translate('Download the file') . ' ' . $this->escapeHtml($description),
         ];
         if ($posterUrl = $document['posterUrl'] ?? null) {
             $aAttrs['data-poster-url'] = $posterUrl;
@@ -58,7 +58,7 @@
             <span class="resource-link"><?=$linkToResource ?></span>
             <?php if ($format || $copyright):?>
                 <?php
-                    $content = ' ';
+                    $content = '';
                     if ($format) {
                         $content .= $this->escapeHtml($format);
                         if ($copyright) {
@@ -68,7 +68,7 @@
                     if ($copyright) {
                         $content .= '<span class="copyright-icons">' . $this->partial('Helpers/copyright-icons.phtml', ['copyright' => $copyright]) . '</span>';
                         if ($link) {
-                            $content .= ' <a class="copyright-description" aria-label="' . $this->translate('usage_rights_ext') . $this->escapeHtmlAttr(' ') . $this->escapeHtmlAttr($copyright) . $this->escapeHtmlAttr(' ') . $this->translate('external_online_link') . ' " href="' . $this->escapeHtml($link) . '" target="_blank">' . $this->escapeHtmlAttr($copyright) . '</a>';
+                            $content .= ' <a class="copyright-description" aria-label="' . $this->translate('Access Restrictions') . ' ' . $this->escapeHtmlAttr($copyright) . ' ' . $this->translate('external_online_link') . ' " href="' . $this->escapeHtml($link) . '" target="_blank">' . $this->escapeHtmlAttr($copyright) . '</a>';
                         } else {
                             $content .= $this->escapeHtml($copyright);
                         }
@@ -76,7 +76,6 @@
                             $content .= $ccbutton;
                         }
                     }
-                    $content .= '';
                 ?>
                 <div class="copyright-wrapper">
                     <span><?=$content?></span>

--- a/themes/finna2/templates/RecordDriver/DefaultRecord/document-links.phtml
+++ b/themes/finna2/templates/RecordDriver/DefaultRecord/document-links.phtml
@@ -33,7 +33,7 @@
         <?php $aAttrs = [
             'href' => $this->proxyUrl($document['url']),
             'target' => '_blank',
-            'aria-label' => $this->translate('external_online_link'),
+            'aria-label' => $this->escapeHtml($description) . $this->escapeHtmlAttr(' ') . $this->translate('external_online_link'),
         ];
         if ($posterUrl = $document['posterUrl'] ?? null) {
             $aAttrs['data-poster-url'] = $posterUrl;
@@ -58,7 +58,7 @@
             <span class="resource-link"><?=$linkToResource ?></span>
             <?php if ($format || $copyright):?>
                 <?php
-                    $content = '(';
+                    $content = ' ';
                     if ($format) {
                         $content .= $this->escapeHtml($format);
                         if ($copyright) {
@@ -68,7 +68,7 @@
                     if ($copyright) {
                         $content .= '<span class="copyright-icons">' . $this->partial('Helpers/copyright-icons.phtml', ['copyright' => $copyright]) . '</span>';
                         if ($link) {
-                            $content .= ' <a class="copyright-description" href="' . $this->escapeHtml($link) . '" target="_blank">' . $this->escapeHtmlAttr($copyright) . '</a>';
+                            $content .= ' <a class="copyright-description" aria-label="' . $this->translate('usage_rights_ext') . $this->escapeHtmlAttr(' ') . $this->escapeHtmlAttr($copyright) . $this->escapeHtmlAttr(' ') . $this->translate('external_online_link') . ' " href="' . $this->escapeHtml($link) . '" target="_blank">' . $this->escapeHtmlAttr($copyright) . '</a>';
                         } else {
                             $content .= $this->escapeHtml($copyright);
                         }
@@ -76,7 +76,7 @@
                             $content .= $ccbutton;
                         }
                     }
-                    $content .= ')';
+                    $content .= '';
                 ?>
                 <div class="copyright-wrapper">
                     <span><?=$content?></span>


### PR DESCRIPTION
Download link and copyright description fix for screenreaders. Previously both download link and copyright link were just saying "outside link to material" but there was no description of the actual content at all. 