### PR TITLE
MARC: Display field 647 correctly in subjects

### DIFF
--- a/themes/finna2/templates/RecordDriver/DefaultRecord/data-allSubjectHeadingsExtended.phtml
+++ b/themes/finna2/templates/RecordDriver/DefaultRecord/data-allSubjectHeadingsExtended.phtml
@@ -13,6 +13,9 @@
     foreach ($field['heading'] as $subfield): ?>
       <?php
         $first = $i++ === 0;
+        if (($namedEvent = (($field['type'] ?? null) === 'named event')) && !$first) {
+          continue;
+        }
         $id = $first && isset($field['id']) ? $field['id'] : null;
         $ids = $first && isset($field['ids']) ? $field['ids'] : null;
         $authType = $field['authType'] ?? null;
@@ -21,6 +24,7 @@
       <?= $first ? '' : ' &#8594; '?>
       <?php $subject = trim($subject . ' ' . $subfield); ?>
       <?=$this->record($this->driver)->getLinkedFieldElement($this->headingType ?? 'subject', $subfield, ['name' => $subject, 'id' => $id, 'ids' => $ids, 'description' => $detail], ['authorityType' => $authType, 'class' => ['backlink'], 'description' => true])?>
+      <?= $namedEvent ? implode(' ', array_slice($field['heading'], 1)) : ''?>
     <?php endforeach; ?>
   </div>
   <?php endforeach; ?>

--- a/themes/finna2/templates/RecordDriver/DefaultRecord/data-allSubjectHeadingsExtended.phtml
+++ b/themes/finna2/templates/RecordDriver/DefaultRecord/data-allSubjectHeadingsExtended.phtml
@@ -13,7 +13,8 @@
     foreach ($field['heading'] as $subfield): ?>
       <?php
         $first = $i++ === 0;
-        if (($namedEvent = (($field['type'] ?? null) === 'named event')) && !$first) {
+        $namedEvent = ($field['type'] ?? null) === 'named event';
+        if ($namedEvent && !$first) {
           continue;
         }
         $id = $first && isset($field['id']) ? $field['id'] : null;


### PR DESCRIPTION
This PR corrects the false logic introduced in #3525 and reverted in https://github.com/NatLibFi/NDL-VuFind2/commit/1a84a5ccc5e404c46d768a894522e6a544bbb033. 

A pair of parentheses was added for deeming the state of `$namedEvent` and the result statements for the ternary operator were swapped.