### PR TITLE
Finna 4288 fix content skip link position 2

### DIFF
--- a/themes/finna2/templates/RecordDriver/DefaultRecord/core.phtml
+++ b/themes/finna2/templates/RecordDriver/DefaultRecord/core.phtml
@@ -85,7 +85,7 @@
 
 <?php $this->metadata()->generateMetatags($this->driver);?>
 <div class="media">
-  <h1 class="record-title visible-xs"><?=$this->escapeHtml($this->driver->getTitle())?></h1>
+  <h1 class="record-title visible-xs" aria-hidden="true" ><?=$this->escapeHtml($this->driver->getTitle())?></h1>
 
   <?php if (!empty($this->extraControls)): ?>
     <?=$this->extraControls['actionControls'] ?? ''?>
@@ -96,7 +96,7 @@
     <?=$thumbnail ?>
   <?php endif; ?>
   <div class="media-body record-information">
-    <h1 class="record-title hidden-xs"><?=$this->escapeHtml($this->driver->getTitle())?></h1>
+    <?=$this->partial('layout/skiplink-core-heading.phtml') ?>
     <?php foreach ($this->driver->tryMethod('getFullTitlesAltScript', [], []) as $altTitle): ?>
       <div class="record-title-alt-script">
         <?=$this->escapeHtml($altTitle)?>

--- a/themes/finna2/templates/RecordDriver/DefaultRecord/core.phtml
+++ b/themes/finna2/templates/RecordDriver/DefaultRecord/core.phtml
@@ -85,8 +85,7 @@
 
 <?php $this->metadata()->generateMetatags($this->driver);?>
 <div class="media">
-  <h1 class="record-title visible-xs" aria-hidden="true" ><?=$this->escapeHtml($this->driver->getTitle())?></h1>
-
+  <h1 class="record-title visible-xs" aria-hidden="true"><?=$this->escapeHtml($this->driver->getTitle())?></h1>
   <?php if (!empty($this->extraControls)): ?>
     <?=$this->extraControls['actionControls'] ?? ''?>
     <?=$this->extraControls['availabilityInfo'] ?? ''?>

--- a/themes/finna2/templates/RecordDriver/DefaultRecord/core.phtml
+++ b/themes/finna2/templates/RecordDriver/DefaultRecord/core.phtml
@@ -13,6 +13,9 @@
   $binding = $this->driver->tryMethod('getBinding');
   $iiifManifests = $this->driver->tryMethod('getIiifManifests');
 
+  // Add Finna skip link target
+  $this->layout()->finnaSkipLinkTarget = $finnaSkipLinkTarget = 'record-skip-link-target';
+
   $addRenderedUrl = function (array $url) use (&$renderedURLs) {
     $renderedURLs[] = [
       'url' => $url['url'],

--- a/themes/finna2/templates/RecordDriver/SolrAipa/core.phtml
+++ b/themes/finna2/templates/RecordDriver/SolrAipa/core.phtml
@@ -47,12 +47,12 @@
 
 <?php $this->metadata()->generateMetatags($this->driver);?>
 <div class="media">
-  <h1 class="record-title visible-xs"><?=$this->escapeHtml($this->driver->getTitle())?></h1>
+  <h1 class="record-title visible-xs" aria-hidden="true"><?=$this->escapeHtml($this->driver->getTitle())?></h1>
   <?php if ($thumbnail && $thumbnailAlignment == 'left'): ?>
     <?=$thumbnail ?>
   <?php endif; ?>
   <div class="media-body record-information">
-      <h1 class="record-title hidden-xs"><?=$this->escapeHtml($this->driver->getTitle())?></h1>
+      <?=$this->partial('layout/skiplink-core-heading.phtml') ?>
       <?php if ($results = $this->driver->getAlternativeTitles()): ?>
         <div class="recordAltTitles record-alt-titles">
           <?=implode('<br>', array_map([$this, 'escapeHtml'], $results))?>

--- a/themes/finna2/templates/RecordDriver/SolrAipa/core.phtml
+++ b/themes/finna2/templates/RecordDriver/SolrAipa/core.phtml
@@ -43,6 +43,9 @@
   $img = $this->recordImage($this->record($this->driver));
   $thumbnail = false;
   $thumbnailAlignment = false;
+
+  // Add Finna skip link target
+  $this->layout()->finnaSkipLinkTarget = $finnaSkipLinkTarget = 'record-skip-link-target';
 ?>
 
 <?php $this->metadata()->generateMetatags($this->driver);?>

--- a/themes/finna2/templates/RecordDriver/SolrEad/core.phtml
+++ b/themes/finna2/templates/RecordDriver/SolrEad/core.phtml
@@ -47,12 +47,12 @@
 
 <?php $this->metadata()->generateMetatags($this->driver);?>
 <div class="media">
-  <h1 class="record-title visible-xs"><?=$this->escapeHtml($this->driver->getTitle())?></h1>
+  <h1 class="record-title visible-xs" aria-hidden="true"><?=$this->escapeHtml($this->driver->getTitle())?></h1>
   <?php if ($thumbnail && $thumbnailAlignment == 'left'): ?>
     <?=$thumbnail ?>
   <?php endif; ?>
   <div class="media-body record-information">
-      <h1 class="record-title hidden-xs"><?=$this->escapeHtml($this->driver->getTitle())?></h1>
+      <?=$this->partial('layout/skiplink-core-heading.phtml') ?>
       <?php if ($results = $this->driver->getAlternativeTitles()): ?>
         <div class="recordAltTitles record-alt-titles">
           <?=implode('<br>', array_map([$this, 'escapeHtml'], $results))?>

--- a/themes/finna2/templates/RecordDriver/SolrEad/core.phtml
+++ b/themes/finna2/templates/RecordDriver/SolrEad/core.phtml
@@ -21,6 +21,10 @@
   $img = $this->recordImage($this->record($this->driver));
   $thumbnail = false;
   $thumbnailAlignment = $this->record($this->driver)->getThumbnailAlignment('result');
+
+  // Add Finna skip link target
+  $this->layout()->finnaSkipLinkTarget = $finnaSkipLinkTarget = 'record-skip-link-target';
+
   ob_start(); ?>
   <div class="media-<?=$thumbnailAlignment ?><?=!empty($audioUrls) ? ' audio' : ''?>">
     <?=$this->record($this->driver)->renderTemplate('record-image-information.phtml', ['img' => $img, 'sizes' => ['small' => ['w' => 100, 'h' => 100], 'medium' => ['w' => 1200, 'h' => 1200]]]);?>

--- a/themes/finna2/templates/RecordDriver/SolrForward/core.phtml
+++ b/themes/finna2/templates/RecordDriver/SolrForward/core.phtml
@@ -65,9 +65,9 @@
 
 <?php $this->metadata()->generateMetatags($this->driver);?>
 <div class="media">
-  <h1 class="record-title visible-xs"><?=$this->escapeHtml($this->driver->getTitle())?></h1>
+  <h1 class="record-title visible-xs" aria-hidden="true"><?=$this->escapeHtml($this->driver->getTitle())?></h1>
   <?php if ($altTitles): ?>
-    <div class="alt-title-wrapper visible-xs">
+    <div class="alt-title-wrapper visible-xs" aria-hidden="true">
       <?=$altTitlesContent?>
     </div>
   <?php endif; ?>
@@ -75,9 +75,10 @@
     <?=$thumbnail ?>
   <?php endif; ?>
   <div class="media-body record-information">
-      <h1 class="record-title hidden-xs"><?=$this->escapeHtml($this->driver->getTitle())?></h1>
+      <?=$this->partial('layout/skiplink-core-heading.phtml') ?>
       <?php if ($altTitles): ?>
-        <div class="alt-title-wrapper hidden-xs">
+        <div class="visually-hidden"><?=$altTitlesContent?></div>
+        <div class="alt-title-wrapper hidden-xs" aria-hidden="true">
           <?=$altTitlesContent?>
         </div>
       <?php endif; ?>

--- a/themes/finna2/templates/RecordDriver/SolrForward/core.phtml
+++ b/themes/finna2/templates/RecordDriver/SolrForward/core.phtml
@@ -28,6 +28,10 @@
 
   $thumbnail = false;
   $thumbnailAlignment = $this->record($this->driver)->getThumbnailAlignment('result');
+
+  // Add Finna skip link target
+  $this->layout()->finnaSkipLinkTarget = $finnaSkipLinkTarget = 'record-skip-link-target';
+
   ob_start(); ?>
   <div class="media-<?=$thumbnailAlignment ?>">
 

--- a/themes/finna2/templates/RecordDriver/SolrLido/core.phtml
+++ b/themes/finna2/templates/RecordDriver/SolrLido/core.phtml
@@ -20,6 +20,10 @@
 
   $thumbnail = false;
   $thumbnailAlignment = $this->record($this->driver)->getThumbnailAlignment('result');
+
+  // Add Finna skip link target
+  $this->layout()->finnaSkipLinkTarget = $finnaSkipLinkTarget = 'record-skip-link-target';
+
   ob_start();
 ?>
   <div class="media-<?=$thumbnailAlignment ?><?=!empty($audioUrls) ? ' audio' : ''?>">

--- a/themes/finna2/templates/RecordDriver/SolrLido/core.phtml
+++ b/themes/finna2/templates/RecordDriver/SolrLido/core.phtml
@@ -72,12 +72,12 @@
 ?>
 <?php $this->metadata()->generateMetatags($this->driver);?>
 <div class="media">
-  <h1 class="record-title visible-xs"><?=$this->escapeHtml($this->driver->getTitle())?></h1>
+  <h1 class="record-title visible-xs" aria-hidden="true"><?=$this->escapeHtml($this->driver->getTitle())?></h1>
   <?php if ($thumbnail && $thumbnailAlignment == 'left'): ?>
     <?=$thumbnail ?>
   <?php endif; ?>
     <div class="media-body record-information">
-      <h1 class="record-title hidden-xs"><?=$this->escapeHtml($this->driver->getTitle())?></h1>
+       <?=$this->partial('layout/skiplink-core-heading.phtml') ?>
       <?php if ($results = $this->driver->getAlternativeTitles()): ?>
         <div class="recordAltTitles record-alt-titles">
           <?=implode('<br>', array_map([$this, 'escapeHtml'], $results))?>

--- a/themes/finna2/templates/RecordDriver/SolrLrmi/core.phtml
+++ b/themes/finna2/templates/RecordDriver/SolrLrmi/core.phtml
@@ -10,6 +10,10 @@
   $thumbnail = false;
   $thumbnailAlignment = $this->record($this->driver)->getThumbnailAlignment('result');
   $formats = $this->driver->getFormats();
+
+  // Add Finna skip link target
+  $this->layout()->finnaSkipLinkTarget = $finnaSkipLinkTarget = 'record-skip-link-target';
+
   ob_start(); ?>
   <div class="media-<?=$thumbnailAlignment?>">
     <?= $this->record($this->driver)->renderTemplate('record-image-information.phtml', ['img' => $img, 'imageClick' => 'none']) ?>

--- a/themes/finna2/templates/RecordDriver/SolrLrmi/core.phtml
+++ b/themes/finna2/templates/RecordDriver/SolrLrmi/core.phtml
@@ -25,12 +25,12 @@
   <?php $thumbnail = ob_get_contents(); ?>
 <?php ob_end_clean(); ?>
 <div class="media">
-  <h1 class="record-title visible-xs"><?=$this->escapeHtml($this->driver->getTitle())?></h1>
+  <h1 class="record-title visible-xs" aria-hidden="true"><?=$this->escapeHtml($this->driver->getTitle())?></h1>
   <?php if ($thumbnail && $thumbnailAlignment == 'left'): ?>
     <?=$thumbnail ?>
   <?php endif; ?>
   <div class="media-body record-information">
-    <h1 class="record-title hidden-xs"><?=$this->escapeHtml($this->driver->getTitle())?></h1>
+    <?=$this->partial('layout/skiplink-core-heading.phtml') ?>
     <?php if ($results = $this->driver->getAlternativeTitles()): ?>
       <div class="recordAltTitles record-alt-titles">
         <?=implode('<br>', array_map([$this, 'escapeHtml'], $results))?>

--- a/themes/finna2/templates/RecordDriver/SolrQdc/core.phtml
+++ b/themes/finna2/templates/RecordDriver/SolrQdc/core.phtml
@@ -43,6 +43,10 @@
   $img = $this->recordImage($this->record($this->driver));
   $thumbnail = false;
   $thumbnailAlignment = $this->record($this->driver)->getThumbnailAlignment('result');
+
+  // Add Finna skip link target
+  $this->layout()->finnaSkipLinkTarget = $finnaSkipLinkTarget = 'record-skip-link-target';
+
   ob_start(); ?>
   <div class="media-<?=$thumbnailAlignment ?><?=!empty($audioUrls) ? ' audio' : ''?>">
 

--- a/themes/finna2/templates/RecordDriver/SolrQdc/core.phtml
+++ b/themes/finna2/templates/RecordDriver/SolrQdc/core.phtml
@@ -69,12 +69,12 @@
 
 <?php $this->metadata()->generateMetatags($this->driver);?>
 <div class="media">
-  <h1 class="record-title visible-xs"><?=$this->escapeHtml($this->driver->getTitle())?></h1>
+  <h1 class="record-title visible-xs" aria-hidden="true"><?=$this->escapeHtml($this->driver->getTitle())?></h1>
   <?php if ($thumbnail && $thumbnailAlignment == 'left'): ?>
     <?=$thumbnail ?>
   <?php endif; ?>
   <div class="media-body record-information">
-      <h1 class="record-title hidden-xs"><?=$this->escapeHtml($this->driver->getTitle())?></h1>
+      <?=$this->partial('layout/skiplink-core-heading.phtml') ?>
       <?php if ($results = $this->driver->getAlternativeTitles()): ?>
         <div class="recordAltTitles record-alt-titles">
           <?=implode('<br>', array_map([$this, 'escapeHtml'], $results))?>

--- a/themes/finna2/templates/layout/layout.phtml
+++ b/themes/finna2/templates/layout/layout.phtml
@@ -163,8 +163,8 @@
           $contentElementId = 'useraccount-content-heading';
         } elseif (!empty($this->layout()->finnaMainHeader)) {
           $contentElementId = 'content-heading';
-        } elseif (!empty($this->layout()->finnaMainTabs)) {
-          $contentElementId = 'content-main-tabs';
+        } elseif (!empty($this->layout()->finnaMainTabs) || (!empty($this->layout()->skipLinkTarget)) || (!empty($this->layout()->content))) {
+          $contentElementId = 'record-skip-link-target';
         }
       ?>
       <a class="skip-link" href="#<?=$contentElementId?>"><?=$this->transEsc('Skip to content') // skip to content ?></a>

--- a/themes/finna2/templates/layout/layout.phtml
+++ b/themes/finna2/templates/layout/layout.phtml
@@ -161,10 +161,14 @@
         $contentElementId = 'main';
         if (!empty($this->layout()->finnaUserAccountHeading)) {
           $contentElementId = 'useraccount-content-heading';
+        } elseif ($isLandingPage) {
+          $contentElementId = 'main';
+        } elseif ((!empty($this->layout()->finnaSkipLinkTarget))) {
+          $contentElementId = 'record-skip-link-target';
         } elseif (!empty($this->layout()->finnaMainHeader)) {
           $contentElementId = 'content-heading';
-        } elseif (!empty($this->layout()->finnaMainTabs) || (!empty($this->layout()->skipLinkTarget)) || (!empty($this->layout()->content))) {
-          $contentElementId = 'record-skip-link-target';
+        } elseif (!empty($this->layout()->finnaMainTabs)) {
+          $contentElementId = 'content-main-tabs';
         }
       ?>
       <a class="skip-link" href="#<?=$contentElementId?>"><?=$this->transEsc('Skip to content') // skip to content ?></a>

--- a/themes/finna2/templates/layout/skiplink-core-heading.phtml
+++ b/themes/finna2/templates/layout/skiplink-core-heading.phtml
@@ -1,0 +1,4 @@
+<!-- START of: finna - layout/skiplink-core-heading.phtml -->
+    <div role="heading" aria-level="1" id="record-skip-link-target" class="visually-hidden" aria-label="<?=$this->escapeHtml($this->driver->getTitle())?>"></div>
+    <h1 class="record-title hidden-xs" aria-hidden="true"><?=$this->escapeHtml($this->driver->getTitle())?></h1>
+<!-- END of: finna - layout/skiplink-core-heading.phtml  -->

--- a/themes/finna2/templates/search/results.phtml
+++ b/themes/finna2/templates/search/results.phtml
@@ -13,7 +13,7 @@
   $geoFilter = '';
 
   // Add Finna skip link target
-  $finnaSkipLinkTarget = "record-skip-link-target";
+  $finnaSkipLinkTarget = 'record-skip-link-target';
 
   // Store search id:
   $this->layout()->searchId = $this->results->getSearchId();

--- a/themes/finna2/templates/search/results.phtml
+++ b/themes/finna2/templates/search/results.phtml
@@ -13,7 +13,7 @@
   $geoFilter = '';
 
   // Add Finna skip link target
-  $finnaSkipLinkTarget = 'record-skip-link-target';
+  $this->layout()->finnaSkipLinkTarget = $finnaSkipLinkTarget = 'record-skip-link-target';
 
   // Store search id:
   $this->layout()->searchId = $this->results->getSearchId();

--- a/themes/finna2/templates/search/results.phtml
+++ b/themes/finna2/templates/search/results.phtml
@@ -12,6 +12,9 @@
   $searchType = $this->params->getSearchType();
   $geoFilter = '';
 
+  // Add Finna skip link target
+  $finnaSkipLinkTarget = "record-skip-link-target";
+
   // Store search id:
   $this->layout()->searchId = $this->results->getSearchId();
 
@@ -110,7 +113,8 @@
   $recommendations = $this->results->getRecommendations('side');
 ?>
 
-<h1 tabindex="-1" id="results-heading" class="visually-hidden"><?= $this->transEsc('Search Results'); ?></h1>
+<h1 tabindex="-1" id="results-heading" class="visually-hidden" aria-hidden="true"><?= $this->transEsc('Search Results'); ?></h1>
+<div id="<?=$finnaSkipLinkTarget ?>" role="heading" aria-level="1" class="visually-hidden" ><?= $this->transEsc('Search Results'); ?></div>
 <?php if ($recordTotal > 0): ?>
   <div class="mobile-nav-toggle-trigger visible-xs hidden-print"></div>
   <div class="mobile-nav-toggle visible-xs hidden-print">


### PR DESCRIPTION
This adds - **finnaSkipLinkTarget** - variable and - **record-skip-link-target** - to all files that need screenreader a correct - **skip to content** - focus.  Without this fix, screenreaders end up in all kind of irrelevant menus before finally getting to correct - **Heading** - information. This fix has been tested also in a narrow mobile view. 